### PR TITLE
datatable improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,5 +49,10 @@ npm install
 lerna bootstrap
 ```
 
+Each package defines its own tests which you can run from within a directory with
+`npm run test`
+
+To run tests in all packages run the same command from the root @data-ui directory.
+
 ## License
 [MIT](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx ./packages/",
-    "publish": "npm run lint && lerna publish && lerna run gh-pages",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "publish": "lerna run lint && lerna run test && lerna publish && lerna run gh-pages",
+    "test": "lerna run test"
   },
   "repository": "https://github.com/williaster/data-ui.git",
   "keywords": [
@@ -20,6 +20,8 @@
   "author": "Chris Williams <chris.williams@airbnb.com>",
   "license": "MIT",
   "devDependencies": {
+    "babel-polyfill": "^6.23.0",
+    "babel-register": "^6.24.1",
     "chai": "^3.5.0",
     "chai-enzyme": "^0.5.2",
     "enzyme": "^2.7.0",

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -5,9 +5,10 @@
   "main": "build/index.js",
   "scripts": {
     "build": "webpack --env build && npm run copy-styles",
-    "dev": "webpack --progress --colors --watch --env dev",
     "copy-styles": "cp ./node_modules/react-virtualized/styles.css ./build/styles.css",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "webpack --progress --colors --watch --env dev",
+    "mocha": "mocha --opts ./test/mocha.opts",
+    "test": "npm run mocha ./test"
   },
   "repository": "https://github.com/williaster/data-ui",
   "keywords": [

--- a/packages/data-table/src/components/Table.jsx
+++ b/packages/data-table/src/components/Table.jsx
@@ -75,96 +75,101 @@ const defaultProps = {
   styles: {},
 };
 
-function BasicTable({
-  cellRendererByColumnKey,
-  classNames: {
-    table: className,
-    header: headerClassName,
-    row: rowClassName,
-  },
-  columnFlexGrow,
-  columnFlexShrink,
-  columnWidth,
-  dataList,
-  deferredMeasurementCache,
-  disableHeader,
-  disableSort,
-  flexLastColumn,
-  height,
-  headerHeight,
-  headerRendererByColumnKey,
-  overscanRowCount,
-  orderedColumnKeys,
-  rowHeight,
-  sort,
-  sortBy,
-  sortDirection,
-  styles: {
-    table: style,
-    header: headerStyle,
-    row: rowStyle,
-  },
-  width,
-}) {
-  return (
-    <Table
-      deferredMeasurementCache={deferredMeasurementCache}
-      disableHeader={disableHeader}
-      headerHeight={disableHeader ? undefined : headerHeight}
-      height={height}
-      overscanRowCount={overscanRowCount}
-      rowHeight={(deferredMeasurementCache && deferredMeasurementCache.rowHeight) || rowHeight}
-      rowGetter={({ index }) => dataList.get(index % dataList.size)}
-      rowCount={dataList.size}
-      sort={sort}
-      sortBy={sortBy}
-      sortDirection={sortDirection}
-      width={width}
-      className={className}
-      headerClassName={headerClassName}
-      rowClassName={rowClassName}
-      style={style}
-      headerStyle={headerStyle}
-      rowStyle={rowStyle}
-    >
-      {orderedColumnKeys.map((columnKey, idx) => {
-        let flexGrow;
-        if (typeof columnFlexGrow !== 'undefined') {
-          flexGrow = typeof columnFlexGrow === 'object' ?
-            columnFlexGrow[columnKey] : columnFlexGrow;
-        } else {
-          flexGrow = flexLastColumn && idx === orderedColumnKeys.length - 1 ? 1 : undefined;
-        }
-        return (
-          <Column
-            key={columnKey}
-            cellRenderer={
-              cellRendererByColumnKey &&
-              cellRendererByColumnKey[columnKey]
-            }
-            dataKey={columnKey}
-            disableSort={
-              typeof disableSort === 'object' ?
-              disableSort[columnKey] : disableSort}
-            flexShrink={
-              typeof columnFlexShrink === 'object' ?
-              columnFlexShrink[columnKey] : columnFlexShrink
-            }
-            flexGrow={flexGrow}
-            headerRendererByColumnKey={
-              headerRendererByColumnKey &&
-              headerRendererByColumnKey[columnKey]
-            }
-            label={columnKey}
-            width={typeof columnWidth === 'object' ?
-              columnWidth(columnKey) : columnWidth
-            }
+// eslint-disable-next-line react/prefer-stateless-function
+class BasicTable extends React.PureComponent {
+  render() {
+    const {
+      cellRendererByColumnKey,
+      classNames: {
+        table: className,
+        header: headerClassName,
+        row: rowClassName,
+      },
+      columnFlexGrow,
+      columnFlexShrink,
+      columnWidth,
+      dataList,
+      deferredMeasurementCache,
+      disableHeader,
+      disableSort,
+      flexLastColumn,
+      height,
+      headerHeight,
+      headerRendererByColumnKey,
+      overscanRowCount,
+      orderedColumnKeys,
+      rowHeight,
+      sort,
+      sortBy,
+      sortDirection,
+      styles: {
+        table: style,
+        header: headerStyle,
+        row: rowStyle,
+      },
+      width,
+    } = this.props;
 
-          />
-        );
-      })}
-    </Table>
-  );
+    return (
+      <Table
+        deferredMeasurementCache={deferredMeasurementCache}
+        disableHeader={disableHeader}
+        headerHeight={disableHeader ? undefined : headerHeight}
+        height={height}
+        overscanRowCount={overscanRowCount}
+        rowHeight={(deferredMeasurementCache && deferredMeasurementCache.rowHeight) || rowHeight}
+        rowGetter={({ index }) => dataList.get(index % dataList.size)}
+        rowCount={dataList.size}
+        sort={sort}
+        sortBy={sortBy}
+        sortDirection={sortDirection}
+        width={width}
+        className={className}
+        headerClassName={headerClassName}
+        rowClassName={rowClassName}
+        style={style}
+        headerStyle={headerStyle}
+        rowStyle={rowStyle}
+      >
+        {orderedColumnKeys.map((columnKey, idx) => {
+          let flexGrow;
+          if (typeof columnFlexGrow !== 'undefined') {
+            flexGrow = typeof columnFlexGrow === 'object' ?
+              columnFlexGrow[columnKey] : columnFlexGrow;
+          } else {
+            flexGrow = flexLastColumn && idx === orderedColumnKeys.length - 1 ? 1 : undefined;
+          }
+          return (
+            <Column
+              key={columnKey}
+              cellRenderer={
+                cellRendererByColumnKey &&
+                cellRendererByColumnKey[columnKey]
+              }
+              dataKey={columnKey}
+              disableSort={
+                typeof disableSort === 'object' ?
+                disableSort[columnKey] : disableSort}
+              flexShrink={
+                typeof columnFlexShrink === 'object' ?
+                columnFlexShrink[columnKey] : columnFlexShrink
+              }
+              flexGrow={flexGrow}
+              headerRendererByColumnKey={
+                headerRendererByColumnKey &&
+                headerRendererByColumnKey[columnKey]
+              }
+              label={columnKey}
+              width={typeof columnWidth === 'object' ?
+                columnWidth(columnKey) : columnWidth
+              }
+
+            />
+          );
+        })}
+      </Table>
+    );
+  }
 }
 
 BasicTable.propTypes = propTypes;

--- a/packages/data-table/src/enhancers/hocUtils.js
+++ b/packages/data-table/src/enhancers/hocUtils.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-param-reassign */
+import React from 'react';
+
+export function baseHOC(pureComponent) {
+  if (pureComponent) {
+    if (!React.PureComponent) {
+      throw new ReferenceError('baseHOC() pureComponent option requires React 15.3.0 or later');
+    }
+    return React.PureComponent;
+  }
+  return React.Component;
+}
+
+export function updateDisplayName(WrappedComponent, EnhancedComponent, hocName) {
+  const wrappedComponentName = WrappedComponent.displayName ||
+    WrappedComponent.name ||
+    'Component';
+
+  EnhancedComponent.WrappedComponent = WrappedComponent;
+  EnhancedComponent.displayName = `${hocName}(${wrappedComponentName})`;
+}

--- a/packages/data-table/src/enhancers/withDynamicCellHeights.jsx
+++ b/packages/data-table/src/enhancers/withDynamicCellHeights.jsx
@@ -1,9 +1,11 @@
-import React, { PropTypes, PureComponent } from 'react';
+import React, { PropTypes } from 'react';
 import { CellMeasurer, CellMeasurerCache } from 'react-virtualized';
+
+import { baseHOC, updateDisplayName } from './hocUtils';
 
 const propTypes = {
   // wrapped by CellMeasurer and returns the cell contents, one or one for each column
-  cellRenderer: PropTypes.oneOf([
+  cellRenderer: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.objectOf(PropTypes.func),
   ]),
@@ -18,19 +20,20 @@ const defaultProps = {
     <div
       style={{
         whiteSpace: 'normal',
-        background: '#eaeaea',
         wordBreak: 'break-word',
       }}
     >
-      {Array(10).join(cellData)}
+      {cellData}
     </div>
   ),
   defaultCellHeight: 32,
   minCellHeight: 32,
 };
 
-function withDynamicCellHeights(WrappedComponent) {
-  class EnhancedComponent extends PureComponent {
+function withDynamicCellHeights(WrappedComponent, pureComponent = true) {
+  const BaseClass = baseHOC(pureComponent);
+
+  class EnhancedComponent extends BaseClass {
     static getDynamicHeightCellCache({
       defaultCellHeight,
       minCellHeight,
@@ -89,6 +92,7 @@ function withDynamicCellHeights(WrappedComponent) {
 
   EnhancedComponent.propTypes = propTypes;
   EnhancedComponent.defaultProps = defaultProps;
+  updateDisplayName(WrappedComponent, EnhancedComponent, 'withDynamicCellHeights');
 
   return EnhancedComponent;
 }

--- a/packages/data-table/src/enhancers/withFiltering.jsx
+++ b/packages/data-table/src/enhancers/withFiltering.jsx
@@ -1,5 +1,6 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
 
+import { baseHOC, updateDisplayName } from './hocUtils';
 import dataListPropType from '../propTypes/dataList';
 
 const propTypes = {
@@ -17,8 +18,10 @@ const defaultProps = {
   initialFilterText: '',
 };
 
-function withFiltering(WrappedComponent) {
-  class WithFilteringComponent extends Component {
+function withFiltering(WrappedComponent, pureComponent = true) {
+  const BaseClass = baseHOC(pureComponent);
+
+  class EnhancedComponent extends BaseClass {
     constructor(props) {
       super(props);
       this.state = {
@@ -29,6 +32,7 @@ function withFiltering(WrappedComponent) {
     }
 
     componentWillReceiveProps(nextProps) {
+      // eslint-disable-next-line react/prop-types
       if (nextProps.dataList !== this.props.dataList) {
         this.onChangeFilterText(this.state.filterText, nextProps);
       }
@@ -57,10 +61,11 @@ function withFiltering(WrappedComponent) {
     }
   }
 
-  WithFilteringComponent.propTypes = propTypes;
-  WithFilteringComponent.defaultProps = defaultProps;
+  EnhancedComponent.propTypes = propTypes;
+  EnhancedComponent.defaultProps = defaultProps;
+  updateDisplayName(WrappedComponent, EnhancedComponent, 'withFiltering');
 
-  return WithFilteringComponent;
+  return EnhancedComponent;
 }
 
 export default withFiltering;

--- a/packages/data-table/src/enhancers/withSorting.jsx
+++ b/packages/data-table/src/enhancers/withSorting.jsx
@@ -1,14 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { SortDirection } from 'react-virtualized';
 
 import dataListPropType from '../propTypes/dataList';
+import { baseHOC, updateDisplayName } from './hocUtils';
 
 const propTypes = {
   dataList: dataListPropType.isRequired,
 };
 
-function withSorting(WrappedComponent) {
-  class WithSortingComponent extends Component {
+function withSorting(WrappedComponent, pureComponent = true) {
+  const BaseClass = baseHOC(pureComponent);
+
+  class EnhancedComponent extends BaseClass {
     constructor(props) {
       super(props);
       this.state = {
@@ -20,6 +23,7 @@ function withSorting(WrappedComponent) {
     }
 
     componentWillReceiveProps(nextProps) {
+      // eslint-disable-next-line react/prop-types
       if (nextProps.dataList !== this.props.dataList) {
         this.onSort(this.state, nextProps);
       }
@@ -56,9 +60,10 @@ function withSorting(WrappedComponent) {
     }
   }
 
-  WithSortingComponent.propTypes = propTypes;
+  EnhancedComponent.propTypes = propTypes;
+  updateDisplayName(WrappedComponent, EnhancedComponent, 'withSorting');
 
-  return WithSortingComponent;
+  return EnhancedComponent;
 }
 
 export default withSorting;

--- a/packages/data-table/src/enhancers/withTableAutoSizer.jsx
+++ b/packages/data-table/src/enhancers/withTableAutoSizer.jsx
@@ -1,6 +1,8 @@
 import React, { PropTypes } from 'react';
 import { AutoSizer } from 'react-virtualized';
 
+import { baseHOC, updateDisplayName } from './hocUtils';
+
 const propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
@@ -13,34 +15,40 @@ const defaultProps = {
   onResize: undefined,
 };
 
-function withTableAutoSizer(WrappedComponent) {
-  function WithAutoSizerComponent({
-    width: overrideWidth,
-    height: overrideHeight,
-    onResize,
-    ...props
-  }) {
-    return (
-      <AutoSizer
-        disableHeight={overrideHeight !== null}
-        disableWidth={overrideWidth !== null}
-        onResize={onResize}
-      >
-        {({ width, height }) => (
-          <WrappedComponent
-            width={overrideWidth !== null ? overrideWidth : width}
-            height={overrideHeight !== null ? overrideHeight : height}
-            {...props}
-          />
-        )}
-      </AutoSizer>
-    );
+function withTableAutoSizer(WrappedComponent, pureComponent = true) {
+  const BaseClass = baseHOC(pureComponent);
+
+  class EnhancedComponent extends BaseClass {
+    render() {
+      const {
+        width: overrideWidth,
+        height: overrideHeight,
+        onResize,
+        ...rest
+      } = this.props;
+      return (
+        <AutoSizer
+          disableHeight={overrideHeight !== null}
+          disableWidth={overrideWidth !== null}
+          onResize={onResize}
+        >
+          {({ width, height }) => (
+            <WrappedComponent
+              width={overrideWidth !== null ? overrideWidth : width}
+              height={overrideHeight !== null ? overrideHeight : height}
+              {...rest}
+            />
+          )}
+        </AutoSizer>
+      );
+    }
   }
 
-  WithAutoSizerComponent.propTypes = propTypes;
-  WithAutoSizerComponent.defaultProps = defaultProps;
+  EnhancedComponent.propTypes = propTypes;
+  EnhancedComponent.defaultProps = defaultProps;
+  updateDisplayName(WrappedComponent, EnhancedComponent, 'withTableAutoSizer');
 
-  return WithAutoSizerComponent;
+  return EnhancedComponent;
 }
 
 export default withTableAutoSizer;

--- a/packages/data-table/src/enhancers/withWindowScroller.jsx
+++ b/packages/data-table/src/enhancers/withWindowScroller.jsx
@@ -1,0 +1,56 @@
+import React, { PropTypes } from 'react';
+import { WindowScroller } from 'react-virtualized';
+
+import { baseHOC, updateDisplayName } from './hocUtils';
+
+const propTypes = {
+  onResize: PropTypes.func,
+  onScroll: PropTypes.func,
+  scrollElement: PropTypes.any,
+};
+
+const defaultProps = {
+  onResize: undefined,
+  onScroll: undefined,
+  scrollElement: undefined,
+};
+
+function withWindowScroller(WrappedComponent, pureComponent = true) {
+  const BaseClass = baseHOC(pureComponent);
+
+  class EnhancedComponent extends BaseClass {
+    render() {
+      const {
+        onResize,
+        onScroll,
+        scrollElement,
+        ...rest
+      } = this.props;
+      return (
+        <WindowScroller
+          onResize={onResize}
+          onScroll={onScroll}
+          scrollElement={scrollElement}
+        >
+          {({ height, isScrolling, scrollTop }) => (
+            <WrappedComponent
+              {...rest}
+              autoHeight
+              height={height}
+              isScrolling={isScrolling}
+              scrollTop={scrollTop}
+            />
+          )}
+        </WindowScroller>
+      );
+    }
+  }
+
+  EnhancedComponent.propTypes = propTypes;
+  EnhancedComponent.defaultProps = defaultProps;
+  updateDisplayName(WrappedComponent, EnhancedComponent, 'withWindowScroller');
+
+  return EnhancedComponent;
+}
+
+export default withWindowScroller;

--- a/packages/data-table/src/index.jsx
+++ b/packages/data-table/src/index.jsx
@@ -3,6 +3,7 @@ import withDynamicCellHeights from './enhancers/withDynamicCellHeights';
 import withFiltering from './enhancers/withFiltering';
 import withSorting from './enhancers/withSorting';
 import withTableAutoSizer from './enhancers/withTableAutoSizer';
+import withWindowScroller from './enhancers/withWindowScroller';
 
 export {
   Table,
@@ -10,4 +11,5 @@ export {
   withFiltering,
   withSorting,
   withTableAutoSizer,
+  withWindowScroller,
 };

--- a/packages/data-table/test/.eslintrc
+++ b/packages/data-table/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "import/no-extraneous-dependencies": 0
+  }
+}

--- a/packages/data-table/test/Table_test.jsx
+++ b/packages/data-table/test/Table_test.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import Table from '../src/components/Table';
+
+describe('Table', () => {
+  it('is valid element', () => {
+    expect(React.isValidElement(<Table />)).to.equal(true);
+  });
+});

--- a/packages/data-table/test/mocha.opts
+++ b/packages/data-table/test/mocha.opts
@@ -1,0 +1,3 @@
+--require babel-polyfill
+--compilers js:babel-register,jsx:babel-register
+--recursive

--- a/packages/demo/examples/data-table/index.jsx
+++ b/packages/demo/examples/data-table/index.jsx
@@ -6,6 +6,7 @@ import {
   withDynamicCellHeights,
   withSorting,
   withTableAutoSizer,
+  withWindowScroller,
 } from '@data-ui/data-table';
 
 import { tableStyles, sorableTableStyles } from './tableStyles';
@@ -44,11 +45,25 @@ export default [
     ),
   },
   {
+    description: 'with window scrolling + auto width HOCs',
+    example: () => {
+      const WindowScrollingTable = withWindowScroller(withTableAutoSizer(Table));
+      return ( // storybook container doesn't set an explicit size
+        <WindowScrollingTable
+          dataList={dataList}
+          orderedColumnKeys={someColumns}
+          columnFlexGrow={1}
+          styles={tableStyles}
+        />
+      );
+    },
+  },
+  {
     description: 'with auto width + height HOC',
     example: () => {
       const AutoSizedTable = withTableAutoSizer(Table);
       return ( // storybook container doesn't set an explicit size
-        <div style={{ height: 500, background: 'pink' }}>
+        <div style={{ height: 500, background: '#FFB400' }}>
           <AutoSizedTable
             dataList={dataList}
             orderedColumnKeys={someColumns}
@@ -76,16 +91,20 @@ export default [
     },
   },
   {
-    description: 'dynamic cell heights',
+    description: 'with dynamic cell height HOC',
     example: () => {
       const DynamicCellHeight = withTableAutoSizer(withDynamicCellHeights(Table));
       return (
         <DynamicCellHeight
-          dataList={dataList}
-          orderedColumnKeys={someColumns}
-          dynamicHeightColumnKeys={someColumns.slice(0, 1)}
+          dataList={dataList.map(d => ({
+            ...d,
+            'long column': Array(Math.random() > 0.5 ? 50 : 20).join('really long text '),
+          }))}
+          orderedColumnKeys={someColumns.slice(0, 2).concat(['long column'])}
+          dynamicHeightColumnKeys={['long column']}
           height={600}
-          columnFlexGrow={1}
+          columnWidth={150}
+          flexLastColumn
           styles={tableStyles}
         />
       );

--- a/packages/demo/examples/index.jsx
+++ b/packages/demo/examples/index.jsx
@@ -7,7 +7,7 @@ requireContext.keys().forEach((packageName) => {
   if (packageName !== 'shared') {
     const examples = requireContext(packageName);
     if (examples && examples.default) {
-      const name = path.dirname(packageName).slice(2);
+      const name = path.dirname(packageName).slice(2); // no './'
       const stories = storiesOf(name, module);
       examples.default.forEach((example) => {
         stories.add(example.description, example.example);

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -7,7 +7,8 @@
     "gh-pages:build": "build-storybook -o _gh-pages -c ./storybook-config",
     "gh-pages:publish": "git-directory-deploy --directory _gh-pages",
     "gh-pages": "npm run gh-pages:clean && npm run gh-pages:build && npm run gh-pages:publish && npm run gh-pages:clean",
-    "storybook": "start-storybook -p 9001 -c ./storybook-config"
+    "storybook": "start-storybook -p 9001 -c ./storybook-config",
+    "test": "echo no tests in @data-ui/demo"
   },
   "repository": "https://github.com/williaster/data-ui.git",
   "keywords": [


### PR DESCRIPTION
This PR 
- hooks up testing to the root repository and adds a simple `Table` test
- updates `Table` and (optionally) HOCs to `PureComponents`
- adds a `withWindowScroller` HOC + example