### PR TITLE
column labels + filtering bug

### DIFF
--- a/packages/data-table/src/components/Table.jsx
+++ b/packages/data-table/src/components/Table.jsx
@@ -32,6 +32,7 @@ const propTypes = {
   }),
   columnFlexGrow: typeOrColumnKeyToType(PropTypes.number),
   columnFlexShrink: typeOrColumnKeyToType(PropTypes.number),
+  columnLabelByColumnKey: PropTypes.objectOf(PropTypes.string),
   columnWidth: typeOrColumnKeyToType(PropTypes.number),
   deferredMeasurementCache: PropTypes.object,
   disableHeader: PropTypes.bool,
@@ -60,6 +61,7 @@ const defaultProps = {
   classNames: {},
   columnFlexGrow: undefined,
   columnFlexShrink: 1,
+  columnLabelByColumnKey: undefined,
   columnWidth: 50,
   deferredMeasurementCache: undefined,
   disableHeader: false,
@@ -87,6 +89,7 @@ class BasicTable extends React.PureComponent {
       },
       columnFlexGrow,
       columnFlexShrink,
+      columnLabelByColumnKey,
       columnWidth,
       dataList,
       deferredMeasurementCache,
@@ -109,7 +112,6 @@ class BasicTable extends React.PureComponent {
       },
       width,
     } = this.props;
-
     return (
       <Table
         deferredMeasurementCache={deferredMeasurementCache}
@@ -159,7 +161,7 @@ class BasicTable extends React.PureComponent {
                 headerRendererByColumnKey &&
                 headerRendererByColumnKey[columnKey]
               }
-              label={columnKey}
+              label={(columnLabelByColumnKey && columnLabelByColumnKey[columnKey]) || columnKey}
               width={typeof columnWidth === 'object' ?
                 columnWidth(columnKey) : columnWidth
               }

--- a/packages/data-table/src/enhancers/withFiltering.jsx
+++ b/packages/data-table/src/enhancers/withFiltering.jsx
@@ -12,7 +12,7 @@ const propTypes = {
 const defaultProps = {
   filterRow: (row, filterText) => {
     const re = new RegExp(filterText, 'gi');
-    const values = Object.values(row).map(value => value.toString().toLowerCase());
+    const values = Object.values(row).map(value => (value || '').toString().toLowerCase());
     return values.some(value => re.test(value));
   },
   initialFilterText: '',

--- a/packages/demo/examples/data-table/index.jsx
+++ b/packages/demo/examples/data-table/index.jsx
@@ -45,6 +45,24 @@ export default [
     ),
   },
   {
+    description: 'custom column labels',
+    example: () => (
+      <Table
+        dataList={dataList}
+        orderedColumnKeys={someColumns.slice(0, 2)}
+        width={700}
+        height={400}
+        columnWidth={100}
+        flexLastColumn
+        styles={tableStyles}
+        columnLabelByColumnKey={{
+          [someColumns[0]]: 'Custom 1',
+          [someColumns[1]]: 'Custom 2',
+        }}
+      />
+    ),
+  },
+  {
     description: 'with window scrolling + auto width HOCs',
     example: () => {
       const WindowScrollingTable = withWindowScroller(withTableAutoSizer(Table));


### PR DESCRIPTION
This PR adds support for custom column labels in the root @data-ui/data-table `<Table/>` (as opposed to using the column key) and fixes a bug where the default `withFiltering` filter func throws if a value is undefined/null.