### PR TITLE
[xy-chart] Add `xy-chart` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 A collection of custom + wrapped components for data-rich (desktop) UIs. Super beta :baby:
 
 ## Packages
-- [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table)
-- [@data-ui/demo](https://github.com/williaster/data-ui/tree/master/packages/demo)
++ [@data-ui/xy-chart](https://github.com/williaster/data-ui/tree/master/packages/xy-chart)
++ [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table)
++ [@data-ui/demo](https://github.com/williaster/data-ui/tree/master/packages/demo)
 
 Lots more coming.
 
 ## Live Playground
 
-For examples of the components in action, go to https://williaster.github.io/data-ui.
+For examples of the components in action, go to [williaster.github.io/data-ui](https://williaster.github.io/data-ui).
 
 OR
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.12"
+  "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
-    "lerna": "2.0.0-rc.2",
+    "lerna": "^2.0.0-rc.2",
     "mocha": "^3.2.0",
     "react": "~15.4.2",
     "react-dom": "~15.4.2"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react",
     "d3",
     "chart",
-    "data-ui"
+    "data-ui",
+    "vx"
   ],
   "author": "Chris Williams <chris.williams@airbnb.com>",
   "license": "MIT",

--- a/packages/data-table/README.md
+++ b/packages/data-table/README.md
@@ -23,5 +23,6 @@ npm run dev # or 'npm run prod'
 ```
 
 ## @data-ui packages
-- --> @data-ui/data-table
-- [@data-ui/demo](https://github.com/williaster/data-ui/tree/master/packages/demo)
++ [@data-ui/xy-chart](https://github.com/williaster/data-ui/tree/master/packages/xy-chart)
++ @data-ui/data-table
++ [@data-ui/demo](https://github.com/williaster/data-ui/tree/master/packages/demo)

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -1,6 +1,7 @@
 # @data-ui/demo
-Storybook of @data-ui examples. :warning: Structure of this repo may change.
+Storybook of @data-ui examples. See it live at [williaster.github.io/data-ui](https://williaster.github.io/data-ui).
 
 ## @data-ui packages
-- [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table)
-- --> @data-ui/demo
++ [@data-ui/xy-chart](https://github.com/williaster/data-ui/tree/master/packages/xy-chart)
++ [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table)
++ @data-ui/demo

--- a/packages/demo/examples/index.jsx
+++ b/packages/demo/examples/index.jsx
@@ -1,7 +1,7 @@
 import path from 'path';
 import { storiesOf } from '@kadira/storybook';
 
-const requireContext = require.context('./', /* subdirs= */true, /index\.jsx/);
+const requireContext = require.context('./', /* subdirs= */true, /index\.jsx?$/);
 
 requireContext.keys().forEach((packageName) => {
   if (packageName !== 'shared') {

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -4,6 +4,7 @@ import mockData from '@vx/mock-data';
 import {
   XYChart,
   LineSeries,
+  LinearGradient,
   VerticalBarSeries,
   XAxis,
   YAxis,
@@ -23,7 +24,6 @@ const ResponsiveXYChart = withScreenSize(({ screenWidth, children, ...rest }) =>
 const data = mockData.appleStock.filter((d, i) => i % 120 === 0).map(d => ({
   x: new Date(d.date),
   y: d.close,
-  color: Math.random() > 0.75 ? 'category1' : 'category2',
 }));
 
 export default [
@@ -37,9 +37,15 @@ export default [
           y: { type: 'linear', includeZero: true },
         }}
       >
+        <LinearGradient
+          id="aqua_lightaqua_gradient"
+          from="#00A699"
+          to="#84D2CB"
+        />
         <VerticalBarSeries
           data={data}
           label="Apple Stock"
+          fill="url(#aqua_lightaqua_gradient)"
         />
       </ResponsiveXYChart>
     ),
@@ -54,13 +60,20 @@ export default [
           y: { type: 'linear', includeZero: true },
         }}
       >
+        <LinearGradient
+          id="aqua_lightaqua_gradient"
+          from="#00A699"
+          to="#84D2CB"
+        />
         <VerticalBarSeries
           data={data}
           label="Apple Stock"
+          fill="url(#aqua_lightaqua_gradient)"
         />
         <LineSeries
           data={data}
           label="Apple Stock"
+          stroke="#484848"
         />
       </ResponsiveXYChart>
     ),
@@ -76,9 +89,15 @@ export default [
         }}
       >
         <YAxis label="Price ($)" numTicks={4} />
+        <LinearGradient
+          id="aqua_lightaqua_gradient"
+          from="#00A699"
+          to="#84D2CB"
+        />
         <VerticalBarSeries
           data={data}
           label="Apple Stock"
+          fill="url(#aqua_lightaqua_gradient)"
         />
         <XAxis label="Time" numTicks={5} />
       </ResponsiveXYChart>
@@ -95,9 +114,15 @@ export default [
         }}
       >
         <YAxis label="Price ($)" numTicks={4} orientation="left" />
+        <LinearGradient
+          id="aqua_lightaqua_gradient"
+          from="#00A699"
+          to="#84D2CB"
+        />
         <VerticalBarSeries
           data={data}
           label="Apple Stock"
+          fill="url(#aqua_lightaqua_gradient)"
         />
         <XAxis label="Time" numTicks={5} orientation="top" />
       </ResponsiveXYChart>
@@ -117,8 +142,39 @@ export default [
         <LineSeries
           data={data}
           label="Apple Stock"
+          showPoints
+        />
+        <LineSeries
+          data={data.map(d => ({ ...d, y: Math.random() > 0.5 ? d.y * 2 : d.y / 2 }))}
+          label="Apple Stock 2"
+          stroke="#484848"
+          strokeDasharray="3 3"
         />
         <XAxis label="Time" numTicks={5} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'categorical bar chart',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        scales={{
+          x: { type: 'band' },
+          y: { type: 'linear', includeZero: true },
+        }}
+      >
+        <LinearGradient
+          id="aqua_lightaqua_gradient"
+          from="#00A699"
+          to="#84D2CB"
+        />
+        <VerticalBarSeries
+          data={data.map((d, i) => ({ ...d, x: 'abcdefghijklmnopqrstuvwxyz'[i % 26] }))}
+          label="Apple Stock"
+          fill="url(#aqua_lightaqua_gradient)"
+        />
+        <XAxis numTicks={data.length} />
       </ResponsiveXYChart>
     ),
   },
@@ -133,10 +189,17 @@ export default [
         }}
       >
         <YAxis label="$$$" numTicks={4} />
+        <LinearGradient
+          id="aqua_lightaqua_gradient"
+          from="#00A699"
+          to="#84D2CB"
+        />
         <VerticalBarSeries
           data={data}
           label="Apple Stock"
+          fill="url(#aqua_lightaqua_gradient)"
         />
+        <XAxis numTicks={0} />
       </ResponsiveXYChart>
     ),
   },

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -5,6 +5,7 @@ import {
   XYChart,
   LineSeries,
   LinearGradient,
+  theme,
   VerticalBarSeries,
   XAxis,
   YAxis,
@@ -13,6 +14,7 @@ import {
 
 const ResponsiveXYChart = withScreenSize(({ screenWidth, children, ...rest }) => (
   <XYChart
+    theme={theme}
     width={screenWidth / 1.5}
     height={screenWidth / 1.5 / 2}
     {...rest}
@@ -200,6 +202,27 @@ export default [
           fill="url(#aqua_lightaqua_gradient)"
         />
         <XAxis numTicks={0} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'no theme',
+    example: () => (
+      <ResponsiveXYChart
+        theme={{}}
+        ariaLabel="Required label"
+        scales={{
+          x: { type: 'time' },
+          y: { type: 'linear', includeZero: true },
+        }}
+      >
+        <YAxis label="Price ($)" numTicks={4} />
+        <VerticalBarSeries
+          data={data}
+          label="Apple Stock"
+          fill="#767676"
+        />
+        <XAxis label="Time" numTicks={5} />
       </ResponsiveXYChart>
     ),
   },

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -8,7 +8,9 @@ import {
 
   IntervalSeries,
   LineSeries,
-  VerticalBarSeries,
+  BarSeries,
+  GroupedBarSeries,
+  StackedBarSeries,
 
   XAxis,
   YAxis,
@@ -74,7 +76,7 @@ const intervalData = intervals.reduce((ret, [i0, i1]) => {
 
 export default [
   {
-    description: 'time bar chart',
+    description: '<BarSeries /> with <PatternLines /> and <LinearGradient />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -94,7 +96,7 @@ export default [
           strokeWidth={1}
           orientation={['diagonal']}
         />
-        <VerticalBarSeries
+        <BarSeries
           data={data.map((d, i) => ({ ...d, fill: `url(#${i === 2 ? 'lines' : 'gradient'})` }))}
           label="Apple Stock"
           fill="url(#aqua_lightaqua_gradient)"
@@ -103,7 +105,7 @@ export default [
     ),
   },
   {
-    description: 'bar and line chart',
+    description: '<BarSeries /> and <LineSeries />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -115,7 +117,7 @@ export default [
           from="#00A699"
           to="#84D2CB"
         />
-        <VerticalBarSeries
+        <BarSeries
           data={data}
           label="Apple Stock"
           fill="url(#aqua_lightaqua_gradient)"
@@ -129,7 +131,7 @@ export default [
     ),
   },
   {
-    description: 'time bar chart with axes',
+    description: '<BarSeries /> with <XAxis /> and <YAxis />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -142,7 +144,7 @@ export default [
           from="#00A699"
           to="#84D2CB"
         />
-        <VerticalBarSeries
+        <BarSeries
           data={data}
           label="Apple Stock"
           fill="url(#aqua_lightaqua_gradient)"
@@ -152,7 +154,7 @@ export default [
     ),
   },
   {
-    description: 'time bar chart with inverted axes',
+    description: 'Inverted <XAxis />, <YAxis />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -165,7 +167,7 @@ export default [
           from="#00A699"
           to="#84D2CB"
         />
-        <VerticalBarSeries
+        <BarSeries
           data={data}
           label="Apple Stock"
           fill="url(#aqua_lightaqua_gradient)"
@@ -175,7 +177,7 @@ export default [
     ),
   },
   {
-    description: 'line chart',
+    description: 'Multiple <LineSeries />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -199,7 +201,7 @@ export default [
     ),
   },
   {
-    description: 'vertical stack',
+    description: '<StackedBarSeries />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -207,17 +209,17 @@ export default [
         yScale={{ type: 'linear' }}
       >
         <YAxis label="Temperature (°F)" numTicks={4} />
-        <VerticalBarSeries
+        <StackedBarSeries
           data={stackedData}
           label="City Temperature"
-          stack={groupKeys}
+          stackKeys={groupKeys}
         />
         <XAxis tickFormat={dateFormatter} />
       </ResponsiveXYChart>
     ),
   },
   {
-    description: 'vertical grouped bar',
+    description: '<GroupedBarSeries />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -226,17 +228,17 @@ export default [
         showYGrid={false}
       >
         <YAxis label="Temperature (°F)" numTicks={4} />
-        <VerticalBarSeries
+        <GroupedBarSeries
           data={groupedData}
           label="City Temperature"
-          group={groupKeys}
+          groupKeys={groupKeys}
         />
         <XAxis tickFormat={dateFormatter} />
       </ResponsiveXYChart>
     ),
   },
   {
-    description: 'categorical bar chart',
+    description: 'Categorical <BarSeries />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -248,7 +250,7 @@ export default [
           from="#00A699"
           to="#84D2CB"
         />
-        <VerticalBarSeries
+        <BarSeries
           data={data.map((d, i) => ({ ...d, x: 'abcdefghijklmnopqrstuvwxyz'[i % 26] }))}
           label="Apple Stock"
           fill="url(#aqua_lightaqua_gradient)"
@@ -258,7 +260,7 @@ export default [
     ),
   },
   {
-    description: 'time intervals',
+    description: '<IntervalSeries />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -289,7 +291,7 @@ export default [
     ),
   },
   {
-    description: 'non-zero y-axis',
+    description: 'Non-zero y-axis',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -302,7 +304,7 @@ export default [
           from="#00A699"
           to="#84D2CB"
         />
-        <VerticalBarSeries
+        <BarSeries
           data={data}
           label="Apple Stock"
           fill="url(#aqua_lightaqua_gradient)"
@@ -312,7 +314,7 @@ export default [
     ),
   },
   {
-    description: 'no theme',
+    description: 'No theme',
     example: () => (
       <ResponsiveXYChart
         theme={{}}
@@ -321,12 +323,12 @@ export default [
         yScale={{ type: 'linear' }}
       >
         <YAxis label="Price ($)" numTicks={4} />
-        <VerticalBarSeries
+        <BarSeries
           data={data.filter((d, i) => i % 2 === 0)}
           label="Apple Stock"
           fill="#484848"
         />
-        <VerticalBarSeries
+        <BarSeries
           data={data.filter((d, i) => i % 2 !== 0 && i !== 5)}
           label="Apple Stock ii"
           fill="#767676"

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -5,10 +5,15 @@ import { timeParse, timeFormat } from 'd3-time-format';
 
 import {
   XYChart,
+
+  IntervalSeries,
   LineSeries,
   VerticalBarSeries,
+
   XAxis,
   YAxis,
+
+  PatternLines,
   LinearGradient,
   withScreenSize,
   theme,
@@ -37,12 +42,30 @@ const data = appleStock.filter((d, i) => i % 120 === 0).map(d => ({
   y: d.close,
 }));
 
+// stacked data
 const stackKeys = Object.keys(cityTemperature[0]).filter(attr => attr !== 'date');
 const stackedData = cityTemperature.slice(0, 12).map(d => ({
   ...d,
   x: d.date,
   y: stackKeys.reduce((ret, curr) => ret + Number(d[curr]), 0),
 }));
+
+// interval data
+const intervals = [[5, 8], [15, 19]];
+
+const intervalLineData = cityTemperature.slice(0, 16).map((d, i) => ({
+  ...d,
+  x: d.date,
+  y: intervals.some(([i0, i1]) => i >= i0 && i <= i1) ? null : d[stackKeys[0]],
+}));
+
+const intervalData = intervals.reduce((ret, [i0, i1]) => {
+  ret.push({
+    x0: cityTemperature[i0].date,
+    x1: cityTemperature[i1].date,
+  });
+  return ret;
+}, []);
 
 export default [
   {
@@ -54,12 +77,20 @@ export default [
         yScale={{ type: 'linear' }}
       >
         <LinearGradient
-          id="aqua_lightaqua_gradient"
+          id="gradient"
           from="#00A699"
           to="#84D2CB"
         />
+        <PatternLines
+          id="lines"
+          height={5}
+          width={5}
+          stroke="#00A699"
+          strokeWidth={1}
+          orientation={['diagonal']}
+        />
         <VerticalBarSeries
-          data={data}
+          data={data.map((d, i) => ({ ...d, fill: `url(#${i === 2 ? 'lines' : 'gradient'})` }))}
           label="Apple Stock"
           fill="url(#aqua_lightaqua_gradient)"
         />
@@ -163,6 +194,42 @@ export default [
     ),
   },
   {
+    description: 'vertical stack',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        xScale={{ type: 'band', paddingInner: 0.05 }}
+        yScale={{ type: 'linear' }}
+      >
+        <YAxis label="Temperature (°F)" numTicks={4} />
+        <VerticalBarSeries
+          data={stackedData}
+          label="City Temperature"
+          stack={stackKeys}
+        />
+        <XAxis tickFormat={dateFormatter} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'vertical grouped bar',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        xScale={{ type: 'band', paddingInner: 0.05 }}
+        yScale={{ type: 'linear' }}
+      >
+        <YAxis label="Temperature (°F)" numTicks={4} />
+        <VerticalBarSeries
+          data={stackedData}
+          label="Apple Stock"
+          stack={stackKeys}
+        />
+        <XAxis tickFormat={dateFormatter} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
     description: 'categorical bar chart',
     example: () => (
       <ResponsiveXYChart
@@ -181,6 +248,37 @@ export default [
           fill="url(#aqua_lightaqua_gradient)"
         />
         <XAxis numTicks={data.length} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'time intervals',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear', domain: [40, 80] }}
+      >
+        <YAxis label="Temperature (°F)" numTicks={4} />
+        <PatternLines
+          id="interval_pattern"
+          height={8}
+          width={8}
+          stroke="#84D2CB"
+          strokeWidth={1}
+          orientation={['diagonal']}
+        />
+        <IntervalSeries
+          data={intervalData}
+          label="Temperature interval"
+          fill="url(#interval_pattern)"
+        />
+        <LineSeries
+          data={intervalLineData}
+          label="Line interval"
+          showPoints
+        />
+        <XAxis />
       </ResponsiveXYChart>
     ),
   },
@@ -228,24 +326,6 @@ export default [
           fill="#767676"
         />
         <XAxis label="Time" numTicks={5} />
-      </ResponsiveXYChart>
-    ),
-  },
-  {
-    description: 'vertical stack',
-    example: () => (
-      <ResponsiveXYChart
-        ariaLabel="Required label"
-        xScale={{ type: 'band', paddingInner: 0.05 }}
-        yScale={{ type: 'linear' }}
-      >
-        <YAxis label="Price ($)" numTicks={4} />
-        <VerticalBarSeries
-          data={stackedData}
-          label="Apple Stock"
-          stack={stackKeys}
-        />
-        <XAxis label="Time" numTicks={5} tickFormat={dateFormatter} />
       </ResponsiveXYChart>
     ),
   },

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -6,14 +6,15 @@ import { timeParse, timeFormat } from 'd3-time-format';
 import {
   XYChart,
 
-  IntervalSeries,
-  LineSeries,
-  BarSeries,
-  GroupedBarSeries,
-  StackedBarSeries,
-
   XAxis,
   YAxis,
+
+  BarSeries,
+  IntervalSeries,
+  LineSeries,
+  GroupedBarSeries,
+  StackedBarSeries,
+  PointSeries,
 
   PatternLines,
   LinearGradient,
@@ -37,7 +38,7 @@ const ResponsiveXYChart = withScreenSize(({ screenWidth, children, ...rest }) =>
   </XYChart>
 ));
 
-const { cityTemperature, appleStock } = mockData;
+const { cityTemperature, appleStock, genRandomNormalPoints } = mockData;
 
 const data = appleStock.filter((d, i) => i % 120 === 0).map(d => ({
   x: new Date(d.date),
@@ -57,6 +58,16 @@ const groupedData = stackedData.slice(0, 6).map(d => ({
   y: Math.max(...groupKeys.map(attr => Number(d[attr]))),
 }));
 
+// point data
+const n = 10;
+const pointData = genRandomNormalPoints(n).map(([x, y], i) => ({
+  x,
+  y,
+  fill: theme.colors.categories[Math.floor(i / n)],
+  size: Math.max(3, Math.random() * 10),
+  label: (i % n) === 0 ? `(${parseInt(x, 10)},${parseInt(y, 10)})` : null,
+}));
+
 // interval data
 const intervals = [[5, 8], [15, 19]];
 
@@ -74,6 +85,7 @@ const intervalData = intervals.reduce((ret, [i0, i1]) => {
   return ret;
 }, []);
 
+// @todo: factor these into separate stories to more fully demo each component
 export default [
   {
     description: '<BarSeries /> with <PatternLines /> and <LinearGradient />',
@@ -105,33 +117,7 @@ export default [
     ),
   },
   {
-    description: '<BarSeries /> and <LineSeries />',
-    example: () => (
-      <ResponsiveXYChart
-        ariaLabel="Required label"
-        xScale={{ type: 'time' }}
-        yScale={{ type: 'linear' }}
-      >
-        <LinearGradient
-          id="aqua_lightaqua_gradient"
-          from="#00A699"
-          to="#84D2CB"
-        />
-        <BarSeries
-          data={data}
-          label="Apple Stock"
-          fill="url(#aqua_lightaqua_gradient)"
-        />
-        <LineSeries
-          data={data}
-          label="Apple Stock"
-          stroke="#484848"
-        />
-      </ResponsiveXYChart>
-    ),
-  },
-  {
-    description: '<BarSeries /> with <XAxis /> and <YAxis />',
+    description: '<BarSeries /> + <LineSeries /> + <XAxis /> + <YAxis />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -149,12 +135,17 @@ export default [
           label="Apple Stock"
           fill="url(#aqua_lightaqua_gradient)"
         />
+        <LineSeries
+          data={data}
+          label="Apple Stock"
+          stroke="#484848"
+        />
         <XAxis label="Time" numTicks={5} />
       </ResponsiveXYChart>
     ),
   },
   {
-    description: 'Inverted <XAxis />, <YAxis />',
+    description: 'Inverted <XAxis /> + <YAxis />',
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
@@ -197,6 +188,27 @@ export default [
           strokeDasharray="3 3"
         />
         <XAxis label="Time" numTicks={5} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: '<PointSeries />',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        xScale={{ type: 'linear', nice: true }}
+        yScale={{ type: 'linear', nice: true }}
+        showXGrid={false}
+        showYGrid={false}
+      >
+        <YAxis label="Y" numTicks={4} />
+        <XAxis label="X" numTicks={4} />
+        <PointSeries
+          data={pointData}
+          label="Random"
+          size={d => d.size}
+        />
+
       </ResponsiveXYChart>
     ),
   },

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -1,0 +1,143 @@
+import React from 'react';
+
+import mockData from '@vx/mock-data';
+import {
+  XYChart,
+  LineSeries,
+  VerticalBarSeries,
+  XAxis,
+  YAxis,
+  withScreenSize,
+} from '../../../xy-chart/build';
+
+const ResponsiveXYChart = withScreenSize(({ screenWidth, children, ...rest }) => (
+  <XYChart
+    width={screenWidth / 1.5}
+    height={screenWidth / 1.5 / 2}
+    {...rest}
+  >
+    {children}
+  </XYChart>
+));
+
+const data = mockData.appleStock.filter((d, i) => i % 120 === 0).map(d => ({
+  x: new Date(d.date),
+  y: d.close,
+  color: Math.random() > 0.75 ? 'category1' : 'category2',
+}));
+
+export default [
+  {
+    description: 'time bar chart',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        scales={{
+          x: { type: 'time' },
+          y: { type: 'linear', includeZero: true },
+        }}
+      >
+        <VerticalBarSeries
+          data={data}
+          label="Apple Stock"
+        />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'bar and line chart',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        scales={{
+          x: { type: 'time' },
+          y: { type: 'linear', includeZero: true },
+        }}
+      >
+        <VerticalBarSeries
+          data={data}
+          label="Apple Stock"
+        />
+        <LineSeries
+          data={data}
+          label="Apple Stock"
+        />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'time bar chart with axes',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        scales={{
+          x: { type: 'time' },
+          y: { type: 'linear', includeZero: true },
+        }}
+      >
+        <YAxis label="Price ($)" numTicks={4} />
+        <VerticalBarSeries
+          data={data}
+          label="Apple Stock"
+        />
+        <XAxis label="Time" numTicks={5} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'time bar chart with inverted axes',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        scales={{
+          x: { type: 'time' },
+          y: { type: 'linear', includeZero: true },
+        }}
+      >
+        <YAxis label="Price ($)" numTicks={4} orientation="left" />
+        <VerticalBarSeries
+          data={data}
+          label="Apple Stock"
+        />
+        <XAxis label="Time" numTicks={5} orientation="top" />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'line chart',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        scales={{
+          x: { type: 'time' },
+          y: { type: 'linear', includeZero: true },
+        }}
+      >
+        <YAxis label="Price ($)" numTicks={4} />
+        <LineSeries
+          data={data}
+          label="Apple Stock"
+        />
+        <XAxis label="Time" numTicks={5} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'non-zero y-axis',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        scales={{
+          x: { type: 'time' },
+          y: { type: 'linear' },
+        }}
+      >
+        <YAxis label="$$$" numTicks={4} />
+        <VerticalBarSeries
+          data={data}
+          label="Apple Stock"
+        />
+      </ResponsiveXYChart>
+    ),
+  },
+];

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -43,20 +43,25 @@ const data = appleStock.filter((d, i) => i % 120 === 0).map(d => ({
 }));
 
 // stacked data
-const stackKeys = Object.keys(cityTemperature[0]).filter(attr => attr !== 'date');
+const groupKeys = Object.keys(cityTemperature[0]).filter(attr => attr !== 'date');
 const stackedData = cityTemperature.slice(0, 12).map(d => ({
   ...d,
   x: d.date,
-  y: stackKeys.reduce((ret, curr) => ret + Number(d[curr]), 0),
+  y: groupKeys.reduce((ret, curr) => ret + Number(d[curr]), 0),
+}));
+
+const groupedData = stackedData.slice(0, 6).map(d => ({
+  ...d,
+  y: Math.max(...groupKeys.map(attr => Number(d[attr]))),
 }));
 
 // interval data
 const intervals = [[5, 8], [15, 19]];
 
-const intervalLineData = cityTemperature.slice(0, 16).map((d, i) => ({
+const intervalLineData = cityTemperature.slice(0, 25).map((d, i) => ({
   ...d,
   x: d.date,
-  y: intervals.some(([i0, i1]) => i >= i0 && i <= i1) ? null : d[stackKeys[0]],
+  y: intervals.some(([i0, i1]) => i >= i0 && i <= i1) ? null : d[groupKeys[0]],
 }));
 
 const intervalData = intervals.reduce((ret, [i0, i1]) => {
@@ -205,7 +210,7 @@ export default [
         <VerticalBarSeries
           data={stackedData}
           label="City Temperature"
-          stack={stackKeys}
+          stack={groupKeys}
         />
         <XAxis tickFormat={dateFormatter} />
       </ResponsiveXYChart>
@@ -216,14 +221,15 @@ export default [
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
-        xScale={{ type: 'band', paddingInner: 0.05 }}
+        xScale={{ type: 'band', paddingInner: 0.15 }}
         yScale={{ type: 'linear' }}
+        showYGrid={false}
       >
         <YAxis label="Temperature (°F)" numTicks={4} />
         <VerticalBarSeries
-          data={stackedData}
-          label="Apple Stock"
-          stack={stackKeys}
+          data={groupedData}
+          label="City Temperature"
+          group={groupKeys}
         />
         <XAxis tickFormat={dateFormatter} />
       </ResponsiveXYChart>

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -1,31 +1,47 @@
 import React from 'react';
 
 import mockData from '@vx/mock-data';
+import { timeParse, timeFormat } from 'd3-time-format';
+
 import {
   XYChart,
   LineSeries,
-  LinearGradient,
-  theme,
   VerticalBarSeries,
   XAxis,
   YAxis,
+  LinearGradient,
   withScreenSize,
+  theme,
 } from '../../../xy-chart/build';
+
+
+const parseDate = timeParse('%Y%m%d');
+const formatDate = timeFormat('%b %d');
+const dateFormatter = date => formatDate(parseDate(date));
 
 const ResponsiveXYChart = withScreenSize(({ screenWidth, children, ...rest }) => (
   <XYChart
     theme={theme}
-    width={screenWidth / 1.5}
-    height={screenWidth / 1.5 / 2}
+    width={screenWidth / 1.1}
+    height={screenWidth / 1.1 / 2}
     {...rest}
   >
     {children}
   </XYChart>
 ));
 
-const data = mockData.appleStock.filter((d, i) => i % 120 === 0).map(d => ({
+const { cityTemperature, appleStock } = mockData;
+
+const data = appleStock.filter((d, i) => i % 120 === 0).map(d => ({
   x: new Date(d.date),
   y: d.close,
+}));
+
+const stackKeys = Object.keys(cityTemperature[0]).filter(attr => attr !== 'date');
+const stackedData = cityTemperature.slice(0, 12).map(d => ({
+  ...d,
+  x: d.date,
+  y: stackKeys.reduce((ret, curr) => ret + Number(d[curr]), 0),
 }));
 
 export default [
@@ -34,10 +50,8 @@ export default [
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
-        scales={{
-          x: { type: 'time' },
-          y: { type: 'linear', includeZero: true },
-        }}
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear' }}
       >
         <LinearGradient
           id="aqua_lightaqua_gradient"
@@ -57,10 +71,8 @@ export default [
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
-        scales={{
-          x: { type: 'time' },
-          y: { type: 'linear', includeZero: true },
-        }}
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear' }}
       >
         <LinearGradient
           id="aqua_lightaqua_gradient"
@@ -85,10 +97,8 @@ export default [
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
-        scales={{
-          x: { type: 'time' },
-          y: { type: 'linear', includeZero: true },
-        }}
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear' }}
       >
         <YAxis label="Price ($)" numTicks={4} />
         <LinearGradient
@@ -110,10 +120,8 @@ export default [
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
-        scales={{
-          x: { type: 'time' },
-          y: { type: 'linear', includeZero: true },
-        }}
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear' }}
       >
         <YAxis label="Price ($)" numTicks={4} orientation="left" />
         <LinearGradient
@@ -135,10 +143,8 @@ export default [
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
-        scales={{
-          x: { type: 'time' },
-          y: { type: 'linear', includeZero: true },
-        }}
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear' }}
       >
         <YAxis label="Price ($)" numTicks={4} />
         <LineSeries
@@ -161,10 +167,8 @@ export default [
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
-        scales={{
-          x: { type: 'band' },
-          y: { type: 'linear', includeZero: true },
-        }}
+        xScale={{ type: 'band' }}
+        yScale={{ type: 'linear' }}
       >
         <LinearGradient
           id="aqua_lightaqua_gradient"
@@ -185,10 +189,8 @@ export default [
     example: () => (
       <ResponsiveXYChart
         ariaLabel="Required label"
-        scales={{
-          x: { type: 'time' },
-          y: { type: 'linear' },
-        }}
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear', includeZero: false }}
       >
         <YAxis label="$$$" numTicks={4} />
         <LinearGradient
@@ -211,18 +213,39 @@ export default [
       <ResponsiveXYChart
         theme={{}}
         ariaLabel="Required label"
-        scales={{
-          x: { type: 'time' },
-          y: { type: 'linear', includeZero: true },
-        }}
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear' }}
       >
         <YAxis label="Price ($)" numTicks={4} />
         <VerticalBarSeries
-          data={data}
+          data={data.filter((d, i) => i % 2 === 0)}
           label="Apple Stock"
+          fill="#484848"
+        />
+        <VerticalBarSeries
+          data={data.filter((d, i) => i % 2 !== 0 && i !== 5)}
+          label="Apple Stock ii"
           fill="#767676"
         />
         <XAxis label="Time" numTicks={5} />
+      </ResponsiveXYChart>
+    ),
+  },
+  {
+    description: 'vertical stack',
+    example: () => (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        xScale={{ type: 'band', paddingInner: 0.05 }}
+        yScale={{ type: 'linear' }}
+      >
+        <YAxis label="Price ($)" numTicks={4} />
+        <VerticalBarSeries
+          data={stackedData}
+          label="Apple Stock"
+          stack={stackKeys}
+        />
+        <XAxis label="Time" numTicks={5} tickFormat={dateFormatter} />
       </ResponsiveXYChart>
     ),
   },

--- a/packages/demo/examples/xy-chart/utils.js
+++ b/packages/demo/examples/xy-chart/utils.js
@@ -1,0 +1,11 @@
+export function numTicksForHeight(height) {
+  if (height <= 300) return 3;
+  if (height <= 600) return 5;
+  return 10;
+}
+
+export function numTicksForWidth(width) {
+  if (width <= 300) return 2;
+  if (width <= 400) return 5;
+  return 10;
+}

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
     "@data-ui/data-table": "^0.0.12",
+    "@data-ui/xy-chart": "^0.0.1",
     "@kadira/storybook": "^2.35.3",
     "@vx/mock-data": "0.0.95",
     "aphrodite": "^1.2.0",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -39,5 +39,8 @@
     "react": "~15.4.2",
     "react-dom": "~15.4.2"
   },
-  "private": true
+  "private": true,
+  "dependencies": {
+    "d3-time-format": "^2.0.5"
+  }
 }

--- a/packages/xy-chart/.babelrc
+++ b/packages/xy-chart/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": ["airbnb"],
+  "plugins": [],
+  "env": {
+    "development": {
+      "plugins": []
+    }
+  }
+}

--- a/packages/xy-chart/.babelrc
+++ b/packages/xy-chart/.babelrc
@@ -1,9 +1,3 @@
 {
-  "presets": ["airbnb"],
-  "plugins": [],
-  "env": {
-    "development": {
-      "plugins": []
-    }
-  }
+  "presets": ["airbnb"]
 }

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -2,10 +2,48 @@
 
 A package of charts with standard x- and y- axes.
 
-@TODO: more docs
+## Components
+### Charts
+`<XYChart />`
+
+### Axes
+`<XAxis />`
+`<YAxis />`
+
+### Series
+`<VerticalBarSeries />`
+`<LineSeries />`
+`<IntervalSeries />`
+
+### Other
+A subset of [vx](https://github.com/hshoff/vx/blob/master/) gradients and patterns are exported in `@data-ui/xy-chart` to customize the style of series. These components create `<def>` elements in the chart SVG with `id`s that you can reference in another component.
+
+[`<PatternLines />`](https://github.com/hshoff/vx/blob/master/packages/vx-pattern/src/patterns/Lines.js)
+[`<LinearGradient />`](https://github.com/hshoff/vx/blob/master/packages/vx-pattern/src/patterns/Lines.js)
+
+
+#### Example usage
+
+```js
+import { XYPlot, VerticalBarSeries, LinearGradient } from '@data-ui/xy-chart';
+
+/// ...
+  <XYChart>
+    <LinearGradient
+      id="my_gradient"
+      from={startColor}
+      to={endColor}
+    />
+    <VerticalBarSeries
+      data={data}
+      fill="url('#my_gradient')"
+    />
+  </XYChart>
+```
+
 
 ## Development
 ```
 npm install
-npm run prod
+npm run dev # or 'prod'
 ```

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -1,0 +1,11 @@
+# @data-ui/xy-chart
+
+A package of charts with standard x- and y- axes.
+
+@TODO: more docs
+
+## Development
+```
+npm install
+npm run prod
+```

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -26,6 +26,7 @@
     "@vx/gradient": "0.0.112",
     "@vx/grid": "0.0.114",
     "@vx/group": "0.0.114",
+    "@vx/pattern": "0.0.112",
     "@vx/responsive": "0.0.114",
     "@vx/scale": "0.0.114",
     "@vx/shape": "0.0.114",

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack -p --env build",
     "dev": "webpack --progress --colors --watch --env dev",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 0"
   },
   "repository": "https://github.com/williaster/data-ui",
   "keywords": [

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -23,12 +23,12 @@
     "@vx/axis": "0.0.114",
     "@vx/curve": "0.0.112",
     "@vx/glyph": "0.0.114",
+    "@vx/gradient": "0.0.112",
     "@vx/grid": "0.0.114",
     "@vx/group": "0.0.114",
     "@vx/responsive": "0.0.114",
     "@vx/scale": "0.0.114",
     "@vx/shape": "0.0.114",
-    "airbnb-prop-types": "^2.5.4",
     "d3-array": "^1.2.0",
     "prop-types": "^15.5.10"
   },

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "xy-chart",
+  "version": "0.0.1",
+  "description": "A package of charts with standard x- and y- axes.",
+  "main": "index.js",
+  "scripts": {
+    "build": "webpack -p --env build",
+    "dev": "webpack --progress --colors --watch --env dev",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "https://github.com/williaster/data-ui",
+  "keywords": [
+    "d3",
+    "react",
+    "vx",
+    "chart",
+    "visualization",
+    "plot"
+  ],
+  "author": "Chris Williams <chris.williams@airbnb.com>",
+  "license": "MIT",
+  "dependencies": {
+    "@vx/axis": "0.0.114",
+    "@vx/curve": "0.0.112",
+    "@vx/glyph": "0.0.114",
+    "@vx/grid": "0.0.114",
+    "@vx/group": "0.0.114",
+    "@vx/responsive": "0.0.114",
+    "@vx/scale": "0.0.114",
+    "@vx/shape": "0.0.114",
+    "airbnb-prop-types": "^2.5.4",
+    "d3-array": "^1.2.0",
+    "prop-types": "^15.5.10"
+  },
+  "devDependencies": {
+    "babel-core": "^6.24.1",
+    "babel-loader": "^6.4.1",
+    "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-preset-airbnb": "^2.2.3",
+    "react": "~15.4.2",
+    "react-dom": "~15.4.2",
+    "webpack": "^2.4.1"
+  },
+  "peerDependencies": {
+    "react": "~15.4.2",
+    "react-dom": "~15.4.2"
+  }
+}

--- a/packages/xy-chart/src/axis/XAxis.jsx
+++ b/packages/xy-chart/src/axis/XAxis.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { AxisBottom, AxisTop } from '@vx/axis';
+import { xAxis as defaultAxisStyles, xTick as defaultTickStyles } from '../theme';
+
+const propTypes = {
+  axisPadding: PropTypes.number,
+  orientation: PropTypes.oneOf(['bottom', 'top']),
+  hideZero: PropTypes.bool,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  numTicks: PropTypes.number,
+  axisStyles: PropTypes.shape({
+    stroke: PropTypes.string,
+    strokeWidth: PropTypes.number,
+    label: PropTypes.shape({
+      bottom: PropTypes.object,
+      top: PropTypes.object,
+    }),
+  }),
+  tickStyles: PropTypes.shape({
+    stroke: PropTypes.string,
+    tickLength: PropTypes.number,
+    label: PropTypes.shape({
+      bottom: PropTypes.object,
+      top: PropTypes.object,
+    }),
+  }),
+  tickLabelComponent: PropTypes.element,
+  tickFormat: PropTypes.func,
+  tickValues: PropTypes.arrayOf(PropTypes.string),
+
+  // probably injected by parent
+  innerHeight: PropTypes.number.isRequired,
+  scale: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  axisPadding: null,
+  axisStyles: defaultAxisStyles,
+  hideZero: false,
+  label: null,
+  numTicks: null,
+  orientation: 'bottom',
+  tickFormat: null,
+  tickLabelComponent: null,
+  tickStyles: defaultTickStyles,
+  tickValues: null,
+};
+
+export default function XAxis({
+  axisPadding,
+  axisStyles,
+  innerHeight,
+  hideZero,
+  label,
+  numTicks,
+  orientation,
+  scale,
+  tickFormat,
+  tickLabelComponent,
+  tickStyles,
+  tickValues,
+}) {
+  const Axis = orientation === 'bottom' ? AxisBottom : AxisTop;
+  return (
+    <Axis
+      top={orientation === 'bottom' ? innerHeight : 0}
+      left={0}
+      axisPadding={axisPadding}
+      hideTicks={numTicks === 0}
+      hideZero={hideZero}
+      label={typeof label === 'string' ?
+        <text {...(axisStyles.label || {})[orientation]}>
+          {label}
+        </text>
+        : label
+      }
+      numTicks={typeof numTicks === 'number' ? numTicks : tickValues && tickValues.length}
+      scale={scale}
+      stroke={axisStyles.stroke}
+      strokeWidth={axisStyles.strokeWidth}
+      tickFormat={tickFormat}
+      tickLength={tickStyles.tickLength}
+      tickStroke={tickStyles.stroke}
+      tickLabelComponent={tickLabelComponent || <text {...(tickStyles.label || {})[orientation]} />}
+    />
+  );
+}
+
+XAxis.propTypes = propTypes;
+XAxis.defaultProps = defaultProps;
+XAxis.displayName = 'XAxis';

--- a/packages/xy-chart/src/axis/XAxis.jsx
+++ b/packages/xy-chart/src/axis/XAxis.jsx
@@ -1,34 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { AxisBottom, AxisTop } from '@vx/axis';
+
+import { axisStylesShape, tickStylesShape } from '../utils/propShapes';
 import { xAxis as defaultAxisStyles, xTick as defaultTickStyles } from '../theme';
 
 const propTypes = {
-  axisPadding: PropTypes.number,
-  orientation: PropTypes.oneOf(['bottom', 'top']),
+  axisStyles: axisStylesShape,
   hideZero: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   numTicks: PropTypes.number,
-  axisStyles: PropTypes.shape({
-    stroke: PropTypes.string,
-    strokeWidth: PropTypes.number,
-    label: PropTypes.shape({
-      bottom: PropTypes.object,
-      top: PropTypes.object,
-    }),
-  }),
-  tickStyles: PropTypes.shape({
-    stroke: PropTypes.string,
-    tickLength: PropTypes.number,
-    label: PropTypes.shape({
-      bottom: PropTypes.object,
-      top: PropTypes.object,
-    }),
-  }),
+  orientation: PropTypes.oneOf(['bottom', 'top']),
+  rangePadding: PropTypes.number,
+  tickStyles: tickStylesShape,
   tickLabelComponent: PropTypes.element,
   tickFormat: PropTypes.func,
-  tickValues: PropTypes.arrayOf(PropTypes.string),
 
   // probably injected by parent
   innerHeight: PropTypes.number.isRequired,
@@ -36,38 +22,36 @@ const propTypes = {
 };
 
 const defaultProps = {
-  axisPadding: null,
   axisStyles: defaultAxisStyles,
   hideZero: false,
   label: null,
   numTicks: null,
   orientation: 'bottom',
+  rangePadding: null,
   tickFormat: null,
   tickLabelComponent: null,
   tickStyles: defaultTickStyles,
-  tickValues: null,
 };
 
 export default function XAxis({
-  axisPadding,
   axisStyles,
   innerHeight,
   hideZero,
   label,
   numTicks,
   orientation,
+  rangePadding,
   scale,
   tickFormat,
   tickLabelComponent,
   tickStyles,
-  tickValues,
 }) {
   const Axis = orientation === 'bottom' ? AxisBottom : AxisTop;
   return (
     <Axis
       top={orientation === 'bottom' ? innerHeight : 0}
       left={0}
-      axisPadding={axisPadding}
+      rangePadding={rangePadding}
       hideTicks={numTicks === 0}
       hideZero={hideZero}
       label={typeof label === 'string' ?
@@ -76,7 +60,7 @@ export default function XAxis({
         </text>
         : label
       }
-      numTicks={typeof numTicks === 'number' ? numTicks : tickValues && tickValues.length}
+      numTicks={numTicks}
       scale={scale}
       stroke={axisStyles.stroke}
       strokeWidth={axisStyles.strokeWidth}

--- a/packages/xy-chart/src/axis/XAxis.jsx
+++ b/packages/xy-chart/src/axis/XAxis.jsx
@@ -22,7 +22,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  axisStyles: defaultAxisStyles,
+  axisStyles: {},
   hideZero: false,
   label: null,
   numTicks: null,
@@ -30,7 +30,7 @@ const defaultProps = {
   rangePadding: null,
   tickFormat: null,
   tickLabelComponent: null,
-  tickStyles: defaultTickStyles,
+  tickStyles: {},
 };
 
 export default function XAxis({
@@ -54,7 +54,7 @@ export default function XAxis({
       rangePadding={rangePadding}
       hideTicks={numTicks === 0}
       hideZero={hideZero}
-      label={typeof label === 'string' ?
+      label={typeof label === 'string' && axisStyles.label ?
         <text {...(axisStyles.label || {})[orientation]}>
           {label}
         </text>
@@ -67,7 +67,9 @@ export default function XAxis({
       tickFormat={tickFormat}
       tickLength={tickStyles.tickLength}
       tickStroke={tickStyles.stroke}
-      tickLabelComponent={tickLabelComponent || <text {...(tickStyles.label || {})[orientation]} />}
+      tickLabelComponent={tickLabelComponent || (tickStyles.label &&
+        <text {...(tickStyles.label || {})[orientation]} />
+      )}
     />
   );
 }

--- a/packages/xy-chart/src/axis/XAxis.jsx
+++ b/packages/xy-chart/src/axis/XAxis.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { AxisBottom, AxisTop } from '@vx/axis';
 
 import { axisStylesShape, tickStylesShape } from '../utils/propShapes';
-import { xAxis as defaultAxisStyles, xTick as defaultTickStyles } from '../theme';
 
 const propTypes = {
   axisStyles: axisStylesShape,

--- a/packages/xy-chart/src/axis/YAxis.jsx
+++ b/packages/xy-chart/src/axis/YAxis.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { AxisLeft, AxisRight } from '@vx/axis';
+
+import { yAxis as defaultAxisStyles, yTick as defaultTickStyles } from '../theme';
+
+const propTypes = {
+  axisPadding: PropTypes.number,
+  orientation: PropTypes.oneOf(['left', 'right']),
+  hideZero: PropTypes.bool,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  labelOffset: PropTypes.number,
+  numTicks: PropTypes.number,
+  axisStyles: PropTypes.shape({
+    stroke: PropTypes.string,
+    strokeWidth: PropTypes.number,
+    label: PropTypes.shape({
+      bottom: PropTypes.object,
+      top: PropTypes.object,
+    }),
+  }),
+  tickStyles: PropTypes.shape({
+    stroke: PropTypes.string,
+    tickLength: PropTypes.number,
+    label: PropTypes.shape({
+      bottom: PropTypes.object,
+      top: PropTypes.object,
+    }),
+  }),
+  tickLabelComponent: PropTypes.element,
+  tickFormat: PropTypes.func,
+  tickValues: PropTypes.arrayOf(PropTypes.string),
+
+  // probably injected by parent
+  innerWidth: PropTypes.number.isRequired,
+  scale: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  axisPadding: null,
+  axisStyles: defaultAxisStyles,
+  hideZero: false,
+  label: null,
+  labelOffset: 0,
+  numTicks: null,
+  orientation: 'right',
+  tickFormat: null,
+  tickLabelComponent: null,
+  tickStyles: defaultTickStyles,
+  tickValues: null,
+};
+
+export default function YAxis({
+  axisPadding,
+  axisStyles,
+  hideZero,
+  innerWidth,
+  label,
+  labelOffset,
+  numTicks,
+  orientation,
+  scale,
+  tickFormat,
+  tickLabelComponent,
+  tickStyles,
+  tickValues,
+}) {
+  const Axis = orientation === 'left' ? AxisLeft : AxisRight;
+  return (
+    <Axis
+      top={0}
+      left={orientation === 'right' ? innerWidth : 0}
+      axisPadding={axisPadding}
+      hideTicks={numTicks === 0}
+      hideZero={hideZero}
+      label={typeof label === 'string' ?
+        <text {...(axisStyles.label || {})[orientation]}>
+          {label}
+        </text>
+        : label
+      }
+      labelOffset={labelOffset}
+      numTicks={typeof numTicks === 'number' ? numTicks : tickValues && tickValues.length}
+      scale={scale}
+      stroke={axisStyles.stroke}
+      strokeWidth={axisStyles.strokeWidth}
+      tickFormat={tickFormat}
+      tickLength={tickStyles.tickLength}
+      tickStroke={tickStyles.stroke}
+      tickLabelComponent={tickLabelComponent || <text {...(tickStyles.label || {})[orientation]} />}
+    />
+  );
+}
+
+YAxis.propTypes = propTypes;
+YAxis.defaultProps = defaultProps;
+YAxis.displayName = 'YAxis';

--- a/packages/xy-chart/src/axis/YAxis.jsx
+++ b/packages/xy-chart/src/axis/YAxis.jsx
@@ -2,34 +2,20 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { AxisLeft, AxisRight } from '@vx/axis';
 
+import { axisStylesShape, tickStylesShape } from '../utils/propShapes';
 import { yAxis as defaultAxisStyles, yTick as defaultTickStyles } from '../theme';
 
 const propTypes = {
-  axisPadding: PropTypes.number,
-  orientation: PropTypes.oneOf(['left', 'right']),
+  axisStyles: axisStylesShape,
   hideZero: PropTypes.bool,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   labelOffset: PropTypes.number,
   numTicks: PropTypes.number,
-  axisStyles: PropTypes.shape({
-    stroke: PropTypes.string,
-    strokeWidth: PropTypes.number,
-    label: PropTypes.shape({
-      bottom: PropTypes.object,
-      top: PropTypes.object,
-    }),
-  }),
-  tickStyles: PropTypes.shape({
-    stroke: PropTypes.string,
-    tickLength: PropTypes.number,
-    label: PropTypes.shape({
-      bottom: PropTypes.object,
-      top: PropTypes.object,
-    }),
-  }),
+  orientation: PropTypes.oneOf(['left', 'right']),
+  rangePadding: PropTypes.number,
+  tickStyles: tickStylesShape,
   tickLabelComponent: PropTypes.element,
   tickFormat: PropTypes.func,
-  tickValues: PropTypes.arrayOf(PropTypes.string),
 
   // probably injected by parent
   innerWidth: PropTypes.number.isRequired,
@@ -37,21 +23,19 @@ const propTypes = {
 };
 
 const defaultProps = {
-  axisPadding: null,
   axisStyles: defaultAxisStyles,
   hideZero: false,
   label: null,
   labelOffset: 0,
   numTicks: null,
   orientation: 'right',
+  rangePadding: null,
   tickFormat: null,
   tickLabelComponent: null,
   tickStyles: defaultTickStyles,
-  tickValues: null,
 };
 
 export default function YAxis({
-  axisPadding,
   axisStyles,
   hideZero,
   innerWidth,
@@ -59,18 +43,18 @@ export default function YAxis({
   labelOffset,
   numTicks,
   orientation,
+  rangePadding,
   scale,
   tickFormat,
   tickLabelComponent,
   tickStyles,
-  tickValues,
 }) {
   const Axis = orientation === 'left' ? AxisLeft : AxisRight;
   return (
     <Axis
       top={0}
       left={orientation === 'right' ? innerWidth : 0}
-      axisPadding={axisPadding}
+      rangePadding={rangePadding}
       hideTicks={numTicks === 0}
       hideZero={hideZero}
       label={typeof label === 'string' ?
@@ -80,7 +64,7 @@ export default function YAxis({
         : label
       }
       labelOffset={labelOffset}
-      numTicks={typeof numTicks === 'number' ? numTicks : tickValues && tickValues.length}
+      numTicks={numTicks}
       scale={scale}
       stroke={axisStyles.stroke}
       strokeWidth={axisStyles.strokeWidth}

--- a/packages/xy-chart/src/axis/YAxis.jsx
+++ b/packages/xy-chart/src/axis/YAxis.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { AxisLeft, AxisRight } from '@vx/axis';
 
 import { axisStylesShape, tickStylesShape } from '../utils/propShapes';
-import { yAxis as defaultAxisStyles, yTick as defaultTickStyles } from '../theme';
 
 const propTypes = {
   axisStyles: axisStylesShape,
@@ -23,7 +22,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  axisStyles: defaultAxisStyles,
+  axisStyles: {},
   hideZero: false,
   label: null,
   labelOffset: 0,
@@ -31,8 +30,8 @@ const defaultProps = {
   orientation: 'right',
   rangePadding: null,
   tickFormat: null,
-  tickLabelComponent: null,
-  tickStyles: defaultTickStyles,
+  tickLabelComponent: undefined,
+  tickStyles: {},
 };
 
 export default function YAxis({
@@ -57,7 +56,7 @@ export default function YAxis({
       rangePadding={rangePadding}
       hideTicks={numTicks === 0}
       hideZero={hideZero}
-      label={typeof label === 'string' ?
+      label={typeof label === 'string' && axisStyles.label ?
         <text {...(axisStyles.label || {})[orientation]}>
           {label}
         </text>
@@ -71,7 +70,9 @@ export default function YAxis({
       tickFormat={tickFormat}
       tickLength={tickStyles.tickLength}
       tickStroke={tickStyles.stroke}
-      tickLabelComponent={tickLabelComponent || <text {...(tickStyles.label || {})[orientation]} />}
+      tickLabelComponent={tickLabelComponent || (tickStyles.label &&
+        <text {...(tickStyles.label || {})[orientation]} />
+      )}
     />
   );
 }

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -7,8 +7,7 @@ import { Group } from '@vx/group';
 import { scaleLinear, scaleTime, scaleBand } from '@vx/scale';
 
 import { componentName, getChildWithName, nonBandBarWidth, isBarSeries } from '../utils/chartUtils';
-import { grid as defaultGridStyles } from '../theme';
-import { scaleShape, gridStylesShape } from '../utils/propShapes';
+import { scaleShape, themeShape } from '../utils/propShapes';
 
 const propTypes = {
   ariaLabel: PropTypes.string.isRequired,
@@ -25,7 +24,7 @@ const propTypes = {
     x: scaleShape.isRequired,
     y: scaleShape.isRequired,
   }).isRequired, // key matches data attribute
-  gridStyles: gridStylesShape,
+  theme: themeShape,
 };
 
 const defaultProps = {
@@ -36,7 +35,7 @@ const defaultProps = {
     bottom: 64,
     left: 64,
   },
-  gridStyles: defaultGridStyles,
+  theme: {},
 };
 
 const scaleTypeToScale = {
@@ -120,7 +119,7 @@ class XYChart extends React.PureComponent {
     const {
       ariaLabel,
       children,
-      gridStyles,
+      theme,
       height,
       width,
     } = this.props;
@@ -143,8 +142,8 @@ class XYChart extends React.PureComponent {
               yScale={yScale}
               width={innerWidth}
               height={innerHeight}
-              stroke={gridStyles.stroke}
-              strokeWidth={gridStyles.strokeWidth}
+              stroke={theme.gridStyles && theme.gridStyles.stroke}
+              strokeWidth={theme.gridStyles && theme.gridStyles.strokeWidth}
               numTicksRows={numTicks.y}
               numTicksColumns={numTicks.x}
             />}
@@ -155,6 +154,7 @@ class XYChart extends React.PureComponent {
               return React.cloneElement(Child, { xScale, yScale, barWidth });
             }
             if (name.match(/Axis$/)) {
+              const styleKey = name[0].toLowerCase();
               return React.cloneElement(Child, {
                 innerHeight,
                 innerWidth,
@@ -162,6 +162,8 @@ class XYChart extends React.PureComponent {
                 numTicks: name === 'XAxis' ? numTicks.x : numTicks.y,
                 scale: name === 'XAxis' ? xScale : yScale,
                 rangePadding: name === 'XAxis' ? xOffset : null,
+                axisStyles: { ...theme[`${styleKey}AxisStyles`], ...Child.props.axisStyles },
+                tickStyles: { ...theme[`${styleKey}TickStyles`], ...Child.props.tickStyles },
               });
             }
             return Child;

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { componentWithName } from 'airbnb-prop-types';
+
+import { extent } from 'd3-array';
+import { Grid } from '@vx/grid';
+import { Group } from '@vx/group';
+import { scaleLinear, scaleTime, scaleOrdinal } from '@vx/scale';
+
+import { componentName, getChildWithName } from '../utils/chartUtils';
+import { grid as defaultGridStyles } from '../theme';
+import { scaleShape } from '../utils/propShapes';
+
+const propTypes = {
+  ariaLabel: PropTypes.string.isRequired,
+  children: componentWithName(/(Series|Axis)$/),
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  margin: PropTypes.shape({
+    top: PropTypes.number,
+    right: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+  }),
+  scales: PropTypes.shape({
+    x: scaleShape.isRequired,
+    y: scaleShape.isRequired,
+  }).isRequired, // key matches data attribute
+  gridStyles: PropTypes.shape({
+    stroke: PropTypes.string,
+    strokeWidth: PropTypes.number,
+  }),
+};
+
+const defaultProps = {
+  children: null,
+  margin: {
+    top: 64,
+    right: 64,
+    bottom: 64,
+    left: 64,
+  },
+  gridStyles: defaultGridStyles,
+};
+
+const scaleTypeToScale = {
+  time: scaleTime,
+  linear: scaleLinear,
+  ordinal: scaleOrdinal,
+};
+
+class XYChart extends React.Component {
+
+  // @todo: refactor this, if axis is categorical can rely on range bands
+  getBarWidth({ innerWidth }) {
+    let barWidth = Infinity;
+    React.Children.forEach(this.props.children, (Child) => {
+      if (componentName(Child).match(/Bar/g)) {
+        const data = Child.props.data;
+        barWidth = Math.min(barWidth, (innerWidth / data.length) - 6);
+      }
+    });
+    return Math.max(0, barWidth === Infinity ? 0 : barWidth);
+  }
+
+  getDimmensions() {
+    const { margin, width, height } = this.props;
+    const completeMargin = { ...defaultProps.margin, ...margin };
+    return {
+      margin: completeMargin,
+      innerHeight: height - completeMargin.top - completeMargin.bottom,
+      innerWidth: width - completeMargin.left - completeMargin.right,
+    };
+  }
+
+  getNumTicks() {
+    const xAxis = getChildWithName('XAxis', this.props.children);
+    const yAxis = getChildWithName('YAxis', this.props.children);
+    return {
+      x: (xAxis && xAxis.props.numTicks) || 0,
+      y: (yAxis && yAxis.props.numTicks) || 0,
+    };
+  }
+
+  getScales() {
+    const { scales: scaleProp } = this.props;
+    const { innerWidth, innerHeight } = this.getDimmensions();
+    const allData = this.collectDataFromChildSeries();
+    const barWidth = this.getBarWidth({ innerWidth });
+
+    const scales = {};
+    Object.entries(scaleProp).forEach(([key, { accessor, type, includeZero, ...rest }]) => {
+      const [min, max] = extent(allData, d => (accessor ? accessor(d) : d[key]));
+
+      let range;
+      if (key === 'x') range = [0 + (barWidth / 2), innerWidth - (barWidth / 2)];
+      if (key === 'y') range = [innerHeight, 0];
+
+      scales[key] = scaleTypeToScale[type]({
+        domain: [
+          type === 'linear' && includeZero ? Math.min(0, min) : min,
+          type === 'linear' && includeZero ? Math.max(0, max) : max,
+        ],
+        range,
+        ...rest,
+      });
+
+      scales[key].accessor = accessor;
+    });
+
+    return scales;
+  }
+
+  collectDataFromChildSeries() {
+    const { children } = this.props;
+    let data = [];
+    React.Children.forEach(children, (child) => {
+      if (child.props && child.props.data) {
+        data = data.concat(child.props.data);
+      }
+    });
+    return data;
+  }
+
+  render() {
+    const {
+      ariaLabel,
+      children,
+      gridStyles,
+      height,
+      width,
+    } = this.props;
+
+    const { margin, innerWidth, innerHeight } = this.getDimmensions();
+    const scales = this.getScales();
+    const numTicks = this.getNumTicks();
+    const barWidth = this.getBarWidth({ innerWidth });
+    return (
+      <svg
+        aria-label={ariaLabel}
+        role="img"
+        width={width}
+        height={height}
+      >
+        <Group left={margin.left} top={margin.top}>
+          {(numTicks.x || numTicks.y) &&
+            <Grid
+              xScale={scales.x}
+              yScale={scales.y}
+              width={innerWidth}
+              height={innerHeight}
+              stroke={gridStyles.stroke}
+              strokeWidth={gridStyles.strokeWidth}
+              numTicksRows={numTicks.y}
+              numTicksColumns={numTicks.x}
+            />}
+          {React.Children.map(children, (child) => {
+            const name = componentName(child);
+            if (name.match(/Series$/)) {
+              return React.cloneElement(child, {
+                scales,
+                barWidth: name.match(/Bar/g) && barWidth,
+              });
+            }
+            if (name.match(/Axis$/)) {
+              return React.cloneElement(child, {
+                innerHeight,
+                innerWidth,
+                labelOffset: name === 'YAxis' ? 0.6 * margin.right : 0,
+                numTicks: name === 'XAxis' ? numTicks.x : numTicks.y,
+                scale: name === 'XAxis' ? scales.x : scales.y,
+              });
+            }
+            return child;
+          })}
+        </Group>
+      </svg>
+    );
+  }
+}
+
+XYChart.propTypes = propTypes;
+XYChart.defaultProps = defaultProps;
+
+export default XYChart;

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -1,5 +1,6 @@
 export { default as LineSeries } from './series/LineSeries';
 export { default as StackedBarSeries } from './series/StackedBarSeries';
+export { default as IntervalSeries } from './series/IntervalSeries';
 export { default as VerticalBarSeries } from './series/VerticalBarSeries';
 
 export { default as XAxis } from './axis/XAxis';
@@ -7,6 +8,7 @@ export { default as YAxis } from './axis/YAxis';
 export { default as XYChart } from './chart/XYChart';
 
 export { LinearGradient } from '@vx/gradient';
+export { PatternLines } from '@vx/pattern';
 export { withScreenSize } from '@vx/responsive';
 
 export { default as theme } from './theme';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -1,11 +1,12 @@
-export { default as LineSeries } from './series/LineSeries';
-export { default as StackedBarSeries } from './series/StackedBarSeries';
-export { default as IntervalSeries } from './series/IntervalSeries';
-export { default as VerticalBarSeries } from './series/VerticalBarSeries';
-
 export { default as XAxis } from './axis/XAxis';
 export { default as YAxis } from './axis/YAxis';
 export { default as XYChart } from './chart/XYChart';
+
+export { default as BarSeries } from './series/BarSeries';
+export { default as GroupedBarSeries } from './series/GroupedBarSeries';
+export { default as IntervalSeries } from './series/IntervalSeries';
+export { default as LineSeries } from './series/LineSeries';
+export { default as StackedBarSeries } from './series/StackedBarSeries';
 
 export { LinearGradient } from '@vx/gradient';
 export { PatternLines } from '@vx/pattern';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -3,5 +3,6 @@ export { default as LineSeries } from './series/LineSeries';
 export { default as XAxis } from './axis/XAxis';
 export { default as YAxis } from './axis/YAxis';
 export { default as XYChart } from './chart/XYChart';
+export { default as theme } from './theme';
 export { LinearGradient } from '@vx/gradient';
 export { withScreenSize } from '@vx/responsive';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -1,0 +1,7 @@
+export { default as VerticalBarSeries } from './series/VerticalBarSeries';
+export { default as LineSeries } from './series/LineSeries';
+// export { default as PointSeries } from './series/PointSeries';
+export { default as XAxis } from './axis/XAxis';
+export { default as YAxis } from './axis/YAxis';
+export { default as XYChart } from './chart/XYChart';
+export { withScreenSize } from '@vx/responsive';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -6,6 +6,7 @@ export { default as BarSeries } from './series/BarSeries';
 export { default as GroupedBarSeries } from './series/GroupedBarSeries';
 export { default as IntervalSeries } from './series/IntervalSeries';
 export { default as LineSeries } from './series/LineSeries';
+export { default as PointSeries } from './series/PointSeries';
 export { default as StackedBarSeries } from './series/StackedBarSeries';
 
 export { LinearGradient } from '@vx/gradient';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -1,7 +1,7 @@
 export { default as VerticalBarSeries } from './series/VerticalBarSeries';
 export { default as LineSeries } from './series/LineSeries';
-// export { default as PointSeries } from './series/PointSeries';
 export { default as XAxis } from './axis/XAxis';
 export { default as YAxis } from './axis/YAxis';
 export { default as XYChart } from './chart/XYChart';
+export { LinearGradient } from '@vx/gradient';
 export { withScreenSize } from '@vx/responsive';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -1,8 +1,12 @@
-export { default as VerticalBarSeries } from './series/VerticalBarSeries';
 export { default as LineSeries } from './series/LineSeries';
+export { default as StackedBarSeries } from './series/StackedBarSeries';
+export { default as VerticalBarSeries } from './series/VerticalBarSeries';
+
 export { default as XAxis } from './axis/XAxis';
 export { default as YAxis } from './axis/YAxis';
 export { default as XYChart } from './chart/XYChart';
-export { default as theme } from './theme';
+
 export { LinearGradient } from '@vx/gradient';
 export { withScreenSize } from '@vx/responsive';
+
+export { default as theme } from './theme';

--- a/packages/xy-chart/src/series/BarSeries.jsx
+++ b/packages/xy-chart/src/series/BarSeries.jsx
@@ -1,23 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Group } from '@vx/group';
-import { Bar, BarStack, BarGroup } from '@vx/shape';
+import { Bar } from '@vx/shape';
 
 import { barSeriesDataShape } from '../utils/propShapes';
-import { callOrValue, scaleTypeToScale } from '../utils/chartUtils';
+import { callOrValue } from '../utils/chartUtils';
 import { colors } from '../theme';
 
 const propTypes = {
   data: barSeriesDataShape.isRequired,
   label: PropTypes.string.isRequired,
-
-  // for groups
-  group: PropTypes.arrayOf(PropTypes.string),
-  groupFills: PropTypes.arrayOf(PropTypes.string),
-
-  // for stacks
-  stack: PropTypes.arrayOf(PropTypes.string),
-  stackFills: PropTypes.arrayOf(PropTypes.string),
 
   // overridden by data props
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -45,16 +37,10 @@ const defaultProps = {
 const x = d => d.x;
 const y = d => d.y;
 
-// every x value has group.length bars
-
-export default function VerticalBarSeries({
+export default function BarSeries({
   barWidth,
   data,
   fill,
-  stack,
-  stackFills,
-  group,
-  groupFills,
   stroke,
   strokeWidth,
   label,
@@ -63,44 +49,6 @@ export default function VerticalBarSeries({
 }) {
   const maxHeight = (yScale.range() || [0])[0];
   const offset = xScale.offset || 0;
-  if (stack) {
-    const zScale = scaleTypeToScale.ordinal({ range: stackFills, domain: stack });
-    return (
-      <BarStack
-        data={data}
-        keys={stack}
-        height={maxHeight}
-        x={x}
-        xScale={xScale}
-        yScale={yScale}
-        zScale={zScale}
-        stroke={stroke}
-        strokeWidth={strokeWidth}
-      />
-    );
-  }
-  if (group) {
-    debugger;
-    const zScale = scaleTypeToScale.ordinal({ range: groupFills, domain: group });
-    const x1Scale = scaleTypeToScale.band({
-      rangeRound: [0, xScale.bandwidth()],
-      domain: group,
-      padding: 0.1,
-    });
-    return (
-      <BarGroup
-        data={data}
-        keys={group}
-        height={maxHeight}
-        x0={x}
-        x0Scale={xScale}
-        x1Scale={x1Scale}
-        yScale={yScale}
-        zScale={zScale}
-        rx={2}
-      />
-    );
-  }
   return (
     <Group key={label}>
       {data.map((d, i) => {
@@ -122,6 +70,6 @@ export default function VerticalBarSeries({
   );
 }
 
-VerticalBarSeries.propTypes = propTypes;
-VerticalBarSeries.defaultProps = defaultProps;
-VerticalBarSeries.displayName = 'VerticalBarSeries';
+BarSeries.propTypes = propTypes;
+BarSeries.defaultProps = defaultProps;
+BarSeries.displayName = 'BarSeries';

--- a/packages/xy-chart/src/series/GroupedBarSeries.jsx
+++ b/packages/xy-chart/src/series/GroupedBarSeries.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { BarGroup } from '@vx/shape';
+
+import { barSeriesDataShape } from '../utils/propShapes';
+import { scaleTypeToScale } from '../utils/chartUtils';
+import { colors } from '../theme';
+
+const propTypes = {
+  data: barSeriesDataShape.isRequired,
+  groupKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+  groupFills: PropTypes.arrayOf(PropTypes.string),
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  groupPadding: PropTypes.number, // see https://github.com/d3/d3-scale#band-scales
+
+  // these will likely be injected by the parent xychart
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  stack: null,
+  stackFills: colors.categories,
+  groupKeys: null,
+  groupFills: colors.categories,
+  groupPadding: 0.1,
+
+  fill: colors.default,
+  stackBy: null,
+  stroke: 'none',
+  strokeWidth: 1,
+};
+
+const x = d => d.x;
+
+export default function GroupedBarSeries({
+  data,
+  groupKeys,
+  groupFills,
+  groupPadding,
+  stroke,
+  strokeWidth,
+  xScale,
+  yScale,
+}) {
+  if (!xScale.bandwidth) { // @todo figure this out/be more graceful
+    throw new Error("'GroupedBarSeries' requires a 'band' type xScale");
+  }
+  const maxHeight = (yScale.range() || [0])[0];
+  const x1Scale = scaleTypeToScale.band({
+    rangeRound: [0, xScale.bandwidth()],
+    domain: groupKeys,
+    padding: groupPadding,
+  });
+  const zScale = scaleTypeToScale.ordinal({ range: groupFills, domain: groupKeys });
+  return (
+    <BarGroup
+      data={data}
+      keys={groupKeys}
+      height={maxHeight}
+      x0={x}
+      x0Scale={xScale}
+      x1Scale={x1Scale}
+      yScale={yScale}
+      zScale={zScale}
+      rx={2}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+    />
+  );
+}
+
+GroupedBarSeries.propTypes = propTypes;
+GroupedBarSeries.defaultProps = defaultProps;
+GroupedBarSeries.displayName = 'GroupedBarSeries';

--- a/packages/xy-chart/src/series/IntervalSeries.jsx
+++ b/packages/xy-chart/src/series/IntervalSeries.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Group } from '@vx/group';
+import { Bar } from '@vx/shape';
+
+import { intervalSeriesDataShape } from '../utils/propShapes';
+import { callOrValue } from '../utils/chartUtils';
+import { colors } from '../theme';
+
+const propTypes = {
+  data: intervalSeriesDataShape.isRequired,
+  label: PropTypes.string.isRequired,
+
+  // overridden by data props
+  fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+
+  // these will likely be injected by the parent xychart
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  fill: colors.default,
+  stroke: 'none',
+  strokeWidth: 1,
+};
+
+const x0 = d => d.x0;
+const x1 = d => d.x1;
+
+export default function IntervalSeries({
+  data,
+  fill,
+  label,
+  stroke,
+  strokeWidth,
+  xScale,
+  yScale,
+}) {
+  const barHeight = (yScale.range() || [0])[0];
+  return (
+    <Group key={label}>
+      {data.map((d, i) => {
+        const x = xScale(x0(d));
+        const barWidth = xScale(x1(d)) - x;
+        return (
+          <Bar
+            key={`interval-${label}-${x}`}
+            x={x}
+            y={0}
+            width={barWidth}
+            height={barHeight}
+            fill={d.fill || callOrValue(fill, d, i)}
+            stroke={d.stroke || callOrValue(stroke, d, i)}
+            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+          />
+        );
+      })}
+    </Group>
+  );
+}
+
+IntervalSeries.propTypes = propTypes;
+IntervalSeries.defaultProps = defaultProps;
+IntervalSeries.displayName = 'IntervalSeries';

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -5,7 +5,7 @@ import { curveCardinal, curveLinear } from '@vx/curve';
 import { GlyphDot } from '@vx/glyph';
 import { LinePath } from '@vx/shape';
 
-import { callOrValue } from '../utils/chartUtils';
+import { callOrValue, isDefined } from '../utils/chartUtils';
 import { colors } from '../theme';
 import { lineSeriesDataShape } from '../utils/propShapes';
 
@@ -59,28 +59,29 @@ export default function LineSeries({
       strokeDasharray={callOrValue(strokeDasharray)}
       curve={interpolation === 'linear' ? curveLinear : curveCardinal}
       glyph={showPoints && ((d, i) => (
-        <GlyphDot
-          key={`${label}-${i}-${x(d)}`}
-          cx={xScale(x(d))}
-          cy={yScale(y(d))}
-          r={4}
-          fill={d.stroke || callOrValue(stroke, d, i)}
-          stroke="#FFFFFF"
-          strokeWidth={1}
-        >
-          {d.label &&
-            <text
-              x={xScale(x(d))}
-              y={yScale(y(d))}
-              dx={10}
-              fill={d.stroke || callOrValue(stroke, d, i)}
-              stroke={'#fff'}
-              strokeWidth={1}
-              fontSize={12}
-            >
-              {d.label}
-            </text>}
-        </GlyphDot>
+        isDefined(y(d)) &&
+          <GlyphDot
+            key={`${label}-${i}-${x(d)}`}
+            cx={xScale(x(d))}
+            cy={yScale(y(d))}
+            r={4}
+            fill={d.stroke || callOrValue(stroke, d, i)}
+            stroke="#FFFFFF"
+            strokeWidth={1}
+          >
+            {d.label &&
+              <text
+                x={xScale(x(d))}
+                y={yScale(y(d))}
+                dx={10}
+                fill={d.stroke || callOrValue(stroke, d, i)}
+                stroke={'#fff'}
+                strokeWidth={1}
+                fontSize={12}
+              >
+                {d.label}
+              </text>}
+          </GlyphDot>
       ))}
     />
   );

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -19,10 +19,8 @@ const propTypes = {
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
 
   // these will likely be injected by the parent chart
-  scales: PropTypes.shape({
-    x: PropTypes.func.isRequired,
-    y: PropTypes.func.isRequired,
-  }).isRequired,
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -38,31 +36,31 @@ export default function LineSeries({
   interpolation,
   label,
   showPoints,
-  scales,
   stroke,
   strokeDasharray,
   strokeWidth,
+  xScale,
+  yScale,
 }) {
-  const { x, y } = scales;
-  const xAccessor = x.accessor || (d => d.x);
-  const yAccessor = y.accessor || (d => d.y);
+  const x = d => d.x;
+  const y = d => d.y;
   return (
     <LinePath
       key={label}
       data={data}
-      xScale={x}
-      yScale={y}
-      x={xAccessor}
-      y={yAccessor}
+      xScale={xScale}
+      yScale={yScale}
+      x={x}
+      y={y}
       stroke={callOrValue(stroke)}
       strokeWidth={callOrValue(strokeWidth)}
       strokeDasharray={callOrValue(strokeDasharray)}
       curve={interpolation === 'linear' ? curveLinear : curveCardinal}
       glyph={showPoints && ((d, i) => (
         <GlyphDot
-          key={`${label}-${i}-${xAccessor(d)}`}
-          cx={x(d.x)}
-          cy={y(d.y)}
+          key={`${label}-${i}-${x(d)}`}
+          cx={xScale(x(d))}
+          cy={yScale(y(d))}
           r={4}
           fill={d.stroke || callOrValue(stroke, d, i)}
           stroke="#FFFFFF"
@@ -70,8 +68,8 @@ export default function LineSeries({
         >
           {d.label &&
             <text
-              x={xAccessor(d.x)}
-              y={yAccessor(d.y)}
+              x={xScale(x(d))}
+              y={yScale(y(d))}
               dx={10}
               fill={d.stroke || callOrValue(stroke, d, i)}
               stroke={'#fff'}

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { curveCardinal, curveLinear } from '@vx/curve';
+import { GlyphDot } from '@vx/glyph';
+import { LinePath } from '@vx/shape';
+
+import { callOrValue } from '../utils/chartUtils';
+import { scaleShape } from '../utils/propShapes';
+
+const propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    x: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    y: PropTypes.number.isRequired,
+    label: PropTypes.string,
+  })).isRequired,
+  interpolation: PropTypes.oneOf(['linear', 'cardinal']), // @todo add more
+  label: PropTypes.string.isRequired,
+  showPoints: PropTypes.bool,
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+
+  // these will likely be injected by the parent chart
+  scales: PropTypes.shape({
+    x: PropTypes.func.isRequired,
+    y: PropTypes.func.isRequired,
+  }).isRequired,
+};
+
+const defaultProps = {
+  interpolation: 'cardinal',
+  showPoints: true,
+  stroke: '#00A699',
+  strokeDasharray: null,
+  strokeWidth: 3,
+};
+
+export default function LineSeries({
+  data,
+  interpolation,
+  label,
+  showPoints,
+  scales,
+  stroke,
+  strokeDasharray,
+  strokeWidth,
+}) {
+  const { x, y } = scales;
+  const xAccessor = x.accessor || (d => d.x);
+  const yAccessor = y.accessor || (d => d.y);
+  return (
+    <LinePath
+      key={label}
+      data={data}
+      xScale={x}
+      yScale={y}
+      x={xAccessor}
+      y={yAccessor}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      strokeDasharray={strokeDasharray}
+      curve={interpolation === 'linear' ? curveLinear : curveCardinal}
+      glyph={showPoints && ((d, i) => (
+        <GlyphDot
+          key={`${label}-${i}-${xAccessor(d)}`}
+          cx={x(d.x)}
+          cy={y(d.y)}
+          r={4}
+          fill={d.stroke || callOrValue(stroke, d, i)}
+          stroke="#FFFFFF"
+          strokeWidth={1}
+        >
+          {d.label &&
+            <text
+              x={xAccessor(d.x)}
+              y={yAccessor(d.y)}
+              dx={10}
+              fill={d.stroke || callOrValue(stroke, d, i)}
+              stroke={'#fff'}
+              strokeWidth={1}
+              fontSize={12}
+            >
+              {d.label}
+            </text>}
+        </GlyphDot>
+      ))}
+    />
+  );
+}
+
+LineSeries.propTypes = propTypes;
+LineSeries.defaultProps = defaultProps;
+LineSeries.displayName = 'LineSeries';

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -32,6 +32,9 @@ const defaultProps = {
   strokeWidth: 3,
 };
 
+const x = d => d.x;
+const y = d => d.y;
+
 export default function LineSeries({
   data,
   interpolation,
@@ -43,8 +46,6 @@ export default function LineSeries({
   xScale,
   yScale,
 }) {
-  const x = d => d.x;
-  const y = d => d.y;
   return (
     <LinePath
       key={label}

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -5,8 +5,9 @@ import { curveCardinal, curveLinear } from '@vx/curve';
 import { GlyphDot } from '@vx/glyph';
 import { LinePath } from '@vx/shape';
 
-import { lineSeriesDataShape } from '../utils/propShapes';
 import { callOrValue } from '../utils/chartUtils';
+import { colors } from '../theme';
+import { lineSeriesDataShape } from '../utils/propShapes';
 
 const propTypes = {
   data: lineSeriesDataShape.isRequired,
@@ -26,7 +27,7 @@ const propTypes = {
 const defaultProps = {
   interpolation: 'cardinal',
   showPoints: false,
-  stroke: '#00A699',
+  stroke: colors.default,
   strokeDasharray: null,
   strokeWidth: 3,
 };

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -5,18 +5,15 @@ import { curveCardinal, curveLinear } from '@vx/curve';
 import { GlyphDot } from '@vx/glyph';
 import { LinePath } from '@vx/shape';
 
+import { lineSeriesDataShape } from '../utils/propShapes';
 import { callOrValue } from '../utils/chartUtils';
-import { scaleShape } from '../utils/propShapes';
 
 const propTypes = {
-  data: PropTypes.arrayOf(PropTypes.shape({
-    x: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    y: PropTypes.number.isRequired,
-    label: PropTypes.string,
-  })).isRequired,
+  data: lineSeriesDataShape.isRequired,
   interpolation: PropTypes.oneOf(['linear', 'cardinal']), // @todo add more
   label: PropTypes.string.isRequired,
   showPoints: PropTypes.bool,
+
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
@@ -30,7 +27,7 @@ const propTypes = {
 
 const defaultProps = {
   interpolation: 'cardinal',
-  showPoints: true,
+  showPoints: false,
   stroke: '#00A699',
   strokeDasharray: null,
   strokeWidth: 3,
@@ -57,9 +54,9 @@ export default function LineSeries({
       yScale={y}
       x={xAccessor}
       y={yAccessor}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      strokeDasharray={strokeDasharray}
+      stroke={callOrValue(stroke)}
+      strokeWidth={callOrValue(strokeWidth)}
+      strokeDasharray={callOrValue(strokeDasharray)}
       curve={interpolation === 'linear' ? curveLinear : curveCardinal}
       glyph={showPoints && ((d, i) => (
         <GlyphDot

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Group } from '@vx/group';
+import { GlyphDot } from '@vx/glyph';
+
+import { callOrValue, isDefined } from '../utils/chartUtils';
+import { labelStyles, colors } from '../theme';
+import { pointSeriesDataShape } from '../utils/propShapes';
+
+const propTypes = {
+  data: pointSeriesDataShape.isRequired,
+  label: PropTypes.string.isRequired,
+  labelComponent: PropTypes.element,
+
+  // attributes on data points will override these
+  fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  size: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+
+  // these will likely be injected by the parent chart
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  labelComponent: <text {...labelStyles} />,
+  size: 4,
+  fill: colors.default,
+  stroke: '#FFFFFF',
+  strokeDasharray: null,
+  strokeWidth: 1,
+};
+
+const x = d => d.x;
+const y = d => d.y;
+
+export default function PointSeries({
+  data,
+  label,
+  labelComponent,
+  fill,
+  size,
+  stroke,
+  strokeWidth,
+  strokeDasharray,
+  xScale,
+  yScale,
+}) {
+  const labels = [];
+  return (
+    <Group key={label}>
+      {data.map((d, i) => {
+        const cx = xScale(x(d));
+        const cy = yScale(y(d));
+        const defined = isDefined(cx) && isDefined(cy);
+        if (defined && d.label) {
+          labels.push({ x: cx, y: cy, label: d.label });
+        }
+        return defined && (
+          <GlyphDot
+            key={`${label}-${x(d)}`}
+            cx={cx}
+            cy={cy}
+            r={callOrValue(size, d, i)}
+            fill={d.fill || callOrValue(fill, d, i)}
+            stroke={d.stroke || callOrValue(stroke, d, i)}
+            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+            strokeDasharray={d.strokeDasharray || callOrValue(strokeDasharray, d, i)}
+          />
+        );
+      })}
+      {/* Put labels on top */}
+      {labels.map(d => React.cloneElement(labelComponent, d, d.label))}
+    </Group>
+  );
+}
+
+PointSeries.propTypes = propTypes;
+PointSeries.defaultProps = defaultProps;
+PointSeries.displayName = 'PointSeries';

--- a/packages/xy-chart/src/series/StackedBarSeries.jsx
+++ b/packages/xy-chart/src/series/StackedBarSeries.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { BarStack } from '@vx/shape';
+
+import { barSeriesDataShape } from '../utils/propShapes';
+import { scaleTypeToScale } from '../utils/chartUtils';
+import { colors } from '../theme';
+
+const propTypes = {
+  data: barSeriesDataShape.isRequired,
+  stackKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+  stackFills: PropTypes.arrayOf(PropTypes.string),
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+
+  // these will likely be injected by the parent xychart
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
+};
+
+const defaultProps = {
+  stackFills: colors.categories,
+  stroke: '#FFFFFF',
+  strokeWidth: 1,
+};
+
+const x = d => d.x;
+
+export default function StackedBarSeries({
+  data,
+  stackKeys,
+  stackFills,
+  stroke,
+  strokeWidth,
+  xScale,
+  yScale,
+}) {
+  if (!xScale.bandwidth) { // @todo figure this out/be more graceful
+    throw new Error("'StackedBarSeries' requires a 'band' type xScale");
+  }
+  const maxHeight = (yScale.range() || [0])[0];
+  const zScale = scaleTypeToScale.ordinal({ range: stackFills, domain: stackKeys });
+  return (
+    <BarStack
+      data={data}
+      keys={stackKeys}
+      height={maxHeight}
+      x={x}
+      xScale={xScale}
+      yScale={yScale}
+      zScale={zScale}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+    />
+  );
+}
+
+StackedBarSeries.propTypes = propTypes;
+StackedBarSeries.defaultProps = defaultProps;
+StackedBarSeries.displayName = 'StackedBarSeries';

--- a/packages/xy-chart/src/series/VerticalBarSeries.jsx
+++ b/packages/xy-chart/src/series/VerticalBarSeries.jsx
@@ -50,7 +50,6 @@ export default function VerticalBarSeries({
 }) {
   const maxHeight = (yScale.range() || [0])[0];
   const offset = xScale.offset || 0;
-  console.log(data);
   if (stack) {
     const zScale = scaleTypeToScale.ordinal({ range: stackFills, domain: stack });
     return (

--- a/packages/xy-chart/src/series/VerticalBarSeries.jsx
+++ b/packages/xy-chart/src/series/VerticalBarSeries.jsx
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types';
 import { Group } from '@vx/group';
 import { Bar } from '@vx/shape';
 
-import { callOrValue } from '../utils/chartUtils';
 import { barSeriesDataShape } from '../utils/propShapes';
+import { callOrValue } from '../utils/chartUtils';
+import { colors } from '../theme';
 
 const propTypes = {
   data: barSeriesDataShape.isRequired,
@@ -22,7 +23,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  fill: '#00A699',
+  fill: colors.default,
   stroke: '#FFFFFF',
   strokeWidth: 1,
 };
@@ -39,7 +40,6 @@ export default function VerticalBarSeries({
 }) {
   const maxHeight = (yScale.range() || [0])[0];
   const offset = xScale.bandwidth ? 0 : (xScale.range() || [0])[0];
-  debugger;
   return (
     <Group key={label}>
       {data.map((d, i) => {

--- a/packages/xy-chart/src/series/VerticalBarSeries.jsx
+++ b/packages/xy-chart/src/series/VerticalBarSeries.jsx
@@ -4,19 +4,13 @@ import { Group } from '@vx/group';
 import { Bar } from '@vx/shape';
 
 import { callOrValue } from '../utils/chartUtils';
-import { scaleShape } from '../utils/propShapes';
-
+import { barSeriesDataShape } from '../utils/propShapes';
 
 const propTypes = {
-  data: PropTypes.arrayOf(PropTypes.shape({
-    x: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    y: PropTypes.number.isRequired,
-    fill: PropTypes.string,
-    stroke: PropTypes.string,
-    strokeWidth: PropTypes.number,
-    label: PropTypes.string,
-  })).isRequired,
+  data: barSeriesDataShape.isRequired,
   label: PropTypes.string.isRequired,
+
+  // overridden by data props
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
@@ -24,8 +18,8 @@ const propTypes = {
   // these will likely be injected by the parent xychart
   barWidth: PropTypes.number.isRequired,
   scales: PropTypes.shape({
-    x: scaleShape.isRequired,
-    y: scaleShape.isRequired,
+    x: PropTypes.func.isRequired,
+    y: PropTypes.func.isRequired,
   }).isRequired,
 };
 
@@ -53,7 +47,7 @@ export default function VerticalBarSeries({
         return (
           <Bar
             key={`bar-${label}-${x(d.x)}`}
-            x={x(d.x) - (0.5 * barWidth)}
+            x={x(d.x) - (x.bandwidth ? 0 : (0.5 * barWidth))}
             y={maxHeight - barHeight}
             width={barWidth}
             height={barHeight}

--- a/packages/xy-chart/src/series/VerticalBarSeries.jsx
+++ b/packages/xy-chart/src/series/VerticalBarSeries.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Group } from '@vx/group';
+import { Bar } from '@vx/shape';
+
+import { callOrValue } from '../utils/chartUtils';
+import { scaleShape } from '../utils/propShapes';
+
+
+const propTypes = {
+  data: PropTypes.arrayOf(PropTypes.shape({
+    x: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    y: PropTypes.number.isRequired,
+    fill: PropTypes.string,
+    stroke: PropTypes.string,
+    strokeWidth: PropTypes.number,
+    label: PropTypes.string,
+  })).isRequired,
+  label: PropTypes.string.isRequired,
+  fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+
+  // these will likely be injected by the parent xychart
+  barWidth: PropTypes.number.isRequired,
+  scales: PropTypes.shape({
+    x: scaleShape.isRequired,
+    y: scaleShape.isRequired,
+  }).isRequired,
+};
+
+const defaultProps = {
+  fill: '#00A699',
+  stroke: '#FFFFFF',
+  strokeWidth: 1,
+};
+
+export default function VerticalBarSeries({
+  barWidth,
+  data,
+  fill,
+  stroke,
+  strokeWidth,
+  label,
+  scales,
+}) {
+  const { x, y } = scales;
+  const maxHeight = (y.range() || [0])[0];
+  return (
+    <Group key={label}>
+      {data.map((d, i) => {
+        const barHeight = maxHeight - y(d.y);
+        return (
+          <Bar
+            key={`bar-${label}-${x(d.x)}`}
+            x={x(d.x) - (0.5 * barWidth)}
+            y={maxHeight - barHeight}
+            width={barWidth}
+            height={barHeight}
+            fill={d.fill || callOrValue(fill, d, i)}
+            stroke={d.stroke || callOrValue(stroke, d, i)}
+            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+          />
+        );
+      })}
+    </Group>
+  );
+}
+
+VerticalBarSeries.propTypes = propTypes;
+VerticalBarSeries.defaultProps = defaultProps;
+VerticalBarSeries.displayName = 'VerticalBarSeries';

--- a/packages/xy-chart/src/series/VerticalBarSeries.jsx
+++ b/packages/xy-chart/src/series/VerticalBarSeries.jsx
@@ -17,10 +17,8 @@ const propTypes = {
 
   // these will likely be injected by the parent xychart
   barWidth: PropTypes.number.isRequired,
-  scales: PropTypes.shape({
-    x: PropTypes.func.isRequired,
-    y: PropTypes.func.isRequired,
-  }).isRequired,
+  xScale: PropTypes.func.isRequired,
+  yScale: PropTypes.func.isRequired,
 };
 
 const defaultProps = {
@@ -36,18 +34,20 @@ export default function VerticalBarSeries({
   stroke,
   strokeWidth,
   label,
-  scales,
+  xScale,
+  yScale,
 }) {
-  const { x, y } = scales;
-  const maxHeight = (y.range() || [0])[0];
+  const maxHeight = (yScale.range() || [0])[0];
+  const offset = xScale.bandwidth ? 0 : (xScale.range() || [0])[0];
+  debugger;
   return (
     <Group key={label}>
       {data.map((d, i) => {
-        const barHeight = maxHeight - y(d.y);
+        const barHeight = maxHeight - yScale(d.y);
         return (
           <Bar
-            key={`bar-${label}-${x(d.x)}`}
-            x={x(d.x) - (x.bandwidth ? 0 : (0.5 * barWidth))}
+            key={`bar-${label}-${xScale(d.x)}`}
+            x={xScale(d.x) - offset}
             y={maxHeight - barHeight}
             width={barWidth}
             height={barHeight}

--- a/packages/xy-chart/src/series/VerticalBarSeries.jsx
+++ b/packages/xy-chart/src/series/VerticalBarSeries.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Group } from '@vx/group';
-import { Bar, BarStack } from '@vx/shape';
+import { Bar, BarStack, BarGroup } from '@vx/shape';
 
 import { barSeriesDataShape } from '../utils/propShapes';
 import { callOrValue, scaleTypeToScale } from '../utils/chartUtils';
@@ -10,6 +10,12 @@ import { colors } from '../theme';
 const propTypes = {
   data: barSeriesDataShape.isRequired,
   label: PropTypes.string.isRequired,
+
+  // for groups
+  group: PropTypes.arrayOf(PropTypes.string),
+  groupFills: PropTypes.arrayOf(PropTypes.string),
+
+  // for stacks
   stack: PropTypes.arrayOf(PropTypes.string),
   stackFills: PropTypes.arrayOf(PropTypes.string),
 
@@ -27,6 +33,9 @@ const propTypes = {
 const defaultProps = {
   stack: null,
   stackFills: colors.categories,
+  group: null,
+  groupFills: colors.categories,
+
   fill: colors.default,
   stackBy: null,
   stroke: '#FFFFFF',
@@ -36,12 +45,16 @@ const defaultProps = {
 const x = d => d.x;
 const y = d => d.y;
 
+// every x value has group.length bars
+
 export default function VerticalBarSeries({
   barWidth,
   data,
   fill,
   stack,
   stackFills,
+  group,
+  groupFills,
   stroke,
   strokeWidth,
   label,
@@ -63,6 +76,28 @@ export default function VerticalBarSeries({
         zScale={zScale}
         stroke={stroke}
         strokeWidth={strokeWidth}
+      />
+    );
+  }
+  if (group) {
+    debugger;
+    const zScale = scaleTypeToScale.ordinal({ range: groupFills, domain: group });
+    const x1Scale = scaleTypeToScale.band({
+      rangeRound: [0, xScale.bandwidth()],
+      domain: group,
+      padding: 0.1,
+    });
+    return (
+      <BarGroup
+        data={data}
+        keys={group}
+        height={maxHeight}
+        x0={x}
+        x0Scale={xScale}
+        x1Scale={x1Scale}
+        yScale={yScale}
+        zScale={zScale}
+        rx={2}
       />
     );
   }

--- a/packages/xy-chart/src/theme.js
+++ b/packages/xy-chart/src/theme.js
@@ -1,0 +1,118 @@
+export const unit = 8;
+
+export const colors = {
+  default: '#00A699',
+  dark: '#00514A',
+  light: '#84D2CB',
+
+  disabled: '#484848',
+  lightDisabled: '#DBDBDB',
+
+  grid: '#DBDBDB',
+  gridDark: '#484848',
+  label: '#767676',
+  tickLabel: '#767676',
+
+  categories: [
+    '#00A699', // aqua
+    '#84D2CB', // light aqua
+    '#FFB400', // yellow-orange
+    '#7b0051', // purple
+    '#FC642D', // red-orange
+    '#FF5A5F', // coral
+  ],
+};
+
+export const grid = {
+  stroke: colors.grid,
+  strokeWidth: 1,
+};
+
+export const fontFamily = 'BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif';
+
+const baseLabel = {
+  fill: colors.label,
+  fontFamily,
+  fontSize: 12,
+  fontWeight: 700,
+  textAnchor: 'middle',
+};
+
+export const xAxis = {
+  stroke: colors.gridDark,
+  strokeWidth: 2,
+  label: {
+    bottom: {
+      ...baseLabel,
+    },
+    top: {
+      ...baseLabel,
+    },
+  },
+};
+
+export const yAxis = {
+  stroke: colors.grid,
+  strokeWidth: 1,
+  label: {
+    left: {
+      ...baseLabel,
+    },
+    right: {
+      ...baseLabel,
+    },
+  },
+};
+
+const baseTickLabel = {
+  fill: colors.tickLabel,
+  fontFamily,
+  fontSize: 12,
+  fontWeight: 200,
+};
+
+export const xTick = {
+  stroke: colors.grid,
+  length: 1 * unit,
+  label: {
+    bottom: {
+      ...baseTickLabel,
+      textAnchor: 'middle',
+      dy: '0.25em',
+    },
+    top: {
+      ...baseTickLabel,
+      textAnchor: 'middle',
+      dy: '-0.25em',
+    },
+  },
+};
+
+export const yTick = {
+  stroke: colors.grid,
+  length: 1 * unit,
+  label: {
+    left: {
+      ...baseTickLabel,
+      textAnchor: 'end',
+      dx: '-0.25em',
+      dy: '0.25em',
+    },
+    right: {
+      ...baseTickLabel,
+      textAnchor: 'start',
+      dx: '0.25em',
+      dy: '0.25em',
+    },
+  },
+};
+
+export default {
+  colors,
+  grid,
+  unit,
+  xAxis,
+  xTick,
+  yAxis,
+  yTick,
+};

--- a/packages/xy-chart/src/theme.js
+++ b/packages/xy-chart/src/theme.js
@@ -19,7 +19,10 @@ export const colors = {
     '#FFB400', // yellow-orange
     '#7b0051', // purple
     '#FC642D', // red-orange
-    '#FF5A5F', // coral
+    '#9BE382', // lime
+    '#484848', // dark grey
+    '#FFBAA0', // peach
+    '#008C99', // dark aqua
   ],
 };
 
@@ -107,6 +110,15 @@ export const yTickStyles = {
   },
 };
 
+export const labelStyles = {
+  fill: colors.label,
+  fontFamily,
+  fontSize: 12,
+  fontWeight: 200,
+  dx: '0.5em',
+  dy: '0.5em',
+};
+
 export default {
   colors,
   gridStyles,
@@ -115,4 +127,5 @@ export default {
   xTickStyles,
   yAxisStyles,
   yTickStyles,
+  labelStyles,
 };

--- a/packages/xy-chart/src/theme.js
+++ b/packages/xy-chart/src/theme.js
@@ -23,7 +23,7 @@ export const colors = {
   ],
 };
 
-export const grid = {
+export const gridStyles = {
   stroke: colors.grid,
   strokeWidth: 1,
 };
@@ -38,7 +38,7 @@ const baseLabel = {
   textAnchor: 'middle',
 };
 
-export const xAxis = {
+export const xAxisStyles = {
   stroke: colors.gridDark,
   strokeWidth: 2,
   label: {
@@ -51,7 +51,7 @@ export const xAxis = {
   },
 };
 
-export const yAxis = {
+export const yAxisStyles = {
   stroke: colors.grid,
   strokeWidth: 1,
   label: {
@@ -71,7 +71,7 @@ const baseTickLabel = {
   fontWeight: 200,
 };
 
-export const xTick = {
+export const xTickStyles = {
   stroke: colors.grid,
   length: 1 * unit,
   label: {
@@ -88,7 +88,7 @@ export const xTick = {
   },
 };
 
-export const yTick = {
+export const yTickStyles = {
   stroke: colors.grid,
   length: 1 * unit,
   label: {
@@ -109,10 +109,10 @@ export const yTick = {
 
 export default {
   colors,
-  grid,
+  gridStyles,
   unit,
-  xAxis,
-  xTick,
-  yAxis,
-  yTick,
+  xAxisStyles,
+  xTickStyles,
+  yAxisStyles,
+  yTickStyles,
 };

--- a/packages/xy-chart/src/utils/chartUtils.js
+++ b/packages/xy-chart/src/utils/chartUtils.js
@@ -4,7 +4,7 @@ import { extent } from 'd3-array';
 
 export function callOrValue(maybeFn, ...args) {
   if (typeof maybeFn === 'function') {
-    return maybeFn(args);
+    return maybeFn(...args);
   }
   return maybeFn;
 }

--- a/packages/xy-chart/src/utils/chartUtils.js
+++ b/packages/xy-chart/src/utils/chartUtils.js
@@ -18,3 +18,18 @@ export function getChildWithName(name, children) {
   const ChildOfInterest = Children.toArray(children).filter(c => componentName(c) === name);
   return ChildOfInterest.length ? ChildOfInterest[0] : null;
 }
+
+export function nonBandBarWidth({ children, totalWidth }) {
+  let barWidth = Infinity;
+  Children.forEach(children, (Child) => {
+    if (componentName(Child).match(/Bar/g)) {
+      const data = Child.props.data;
+      barWidth = Math.min(barWidth, (totalWidth / data.length) - 6);
+    }
+  });
+  return barWidth === Infinity ? 0 : Math.max(0, barWidth);
+}
+
+export function isBarSeries(name) {
+  return name.match(/Bar/g);
+}

--- a/packages/xy-chart/src/utils/chartUtils.js
+++ b/packages/xy-chart/src/utils/chartUtils.js
@@ -1,0 +1,20 @@
+import { Children } from 'react';
+
+export function callOrValue(maybeFn, ...args) {
+  if (typeof maybeFn === 'function') {
+    return maybeFn(args);
+  }
+  return maybeFn;
+}
+
+export function componentName(component) {
+  if (component && component.type) {
+    return component.type.displayName || component.type.name || 'Component';
+  }
+  return '';
+}
+
+export function getChildWithName(name, children) {
+  const ChildOfInterest = Children.toArray(children).filter(c => componentName(c) === name);
+  return ChildOfInterest.length ? ChildOfInterest[0] : null;
+}

--- a/packages/xy-chart/src/utils/chartUtils.js
+++ b/packages/xy-chart/src/utils/chartUtils.js
@@ -21,6 +21,10 @@ export function getChildWithName(name, children) {
   return ChildOfInterest.length ? ChildOfInterest[0] : null;
 }
 
+export function isDefined(val) {
+  return typeof val !== 'undefined' && val !== null;
+}
+
 export function isAxis(name) {
   return name.match(/axis/gi);
 }

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+
+export const scaleShape = PropTypes.shape({
+  accessor: PropTypes.func,
+  type: PropTypes.oneOf([
+    'time',
+    'linear',
+    'ordinal',
+  ]).isRequired,
+
+  includeZero: PropTypes.bool,
+
+  // these would override any computation done by xyplot
+  // and would allow specifying colors for scales, etc.
+  range: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  domain: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+});
+
+// export const axisShape = PropTypes.shape({
+//   orientation: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+//   label: PropTypes.string,
+//   showGrid: PropTypes.bool,
+//   showTicks: PropTypes.bool,
+//   tickFormat: PropTypes.func,
+//   numTicks: PropTypes.number,
+//   tickValues: PropTypes.oneOfType([ // array of tick values or a function that returns one
+//     PropTypes.func,
+//     PropTypes.arrayOf(PropTypes.string),
+//   ]),
+// });

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -23,7 +23,6 @@ export const lineSeriesDataShape = PropTypes.arrayOf(
       PropTypes.instanceOf(Date),
     ]).isRequired,
     y: PropTypes.number.isRequired,
-    label: PropTypes.string,
   }),
 );
 
@@ -37,7 +36,22 @@ export const barSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
   fill: PropTypes.string,
   stroke: PropTypes.string,
   strokeWidth: PropTypes.number,
-  label: PropTypes.string,
+}));
+
+export const intervalSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
+  x0: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]).isRequired,
+  x1: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]).isRequired,
+  fill: PropTypes.string,
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
 }));
 
 export const axisStylesShape = PropTypes.shape({

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -6,6 +6,7 @@ export const scaleShape = PropTypes.shape({
     'time',
     'linear',
     'ordinal',
+    'band',
   ]).isRequired,
 
   includeZero: PropTypes.bool,
@@ -16,15 +17,49 @@ export const scaleShape = PropTypes.shape({
   domain: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
 });
 
-// export const axisShape = PropTypes.shape({
-//   orientation: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
-//   label: PropTypes.string,
-//   showGrid: PropTypes.bool,
-//   showTicks: PropTypes.bool,
-//   tickFormat: PropTypes.func,
-//   numTicks: PropTypes.number,
-//   tickValues: PropTypes.oneOfType([ // array of tick values or a function that returns one
-//     PropTypes.func,
-//     PropTypes.arrayOf(PropTypes.string),
-//   ]),
-// });
+export const lineSeriesDataShape = PropTypes.arrayOf(
+  PropTypes.shape({
+    x: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date),
+    ]).isRequired,
+    y: PropTypes.number.isRequired,
+    label: PropTypes.string,
+  }),
+);
+
+export const barSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
+  x: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]).isRequired,
+  y: PropTypes.number.isRequired,
+  fill: PropTypes.string,
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  label: PropTypes.string,
+}));
+
+export const axisStylesShape = PropTypes.shape({
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  label: PropTypes.shape({
+    left: PropTypes.object,
+    right: PropTypes.object,
+    bottom: PropTypes.object,
+    top: PropTypes.object,
+  }),
+});
+
+export const tickStylesShape = PropTypes.shape({
+  stroke: PropTypes.string,
+  tickLength: PropTypes.number,
+  label: PropTypes.shape({
+    left: PropTypes.object,
+    right: PropTypes.object,
+    bottom: PropTypes.object,
+    top: PropTypes.object,
+  }),
+});

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -12,6 +12,7 @@ export const scaleShape = PropTypes.shape({
   // these would override any computation done by xyplot
   // and would allow specifying colors for scales, etc.
   range: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  rangeRound: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
   domain: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
 });
 
@@ -36,6 +37,20 @@ export const barSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
   fill: PropTypes.string,
   stroke: PropTypes.string,
   strokeWidth: PropTypes.number,
+}));
+
+export const pointSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
+  x: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]).isRequired,
+  y: PropTypes.number.isRequired,
+  size: PropTypes.number,
+  fill: PropTypes.string,
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
+  strokeDasharray: PropTypes.string,
 }));
 
 export const intervalSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -66,3 +66,11 @@ export const gridStylesShape = PropTypes.shape({
   stroke: PropTypes.string,
   strokeWidth: PropTypes.number,
 });
+
+export const themeShape = PropTypes.shape({
+  gridStyles: gridStylesShape,
+  xAxisStyles: axisStylesShape,
+  xTickStyles: tickStylesShape,
+  yAxisStyles: axisStylesShape,
+  yTickStyles: tickStylesShape,
+});

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -1,11 +1,9 @@
 import PropTypes from 'prop-types';
 
 export const scaleShape = PropTypes.shape({
-  accessor: PropTypes.func,
   type: PropTypes.oneOf([
     'time',
     'linear',
-    'ordinal',
     'band',
   ]).isRequired,
 
@@ -62,4 +60,9 @@ export const tickStylesShape = PropTypes.shape({
     bottom: PropTypes.object,
     top: PropTypes.object,
   }),
+});
+
+export const gridStylesShape = PropTypes.shape({
+  stroke: PropTypes.string,
+  strokeWidth: PropTypes.number,
 });

--- a/packages/xy-chart/theme.js
+++ b/packages/xy-chart/theme.js
@@ -1,0 +1,68 @@
+export const unit = 8;
+
+export const colors = {
+  default: '#00A699',
+  dark: '#00514A',
+  light: '#84D2CB',
+
+  disabled: '#484848',
+  lightDisabled: '#DBDBDB',
+
+  grid: '#DBDBDB',
+  label: '#484848',
+  tickLabel: '#767676',
+
+  categories: [
+    '#00A699', // aqua
+    '#84D2CB', // light aqua
+    '#FFB400', // yellow-orange
+    '#7b0051', // purple
+    '#FC642D', // red-orange
+    '#FF5A5F', // coral
+  ],
+};
+
+export const grid = {
+  stroke: colors.grid,
+  strokeWidth: 1,
+};
+
+export const fontFamily = 'BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif';
+
+export const axis = {
+  stroke: colors.grid,
+  strokeWidth: 1,
+  tickStroke: colors.grid,
+  tickLength: 1 * unit,
+  label: {
+    textAnchor: 'middle',
+    dy: '0.25em',
+    fill: colors.tickLabel,
+    fontFamily,
+    fontSize: 14,
+    fontWeight: 800,
+  },
+  xTickLabel: {
+    textAnchor: 'middle',
+    dy: '0.25em',
+    fontFamily,
+    fontSize: 14,
+    fill: colors.tickLabel,
+    fontWeight: 200,
+  },
+  yTickLabel: {
+    textAnchor: 'start',
+    dy: '0.25em',
+    fontFamily,
+    fontSize: 14,
+    fill: colors.tickLabel,
+    fontWeight: 200,
+  },
+};
+
+export default {
+  axis,
+  colors,
+  grid,
+  unit,
+};

--- a/packages/xy-chart/webpack.config.js
+++ b/packages/xy-chart/webpack.config.js
@@ -1,0 +1,29 @@
+const path = require('path');
+
+const dist = path.resolve(__dirname, './build');
+const src = path.resolve(__dirname, './src');
+
+const config = {
+  entry: {
+    index: `${src}/index`,
+  },
+  output: {
+    filename: '[name].js',
+    path: `${dist}`,
+    libraryTarget: 'commonjs2',
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        include: src,
+        loader: 'babel-loader',
+      },
+    ],
+  },
+};
+
+module.exports = config;


### PR DESCRIPTION
This PR adds the xy-chart package for re-usable + composable + themeable charts with x/y-axes. It leverages [vx](https://github.com/hshoff/vx) for low-level components 💯 . Check out the [examples](https://github.com/williaster/data-ui/compare/chris--xyplot?expand=1#diff-2038be74226026eb7988ec5aeedadd4a) to look at the API.

![xy-chart](https://cloud.githubusercontent.com/assets/4496521/26419570/fcfe9396-4074-11e7-93ef-b77fd5ec132b.gif)

next steps:
- [ ] address any feedback from @hshoff @andyfangdz
- [ ] merge this + publish the first version
- [ ] refactor [@andyfangdz's PR](https://github.com/williaster/data-ui/pull/10), let me know if you want me to have a go at this or if you want to, happy either way :)
- [ ] add more series so we can use it in DLS: stacked / grouped bar, etc.
- [ ] refactor repo to use jest instead of mocha -> add some tests 🎉 

note: proper axis display here depends on [this vx PR](https://github.com/hshoff/vx/pull/42)

cc @elibrumbaugh 

