### PR TITLE
[dev] add webpack-dashboard

### DIFF
--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack -p --env build && npm run copy-styles",
     "copy-styles": "cp ./node_modules/react-virtualized/styles.css ./build/styles.css",
-    "dev": "webpack --progress --colors --watch --env dev",
+    "dev": "webpack-dashboard -- webpack --progress --colors --watch --env dev",
     "test": "jest --colors --verbose --coverage"
   },
   "repository": "https://github.com/williaster/data-ui",
@@ -34,7 +34,8 @@
     "react": "~15.4.2",
     "react-addons-test-utils": "~15.4.2",
     "react-dom": "~15.4.2",
-    "webpack": "^2.4.1"
+    "webpack": "^2.4.1",
+    "webpack-dashboard": "^0.4.0"
   },
   "peerDependencies": {
     "react": "~15.4.2",

--- a/packages/data-table/webpack.config.js
+++ b/packages/data-table/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const DashboardPlugin = require('webpack-dashboard/plugin');
 
 const dist = path.resolve(__dirname, './build');
 const src = path.resolve(__dirname, './src');
@@ -28,6 +29,9 @@ const config = {
       },
     ],
   },
+  plugins: [
+    new DashboardPlugin(),
+  ],
 };
 
 module.exports = config;

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -5,7 +5,7 @@
   "main": "build/index.js",
   "scripts": {
     "build": "webpack -p --env build",
-    "dev": "webpack --progress --colors --watch --env dev",
+    "dev": "webpack-dashboard -- webpack --progress --colors --watch --env dev",
     "test": "jest --colors --verbose --coverage"
   },
   "repository": "https://github.com/williaster/data-ui",
@@ -44,7 +44,8 @@
     "react": "~15.4.2",
     "react-addons-test-utils": "~15.4.2",
     "react-dom": "~15.4.2",
-    "webpack": "^2.4.1"
+    "webpack": "^2.4.1",
+    "webpack-dashboard": "^0.4.0"
   },
   "peerDependencies": {
     "react": "~15.4.2",

--- a/packages/xy-chart/webpack.config.js
+++ b/packages/xy-chart/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const DashboardPlugin = require('webpack-dashboard/plugin');
 
 const dist = path.resolve(__dirname, './build');
 const src = path.resolve(__dirname, './src');
@@ -24,6 +25,9 @@ const config = {
       },
     ],
   },
+  plugins: [
+    new DashboardPlugin(),
+  ],
 };
 
 module.exports = config;


### PR DESCRIPTION
this PR adds [`webpack-dashboard`](https://github.com/FormidableLabs/webpack-dashboard) to the `xy-chart` and `data-table` packages for this NASA-like build dashboard:

![image](https://cloud.githubusercontent.com/assets/4496521/26619150/0ed8d5e6-4592-11e7-9864-a7d8d42a15e2.png)


