### PR TITLE
[xy-chart] add `withTheme` HOC

### DIFF
--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -130,7 +130,7 @@ class XYChart extends React.PureComponent {
     const { margin, innerWidth, innerHeight } = this.getDimmensions();
     const { numXTicks, numYTicks } = this.getNumTicks(innerWidth, innerHeight);
     const { xScale, yScale } = this.collectScalesFromProps();
-    return (
+    return innerWidth > 0 && innerHeight > 0 && (
       <svg
         aria-label={ariaLabel}
         role="img"

--- a/packages/xy-chart/src/enhancer/withTheme.js
+++ b/packages/xy-chart/src/enhancer/withTheme.js
@@ -1,0 +1,31 @@
+/*
+ * example usage:
+ * const XYChartWithTheme = withTheme(theme)(XYChart);
+ */
+import React from 'react';
+import updateDisplayName from '../utils/updateDisplayName';
+import defaultTheme from '../theme';
+
+function withTheme(theme = defaultTheme) {
+  return function withThemeHOC(WrappedComponent) {
+    // use a class for ref-ability and for PureComponent optimization
+    // eslint-disable-next-line react/prefer-stateless-function
+    class EnhancedComponent extends React.PureComponent {
+      render() {
+        return (
+          <WrappedComponent theme={theme} {...this.props} />
+        );
+      }
+    }
+
+    EnhancedComponent.propTypes = WrappedComponent.propTypes || {};
+    EnhancedComponent.defaultProps = WrappedComponent.defaultProps || {};
+    if (EnhancedComponent.propTypes.theme) delete EnhancedComponent.propTypes.theme;
+    if (EnhancedComponent.defaultProps.theme) delete EnhancedComponent.defaultProps.theme;
+    updateDisplayName(WrappedComponent, EnhancedComponent, 'withTheme');
+
+    return EnhancedComponent;
+  };
+}
+
+export default withTheme;

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -11,6 +11,7 @@ export { default as StackedBarSeries } from './series/StackedBarSeries';
 
 export { LinearGradient } from '@vx/gradient';
 export { PatternLines } from '@vx/pattern';
-export { withScreenSize } from '@vx/responsive';
+export { withScreenSize, withParentSize } from '@vx/responsive';
 
+export { default as withTheme } from './enhancer/withTheme';
 export { default as theme } from './theme';

--- a/packages/xy-chart/src/utils/updateDisplayName.js
+++ b/packages/xy-chart/src/utils/updateDisplayName.js
@@ -1,0 +1,9 @@
+/* eslint-disable no-param-reassign */
+export default function updateDisplayName(WrappedComponent, EnhancedComponent, hocName) {
+  const wrappedComponentName = WrappedComponent.displayName ||
+    WrappedComponent.name ||
+    'Component';
+
+  EnhancedComponent.WrappedComponent = WrappedComponent;
+  EnhancedComponent.displayName = `${hocName}(${wrappedComponentName})`;
+}

--- a/packages/xy-chart/test/XAxis.test.js
+++ b/packages/xy-chart/test/XAxis.test.js
@@ -7,8 +7,8 @@ describe('<XAxis />', () => {
   const chartProps = {
     xScale: { type: 'band' },
     yScale: { type: 'linear' },
-    width: 100,
-    height: 100,
+    width: 200,
+    height: 200,
     ariaLabel: 'label',
   };
 

--- a/packages/xy-chart/test/XYChart.test.js
+++ b/packages/xy-chart/test/XYChart.test.js
@@ -25,6 +25,16 @@ describe('<XYChart />', () => {
     expect(XYChart).toBeDefined();
   });
 
+  test('it should not render with invalid width or height', () => {
+    const valid = shallow(<XYChart {...mockProps} />);
+    const invalidWidth = shallow(<XYChart {...mockProps} width={0} />);
+    const invalidHeight = shallow(<XYChart {...mockProps} height={0} />);
+
+    expect(valid.children().length).toBe(1);
+    expect(invalidWidth.children().length).toBe(0);
+    expect(invalidHeight.children().length).toBe(0);
+  });
+
   test('it should render an svg with an aria label', () => {
     const wrapper = shallow(<XYChart {...mockProps} />);
     const svg = wrapper.find('svg');

--- a/packages/xy-chart/test/YAxis.test.js
+++ b/packages/xy-chart/test/YAxis.test.js
@@ -7,8 +7,8 @@ describe('<YAxis />', () => {
   const chartProps = {
     xScale: { type: 'band' },
     yScale: { type: 'linear' },
-    width: 100,
-    height: 100,
+    width: 200,
+    height: 200,
     ariaLabel: 'label',
   };
 

--- a/packages/xy-chart/test/withTheme.test.js
+++ b/packages/xy-chart/test/withTheme.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { theme as defaultTheme, withTheme } from '../src';
+
+describe('withTheme', () => {
+  test('it should be a fn', () => {
+    expect(withTheme).toBeInstanceOf(Function);
+  });
+
+  test('it should return a fn', () => {
+    expect(withTheme()).toBeInstanceOf(Function);
+  });
+});
+
+describe('HOC', () => {
+  test('it has a wrapped displayName', () => {
+    function MyComponent() { return null; }
+    function WithDisplayName() { return null; }
+    WithDisplayName.displayName = 'MyDisplayName';
+
+    const hoc1 = withTheme({})(MyComponent);
+    expect(hoc1.displayName).toBe('withTheme(MyComponent)');
+
+    const hoc2 = withTheme({})(WithDisplayName);
+    expect(hoc2.displayName).toBe('withTheme(MyDisplayName)');
+  });
+
+  test('it passes the theme prop to the wrapped component', () => {
+    const testTheme = { my: 'theme' };
+    function MyComponent({ theme }) {
+      expect(theme).toBe(testTheme);
+      return null;
+    }
+    const HOC = withTheme(testTheme)(MyComponent);
+    shallow(<HOC />).dive();
+  });
+
+  test('it passes the default theme when no theme is passed', () => {
+    function MyComponent({ theme }) {
+      expect(theme).toEqual(defaultTheme);
+      return null;
+    }
+    const HOC = withTheme()(MyComponent);
+    shallow(<HOC />).dive();
+  });
+});

--- a/packages/xy-chart/test/withTheme.test.js
+++ b/packages/xy-chart/test/withTheme.test.js
@@ -37,10 +37,22 @@ describe('HOC', () => {
 
   test('it passes the default theme when no theme is passed', () => {
     function MyComponent({ theme }) {
-      expect(theme).toEqual(defaultTheme);
+      expect(theme).toBe(defaultTheme);
       return null;
     }
     const HOC = withTheme()(MyComponent);
     shallow(<HOC />).dive();
+  });
+
+  test('it allows theme to be overridden', () => {
+    const overrideTheme = { override: 'theme' };
+    function MyComponent() { return null; }
+    const HOC = withTheme()(MyComponent);
+
+    let wrapper = shallow(<HOC />);
+    expect(wrapper.find(MyComponent).prop('theme')).toBe(defaultTheme);
+
+    wrapper = shallow(<HOC theme={overrideTheme} />);
+    expect(wrapper.find(MyComponent).prop('theme')).toBe(overrideTheme);
   });
 });


### PR DESCRIPTION
This PR adds a `withTheme` HOC for easier theme customizability. example usage:

```js
const XYChartWithTheme = withTheme(theme)(XYChart);
```

Tested in demo page + with jest.
note it also adds a sanity width/height check to `<XYChart />` for positive values.