### PR TITLE
[dependencies] update to React ^15.5.0 and use prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@data-ui/data-ui",
   "version": "0.0.0",
-  "description": "A collection of components for data-rich user interfaces",
+  "description": "A collection of components for data-rich user interfaces https://williaster.github.io/data-ui",
   "main": "index.js",
   "scripts": {
     "lint": "eslint --ignore-path=.eslintignore --ext .js,.jsx ./packages/",
@@ -32,14 +32,14 @@
     "eslint-plugin-react": "^6.10.3",
     "jest": "^20.0.3",
     "lerna": "^2.0.0-rc.2",
-    "react": "~15.4.2",
-    "react-addons-test-utils": "~15.4.2",
-    "react-dom": "~15.4.2"
+    "react": "^15.5.0",
+    "react-addons-test-utils": "^15.5.0",
+    "react-dom": "^15.5.0"
   },
   "peerDependencies": {
     "lerna": "2.0.0-rc.2",
-    "react": "~15.4.2",
-    "react-dom": "~15.4.2"
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0"
   },
   "jest": {
     "projects": [

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack -p --env build && npm run copy-styles",
     "copy-styles": "cp ./node_modules/react-virtualized/styles.css ./build/styles.css",
-    "dev": "webpack-dashboard -- webpack --progress --colors --watch --env dev",
+    "dev": "webpack-dashboard --port 3001 -- webpack --progress --colors --watch --env dev",
     "test": "jest --colors --verbose --coverage"
   },
   "repository": "https://github.com/williaster/data-ui",
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/williaster/data-ui#readme",
   "dependencies": {
     "immutable": "^3.8.1",
+    "prop-types": "^15.5.10",
     "react-virtualized": "^9.7.3"
   },
   "devDependencies": {
@@ -31,14 +32,14 @@
     "babel-preset-airbnb": "^2.2.3",
     "css-loader": "^0.28.0",
     "jest": "^20.0.3",
-    "react": "~15.4.2",
-    "react-addons-test-utils": "~15.4.2",
-    "react-dom": "~15.4.2",
+    "react": "^15.5.0",
+    "react-addons-test-utils": "^15.5.0",
+    "react-dom": "^15.5.0",
     "webpack": "^2.4.1",
     "webpack-dashboard": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "~15.4.2",
-    "react-dom": "~15.4.2"
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0"
   }
 }

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -39,7 +39,6 @@
     "webpack-dashboard": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0"
+    "react": "^15.5.0"
   }
 }

--- a/packages/data-table/src/components/Table.jsx
+++ b/packages/data-table/src/components/Table.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Column, SortDirection, Table } from 'react-virtualized';
 
 import dataListPropType from '../propTypes/dataList';

--- a/packages/data-table/src/enhancers/withDynamicCellHeights.jsx
+++ b/packages/data-table/src/enhancers/withDynamicCellHeights.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { CellMeasurer, CellMeasurerCache } from 'react-virtualized';
 
 import { baseHOC, updateDisplayName } from './hocUtils';

--- a/packages/data-table/src/enhancers/withFiltering.jsx
+++ b/packages/data-table/src/enhancers/withFiltering.jsx
@@ -1,5 +1,6 @@
 /* eslint react/prop-types: 0 */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { baseHOC, updateDisplayName } from './hocUtils';
 import dataListPropType from '../propTypes/dataList';

--- a/packages/data-table/src/enhancers/withSorting.jsx
+++ b/packages/data-table/src/enhancers/withSorting.jsx
@@ -1,6 +1,7 @@
 /* eslint react/prop-types: 0 */
 /* ^ there is a bug with how props are parsed with the enhanced component */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { SortDirection } from 'react-virtualized';
 
 import dataListPropType from '../propTypes/dataList';

--- a/packages/data-table/src/enhancers/withTableAutoSizer.jsx
+++ b/packages/data-table/src/enhancers/withTableAutoSizer.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { AutoSizer } from 'react-virtualized';
 
 import { baseHOC, updateDisplayName } from './hocUtils';

--- a/packages/data-table/src/enhancers/withWindowScroller.jsx
+++ b/packages/data-table/src/enhancers/withWindowScroller.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { WindowScroller } from 'react-virtualized';
 
 import { baseHOC, updateDisplayName } from './hocUtils';

--- a/packages/data-table/webpack.config.js
+++ b/packages/data-table/webpack.config.js
@@ -30,7 +30,8 @@ const config = {
     ],
   },
   plugins: [
-    new DashboardPlugin(),
+    // make the port diff from other packages to run simultaneously
+    new DashboardPlugin({ port: 3001 }),
   ],
 };
 

--- a/packages/demo/examples/data-table/FilterableTable.jsx
+++ b/packages/demo/examples/data-table/FilterableTable.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import {
   Table,

--- a/packages/demo/examples/shared/LabeledInput.jsx
+++ b/packages/demo/examples/shared/LabeledInput.jsx
@@ -1,5 +1,6 @@
 /* Controlled, labeled input */
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { css, withStyles, withStylesProps } from '../../themes/withStyles';
 
 const propTypes = {

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -30,15 +30,16 @@
     "git-directory-deploy": "^1.5.1",
     "glob": "^7.1.1",
     "immutable": "^3.8.1",
-    "react": "~15.4.2",
-    "react-dom": "~15.4.2",
+    "prop-types": "^15.5.10",
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0",
     "react-with-styles": "^1.3.0",
     "react-with-styles-interface-aphrodite": "^1.2.0"
   },
   "peerDependencies": {
     "aphrodite": "^1.2.0",
-    "react": "~15.4.2",
-    "react-dom": "~15.4.2"
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0"
   },
   "private": true
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -38,8 +38,7 @@
   },
   "peerDependencies": {
     "aphrodite": "^1.2.0",
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0"
+    "react": "^15.5.0"
   },
   "private": true
 }

--- a/packages/demo/themes/withStyles.js
+++ b/packages/demo/themes/withStyles.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import ThemedStyleSheet from 'react-with-styles/lib/ThemedStyleSheet';
 import aphroditeInterface from 'react-with-styles-interface-aphrodite';
 import { css, withStyles, ThemeProvider } from 'react-with-styles';

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@data-ui/xy-chart",
   "version": "0.0.4",
-  "description": "A package of charts with standard x- and y- axes.",
+  "description": "A package of charts with standard x- and y- axes. https://williaster.github.io/data-ui",
   "main": "build/index.js",
   "scripts": {
     "build": "webpack -p --env build",
@@ -41,14 +41,14 @@
     "babel-preset-airbnb": "^2.2.3",
     "enzyme": "^2.8.2",
     "jest": "^20.0.3",
-    "react": "~15.4.2",
-    "react-addons-test-utils": "~15.4.2",
-    "react-dom": "~15.4.2",
+    "react": "^15.5.0",
+    "react-addons-test-utils": "^15.5.0",
+    "react-dom": "^15.5.0",
     "webpack": "^2.4.1",
     "webpack-dashboard": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "~15.4.2",
-    "react-dom": "~15.4.2"
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0"
   }
 }

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -48,7 +48,6 @@
     "webpack-dashboard": "^0.4.0"
   },
   "peerDependencies": {
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0"
+    "react": "^15.5.0"
   }
 }


### PR DESCRIPTION
This PR bumps React to `^15.5.0` across all packages and updates to use `prop-types` in the `@data-ui/data-table` package. Still seeing some warnings in dev mode.