### PR TITLE
add `@data-ui/theme`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
-    "jest": "^20.0.3",
+    "jest": "^19.0.0",
     "lerna": "^2.0.0-rc.2",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",

--- a/packages/data-ui-theme/.babelrc
+++ b/packages/data-ui-theme/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["airbnb"]
+}

--- a/packages/data-ui-theme/README.md
+++ b/packages/data-ui-theme/README.md
@@ -1,0 +1,12 @@
+# @data-ui/theme
+This package exports theme variables that can be used by other packages. For now there's one theme and we'll add more as needed.
+
+```js
+import { font, svgFont, label, size, colors } from `@data-ui/theme`;
+```
+
+## @data-ui packages
+- [@data-ui/xy-chart](https://github.com/williaster/data-ui/tree/master/packages/xy-chart)
+- [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table)
+- @data-ui/theme
+- [@data-ui/demo](https://github.com/williaster/data-ui/tree/master/packages/demo)

--- a/packages/data-ui-theme/package.json
+++ b/packages/data-ui-theme/package.json
@@ -4,7 +4,7 @@
   "description": "Themes for data-ui",
   "main": "build/index.js",
   "scripts": {
-    "build": "babel src/ -d lib/ --ignore src/components",
+    "build": "babel src/ -d build/",
     "test": "jest --colors --verbose --coverage"
   },
   "repository": "https://github.com/williaster/data-ui.git",
@@ -17,9 +17,9 @@
   "license": "MIT",
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
+    "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-jest": "^20.0.3",
-    "babel-loader": "^6.4.1",
     "babel-plugin-syntax-jsx": "^6.18.0",
     "babel-preset-airbnb": "^2.2.3",
     "jest": "^19.0.0",

--- a/packages/data-ui-theme/package.json
+++ b/packages/data-ui-theme/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@data-ui/theme",
+  "version": "0.0.0",
+  "description": "Themes for data-ui",
+  "main": "build/index.js",
+  "scripts": {
+    "build": "babel src/ -d lib/ --ignore src/components",
+    "test": "jest --colors --verbose --coverage"
+  },
+  "repository": "https://github.com/williaster/data-ui.git",
+  "keywords": [
+    "data-ui",
+    "visualization",
+    "theme"
+  ],
+  "author": "Chris Williams <chris.williams@airbnb.com>",
+  "license": "MIT",
+  "homepage": "https://github.com/williaster/data-ui#readme",
+  "devDependencies": {
+    "babel-core": "^6.24.1",
+    "babel-jest": "^20.0.3",
+    "babel-loader": "^6.4.1",
+    "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-preset-airbnb": "^2.2.3",
+    "jest": "^19.0.0",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
+    "react-test-renderer": "^15.6.1"
+  },
+  "peerDependencies": {
+    "react": "^15.4.0"
+  }
+}

--- a/packages/data-ui-theme/src/color.js
+++ b/packages/data-ui-theme/src/color.js
@@ -16,28 +16,38 @@ export const allColors = {
   orange: ['#fff4e6', '#ffe8cc', '#ffd8a8', '#ffc078', '#ffa94d', '#ff922b', '#fd7e14', '#f76707', '#e8590c', '#d9480f'],
 };
 
-export const getPaletteForBrightness = (brightness = 7) => (
-  Object.values(allColors).map(x => x[brightness]).sort()
-);
-
 export const grayColors = [
   '#f8f9fa', '#f1f3f5', '#e9ecef', '#dee2e6', '#ced4da', '#adb5bd', '#868e96', '#495057', '#343a40', '#212529',
 ];
 
+export const getPaletteForBrightness = ({
+  brightness = 7,
+  order = ['cyan', 'yellow', 'pink', 'grape', 'teal', 'blue', 'lime', 'violet', 'orange', 'indigo', 'red', 'green'],
+}) => (
+  order.map(key => allColors[key][brightness])
+);
+
 export const dataColorHues = Object.keys(allColors).sort();
 
-export default {
-  default: allColors.cyan[6],
-  dark: allColors.cyan[8],
-  light: allColors.cyan[4],
+export const textColor = grayColors[7];
 
-  disabled: grayColors[6],
+export default {
+  default: allColors.cyan[5],
+  dark: allColors.cyan[7],
+  light: allColors.cyan[3],
+
+  disabled: textColor,
   lightDisabled: grayColors[4],
 
-  grid: grayColors[4],
-  gridDark: grayColors[7],
-  label: grayColors[6],
-  tickLabel: grayColors[6],
+  text: textColor,
+  black: grayColors[9],
+  darkGray: grayColors[8],
+  lightGray: grayColors[3],
 
-  categories: getPaletteForBrightness(7),
+  grid: grayColors[4],
+  gridDark: grayColors[8],
+  label: textColor,
+  tickLabel: textColor,
+
+  categories: getPaletteForBrightness({ brightness: 7 }),
 };

--- a/packages/data-ui-theme/src/color.js
+++ b/packages/data-ui-theme/src/color.js
@@ -1,0 +1,43 @@
+/* eslint max-len: 0 */
+
+// source https://yeun.github.io/open-color/
+export const allColors = {
+  red: ['#fff5f5', '#ffe3e3', '#ffc9c9', '#ffa8a8', '#ff8787', '#ff6b6b', '#fa5252', '#f03e3e', '#e03131', '#c92a2a'],
+  pink: ['#fff0f6', '#ffdeeb', '#fcc2d7', '#faa2c1', '#f783ac', '#f06595', '#e64980', '#d6336c', '#c2255c', '#a61e4d'],
+  grape: ['#f8f0fc', '#f3d9fa', '#eebefa', '#e599f7', '#da77f2', '#cc5de8', '#be4bdb', '#ae3ec9', '#9c36b5', '#862e9c'],
+  violet: ['#f3f0ff', '#e5dbff', '#d0bfff', '#b197fc', '#9775fa', '#845ef7', '#7950f2', '#7048e8', '#6741d9', '#5f3dc4'],
+  indigo: ['#edf2ff', '#dbe4ff', '#bac8ff', '#91a7ff', '#748ffc', '#5c7cfa', '#4c6ef5', '#4263eb', '#3b5bdb', '#364fc7'],
+  blue: ['#e8f7ff', '#ccedff', '#a3daff', '#72c3fc', '#4dadf7', '#329af0', '#228ae6', '#1c7cd6', '#1b6ec2', '#1862ab'],
+  cyan: ['#e3fafc', '#c5f6fa', '#99e9f2', '#66d9e8', '#3bc9db', '#22b8cf', '#15aabf', '#1098ad', '#0c8599', '#0b7285'],
+  teal: ['#e6fcf5', '#c3fae8', '#96f2d7', '#63e6be', '#38d9a9', '#20c997', '#12b886', '#0ca678', '#099268', '#087f5b'],
+  green: ['#ebfbee', '#d3f9d8', '#b2f2bb', '#8ce99a', '#69db7c', '#51cf66', '#40c057', '#37b24d', '#2f9e44', '#2b8a3e'],
+  lime: ['#f4fce3', '#e9fac8', '#d8f5a2', '#c0eb75', '#a9e34b', '#94d82d', '#82c91e', '#74b816', '#66a80f', '#5c940d'],
+  yellow: ['#fff9db', '#fff3bf', '#ffec99', '#ffe066', '#ffd43b', '#fcc419', '#fab005', '#f59f00', '#f08c00', '#e67700'],
+  orange: ['#fff4e6', '#ffe8cc', '#ffd8a8', '#ffc078', '#ffa94d', '#ff922b', '#fd7e14', '#f76707', '#e8590c', '#d9480f'],
+};
+
+export const getPaletteForBrightness = (brightness = 7) => (
+  Object.values(allColors).map(x => x[brightness]).sort()
+);
+
+export const grayColors = [
+  '#f8f9fa', '#f1f3f5', '#e9ecef', '#dee2e6', '#ced4da', '#adb5bd', '#868e96', '#495057', '#343a40', '#212529',
+];
+
+export const dataColorHues = Object.keys(allColors).sort();
+
+export default {
+  default: allColors.cyan[6],
+  dark: allColors.cyan[8],
+  light: allColors.cyan[4],
+
+  disabled: grayColors[6],
+  lightDisabled: grayColors[4],
+
+  grid: grayColors[4],
+  gridDark: grayColors[7],
+  label: grayColors[6],
+  tickLabel: grayColors[6],
+
+  categories: getPaletteForBrightness(7),
+};

--- a/packages/data-ui-theme/src/font.js
+++ b/packages/data-ui-theme/src/font.js
@@ -1,0 +1,63 @@
+const getFont = ({
+  fontFamily,
+  fontSize,
+  letterSpacing = 0,
+  lineHeight,
+  padding,
+}) => ({
+  color: '#222222',
+  fontFamily,
+  fontSize,
+  letterSpacing,
+  lineHeight: `${lineHeight}px`,
+  paddingBottom: padding,
+  paddingTop: padding,
+});
+
+const fontFamily = 'BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif';
+
+export default {
+  fontFamily,
+
+  // weights
+  light: {
+    fontWeight: 200,
+  },
+  bold: {
+    fontWeight: 700,
+  },
+
+  // size
+  tiny: {
+    ...getFont({
+      fontFamily,
+      fontSize: 10,
+      lineHeight: 12,
+      letterSpacing: 0.4,
+    }),
+  },
+  small: {
+    ...getFont({
+      fontFamily,
+      fontSize: 12,
+      lineHeight: 16,
+      letterSpacing: 0.4,
+    }),
+  },
+  regular: {
+    ...getFont({
+      fontFamily,
+      fontSize: 14,
+      lineHeight: 18,
+      letterSpacing: 0.2,
+    }),
+  },
+  large: {
+    ...getFont({
+      fontFamily,
+      fontSize: 18,
+      lineHeight: 24,
+      spacing: 0,
+    }),
+  },
+};

--- a/packages/data-ui-theme/src/font.js
+++ b/packages/data-ui-theme/src/font.js
@@ -1,3 +1,5 @@
+import { textColor } from './color';
+
 const getFont = ({
   fontFamily,
   fontSize,
@@ -5,7 +7,7 @@ const getFont = ({
   lineHeight,
   padding,
 }) => ({
-  color: '#222222',
+  color: textColor,
   fontFamily,
   fontSize,
   letterSpacing,

--- a/packages/data-ui-theme/src/index.js
+++ b/packages/data-ui-theme/src/index.js
@@ -1,5 +1,5 @@
 export { default as color, allColors, getPaletteForBrightness } from './color';
 export { default as font } from './font';
-export { default as size } from './size';
+export { unit } from './size';
 export { default as svgFont } from './svgFont';
 export { default as svgLabel } from './svgLabel';

--- a/packages/data-ui-theme/src/index.js
+++ b/packages/data-ui-theme/src/index.js
@@ -1,0 +1,5 @@
+export { default as color, allColors, getPaletteForBrightness } from './color';
+export { default as font } from './font';
+export { default as size } from './size';
+export { default as svgFont } from './svgFont';
+export { default as svgLabel } from './svgLabel';

--- a/packages/data-ui-theme/src/size.js
+++ b/packages/data-ui-theme/src/size.js
@@ -1,0 +1,2 @@
+/* eslint import/prefer-default-export: 0 */
+export const unit = 8;

--- a/packages/data-ui-theme/src/svgFont.js
+++ b/packages/data-ui-theme/src/svgFont.js
@@ -1,9 +1,12 @@
-const getFont = ({
+import { textColor } from './color';
+
+const getSvgFont = ({
   fontFamily,
   fontSize,
   letterSpacing,
 }) => ({
-  color: '#222222',
+  fill: textColor,
+  stroke: 'none',
   fontFamily,
   fontSize,
   letterSpacing,
@@ -23,40 +26,40 @@ export default {
   },
 
   // alignment
-  left: {
+  start: {
     textAnchor: 'start',
   },
   middle: {
     textAnchor: 'middle',
   },
-  right: {
+  end: {
     textAnchor: 'end',
   },
 
   // size
   tiny: {
-    ...getFont({
+    ...getSvgFont({
       fontFamily,
       fontSize: 10,
       letterSpacing: 0.4,
     }),
   },
   small: {
-    ...getFont({
+    ...getSvgFont({
       fontFamily,
       fontSize: 12,
       letterSpacing: 0.4,
     }),
   },
   regular: {
-    ...getFont({
+    ...getSvgFont({
       fontFamily,
       fontSize: 14,
       letterSpacing: 0.2,
     }),
   },
   large: {
-    ...getFont({
+    ...getSvgFont({
       fontFamily,
       fontSize: 18,
       spacing: 0,

--- a/packages/data-ui-theme/src/svgFont.js
+++ b/packages/data-ui-theme/src/svgFont.js
@@ -1,0 +1,65 @@
+const getFont = ({
+  fontFamily,
+  fontSize,
+  letterSpacing,
+}) => ({
+  color: '#222222',
+  fontFamily,
+  fontSize,
+  letterSpacing,
+});
+
+const fontFamily = 'BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif';
+
+export default {
+  fontFamily,
+
+  // weights
+  light: {
+    fontWeight: 200,
+  },
+  bold: {
+    fontWeight: 700,
+  },
+
+  // alignment
+  left: {
+    textAnchor: 'start',
+  },
+  middle: {
+    textAnchor: 'middle',
+  },
+  right: {
+    textAnchor: 'end',
+  },
+
+  // size
+  tiny: {
+    ...getFont({
+      fontFamily,
+      fontSize: 10,
+      letterSpacing: 0.4,
+    }),
+  },
+  small: {
+    ...getFont({
+      fontFamily,
+      fontSize: 12,
+      letterSpacing: 0.4,
+    }),
+  },
+  regular: {
+    ...getFont({
+      fontFamily,
+      fontSize: 14,
+      letterSpacing: 0.2,
+    }),
+  },
+  large: {
+    ...getFont({
+      fontFamily,
+      fontSize: 18,
+      spacing: 0,
+    }),
+  },
+};

--- a/packages/data-ui-theme/src/svgLabel.js
+++ b/packages/data-ui-theme/src/svgLabel.js
@@ -1,0 +1,42 @@
+import font from './svgFont';
+
+export const baseLabel = {
+  ...font.small,
+  ...font.bold,
+  ...font.middle,
+};
+
+export const baseTickLabel = {
+  ...font.small,
+  ...font.light,
+  ...font.middle,
+};
+
+export const tickLabels = {
+  top: {
+    ...baseTickLabel,
+    dy: '-0.25em',
+  },
+  right: {
+    ...baseTickLabel,
+    ...font.right,
+    dx: '0.25em',
+    dy: '0.25em',
+  },
+  bottom: {
+    ...baseTickLabel,
+    dy: '0.25em',
+  },
+  left: {
+    ...baseTickLabel,
+    ...font.left,
+    dx: '-0.25em',
+    dy: '0.25em',
+  },
+};
+
+export default {
+  baseLabel,
+  baseTickLabel,
+  tickLabels,
+};

--- a/packages/data-ui-theme/src/svgLabel.js
+++ b/packages/data-ui-theme/src/svgLabel.js
@@ -19,7 +19,7 @@ export const tickLabels = {
   },
   right: {
     ...baseTickLabel,
-    ...font.right,
+    ...font.start,
     dx: '0.25em',
     dy: '0.25em',
   },
@@ -29,7 +29,7 @@ export const tickLabels = {
   },
   left: {
     ...baseTickLabel,
-    ...font.left,
+    ...font.end,
     dx: '-0.25em',
     dy: '0.25em',
   },

--- a/packages/data-ui-theme/test/color.test.js
+++ b/packages/data-ui-theme/test/color.test.js
@@ -1,0 +1,15 @@
+import { color, allColors, getPaletteForBrightness } from '../src';
+
+describe('color', () => {
+  test('`color` should be defined', () => {
+    expect(color).toBeDefined();
+  });
+
+  test('`allColors` should be defined', () => {
+    expect(allColors).toBeDefined();
+  });
+
+  test('`getPaletteForBrightness` should be defined', () => {
+    expect(getPaletteForBrightness).toBeDefined();
+  });
+});

--- a/packages/data-ui-theme/test/font.test.js
+++ b/packages/data-ui-theme/test/font.test.js
@@ -1,0 +1,19 @@
+import { font } from '../src';
+
+describe('font', () => {
+  test('it should define fontFamily', () => {
+    expect(font.fontFamily).toBeDefined();
+  });
+
+  test('it should define weights', () => {
+    expect(font.light).toBeDefined();
+    expect(font.bold).toBeDefined();
+  });
+
+  test('it should define sizes', () => {
+    expect(font.tiny).toBeDefined();
+    expect(font.small).toBeDefined();
+    expect(font.regular).toBeDefined();
+    expect(font.large).toBeDefined();
+  });
+});

--- a/packages/data-ui-theme/test/svgFont.test.js
+++ b/packages/data-ui-theme/test/svgFont.test.js
@@ -11,9 +11,9 @@ describe('svgFont', () => {
   });
 
   test('it should define alignments', () => {
-    expect(svgFont.left).toBeDefined();
+    expect(svgFont.start).toBeDefined();
     expect(svgFont.middle).toBeDefined();
-    expect(svgFont.right).toBeDefined();
+    expect(svgFont.end).toBeDefined();
   });
 
   test('it should define sizes', () => {

--- a/packages/data-ui-theme/test/svgFont.test.js
+++ b/packages/data-ui-theme/test/svgFont.test.js
@@ -1,0 +1,25 @@
+import { svgFont } from '../src';
+
+describe('svgFont', () => {
+  test('it should define fontFamily', () => {
+    expect(svgFont.fontFamily).toBeDefined();
+  });
+
+  test('it should define weights', () => {
+    expect(svgFont.light).toBeDefined();
+    expect(svgFont.bold).toBeDefined();
+  });
+
+  test('it should define alignments', () => {
+    expect(svgFont.left).toBeDefined();
+    expect(svgFont.middle).toBeDefined();
+    expect(svgFont.right).toBeDefined();
+  });
+
+  test('it should define sizes', () => {
+    expect(svgFont.tiny).toBeDefined();
+    expect(svgFont.small).toBeDefined();
+    expect(svgFont.regular).toBeDefined();
+    expect(svgFont.large).toBeDefined();
+  });
+});

--- a/packages/data-ui-theme/test/svgLabel.test.js
+++ b/packages/data-ui-theme/test/svgLabel.test.js
@@ -1,0 +1,19 @@
+import { svgLabel } from '../src';
+
+describe('svgLabel', () => {
+  test('it should define a baseLabel', () => {
+    expect(svgLabel.baseLabel).toBeDefined();
+  });
+
+  test('it should define a baseTickLabel', () => {
+    expect(svgLabel.baseTickLabel).toBeDefined();
+  });
+
+  test('it should define tick labels for all orientations', () => {
+    expect(svgLabel.tickLabels).toBeDefined();
+    expect(svgLabel.tickLabels.top).toBeDefined();
+    expect(svgLabel.tickLabels.right).toBeDefined();
+    expect(svgLabel.tickLabels.bottom).toBeDefined();
+    expect(svgLabel.tickLabels.left).toBeDefined();
+  });
+});

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -2,6 +2,7 @@
 Storybook of @data-ui examples. See it live at [williaster.github.io/data-ui](https://williaster.github.io/data-ui).
 
 ## @data-ui packages
-+ [@data-ui/xy-chart](https://github.com/williaster/data-ui/tree/master/packages/xy-chart)
-+ [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table)
-+ @data-ui/demo
+- [@data-ui/xy-chart](https://github.com/williaster/data-ui/tree/master/packages/xy-chart)
+- [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table)
+- [@data-ui/theme](https://github.com/williaster/data-ui/tree/master/packages/theme)
+- @data-ui/demo

--- a/packages/demo/examples/data-table/tableStyles.js
+++ b/packages/demo/examples/data-table/tableStyles.js
@@ -11,6 +11,7 @@ const tableStyles = {
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
+    ...font.regular,
     ...font.bold,
   },
 
@@ -18,7 +19,7 @@ const tableStyles = {
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
-    ...font.small,
+    ...font.regular,
     ...font.light,
     background: index % 2 === 0 ? color.lightGray : null,
   }),

--- a/packages/demo/examples/xy-chart/index.jsx
+++ b/packages/demo/examples/xy-chart/index.jsx
@@ -46,6 +46,8 @@ const ResponsiveXYChart = withScreenSize(({ screenWidth, children, ...rest }) =>
   </XYChart>
 ));
 
+const { colors } = theme;
+
 // @todo: factor these into separate stories to more fully demo each component
 export default [
   {
@@ -58,14 +60,14 @@ export default [
       >
         <LinearGradient
           id="gradient"
-          from="#00A699"
-          to="#84D2CB"
+          from={colors.default}
+          to={colors.dark}
         />
         <PatternLines
           id="lines"
           height={5}
           width={5}
-          stroke="#00A699"
+          stroke={colors.default}
           strokeWidth={1}
           orientation={['diagonal']}
         />
@@ -90,8 +92,8 @@ export default [
         <YAxis label="Price ($)" numTicks={4} />
         <LinearGradient
           id="aqua_lightaqua_gradient"
-          from="#00A699"
-          to="#84D2CB"
+          from={colors.default}
+          to={colors.dark}
         />
         <BarSeries
           data={timeSeriesData}
@@ -101,7 +103,7 @@ export default [
         <LineSeries
           data={timeSeriesData}
           label="Apple Stock"
-          stroke="#484848"
+          stroke={colors.text}
         />
         <XAxis label="Time" numTicks={5} />
       </ResponsiveXYChart>
@@ -118,8 +120,8 @@ export default [
         <YAxis label="Price ($)" numTicks={4} orientation="left" />
         <LinearGradient
           id="aqua_lightaqua_gradient"
-          from="#00A699"
-          to="#84D2CB"
+          from={colors.default}
+          to={colors.dark}
         />
         <BarSeries
           data={timeSeriesData}
@@ -147,7 +149,7 @@ export default [
         <LineSeries
           data={timeSeriesData.map(d => ({ ...d, y: Math.random() > 0.5 ? d.y * 2 : d.y / 2 }))}
           label="Apple Stock 2"
-          stroke="#484848"
+          stroke={colors.black}
           strokeDasharray="3 3"
         />
         <XAxis label="Time" numTicks={5} />
@@ -221,8 +223,8 @@ export default [
       >
         <LinearGradient
           id="aqua_lightaqua_gradient"
-          from="#00A699"
-          to="#84D2CB"
+          from={colors.default}
+          to={colors.dark}
         />
         <BarSeries
           data={categoricalData}
@@ -246,7 +248,7 @@ export default [
           id="interval_pattern"
           height={8}
           width={8}
-          stroke="#84D2CB"
+          stroke={colors.dark}
           strokeWidth={1}
           orientation={['diagonal']}
         />
@@ -275,8 +277,8 @@ export default [
         <YAxis label="$$$" numTicks={4} />
         <LinearGradient
           id="aqua_lightaqua_gradient"
-          from="#00A699"
-          to="#84D2CB"
+          from={colors.default}
+          to={colors.dark}
         />
         <BarSeries
           data={timeSeriesData}

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
     "@data-ui/data-table": "^0.0.17",
-    "@data-ui/theme": "^0.0.1",
+    "@data-ui/theme": "^0.0.0",
     "@data-ui/xy-chart": "^0.0.9",
     "@kadira/storybook": "^2.35.3",
     "@vx/mock-data": "0.0.95",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -7,7 +7,7 @@
     "gh-pages:build": "build-storybook -o _gh-pages -c ./storybook-config",
     "gh-pages:publish": "git-directory-deploy --directory _gh-pages",
     "gh-pages": "npm run gh-pages:clean && npm run gh-pages:build && npm run gh-pages:publish && npm run gh-pages:clean",
-    "storybook": "start-storybook -p 9001 -c ./storybook-config",
+    "dev": "start-storybook -p 9001 -c ./storybook-config",
     "test": "echo no tests in @data-ui/demo"
   },
   "repository": "https://github.com/williaster/data-ui.git",
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
     "@data-ui/data-table": "^0.0.17",
+    "@data-ui/theme": "^0.0.1",
     "@data-ui/xy-chart": "^0.0.9",
     "@kadira/storybook": "^2.35.3",
     "@vx/mock-data": "0.0.95",

--- a/packages/demo/themes/DefaultTheme.js
+++ b/packages/demo/themes/DefaultTheme.js
@@ -1,73 +1,7 @@
-const unit = 8;
-
-const color = {
-  lightGray: '#F2F2F2',
-  mediumGray: '#DBDBDB',
-  darkGray: '#767676',
-  black: '#474747',
-  coral: '#D43242',
-};
-
-const getFont = ({ fontFamily, fontSize, letterSpacing = 0, lineHeight, padding }) => ({
-  color: color.black,
-  fontFamily,
-  fontSize,
-  letterSpacing,
-  lineHeight: `${lineHeight}px`,
-  paddingBottom: padding,
-  paddingTop: padding,
-});
-
-const fontFamily = 'BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif';
+import { color, font, unit } from '@data-ui/theme';
 
 export default {
   color,
-
-  font: {
-    fontFamily,
-
-    // weights
-    light: {
-      fontWeight: 200,
-    },
-    bold: {
-      fontWeight: 700,
-    },
-
-    // size
-    tiny: {
-      ...getFont({
-        fontFamily,
-        fontSize: 12,
-        lineHeight: 16,
-        letterSpacing: 0.4,
-      }),
-    },
-    small: {
-      ...getFont({
-        fontFamily,
-        fontSize: 14,
-        lineHeight: 18,
-        letterSpacing: 0.2,
-      }),
-    },
-    regular: {
-      ...getFont({
-        fontFamily,
-        fontSize: 18,
-        lineHeight: 24,
-        spacing: 0,
-      }),
-    },
-    large: {
-      ...getFont({
-        fontFamily,
-        fontSize: 22,
-        lineHeight: 28,
-        letterSpacing: -0.2,
-      }),
-    },
-  },
-
+  font,
   unit,
 };

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -68,3 +68,10 @@ A subset of [vx](https://github.com/hshoff/vx/blob/master/) gradients and patter
 npm install
 npm run dev # or 'prod'
 ```
+
+## @data-ui packages
+- @data-ui/xy-chart
+- [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table)
+- [@data-ui/theme](https://github.com/williaster/data-ui/tree/master/packages/theme)
+- [@data-ui/demo](https://github.com/williaster/data-ui/tree/master/packages/demo)
+

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -20,6 +20,7 @@
   "author": "Chris Williams <chris.williams@airbnb.com>",
   "license": "MIT",
   "dependencies": {
+    "@data-ui/theme": "0.0.1",
     "@vx/axis": "0.0.120",
     "@vx/curve": "0.0.112",
     "@vx/glyph": "0.0.120",

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -20,7 +20,7 @@
   "author": "Chris Williams <chris.williams@airbnb.com>",
   "license": "MIT",
   "dependencies": {
-    "@data-ui/theme": "0.0.1",
+    "@data-ui/theme": "^0.0.0",
     "@vx/axis": "0.0.120",
     "@vx/curve": "0.0.112",
     "@vx/glyph": "0.0.120",

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -144,10 +144,10 @@ class XYChart extends React.PureComponent {
               yScale={yScale}
               width={innerWidth}
               height={innerHeight}
-              stroke={theme.gridStyles && theme.gridStyles.stroke}
-              strokeWidth={theme.gridStyles && theme.gridStyles.strokeWidth}
               numTicksRows={showYGrid && numYTicks}
               numTicksColumns={showXGrid && numXTicks}
+              stroke={theme.gridStyles && theme.gridStyles.stroke}
+              strokeWidth={theme.gridStyles && theme.gridStyles.strokeWidth}
             />}
           {React.Children.map(children, (Child) => {
             const name = componentName(Child);

--- a/packages/xy-chart/src/theme.js
+++ b/packages/xy-chart/src/theme.js
@@ -1,44 +1,10 @@
-export const unit = 8;
+import { color, svgLabel, unit } from '@data-ui/theme';
 
-export const colors = {
-  default: '#00A699',
-  dark: '#00514A',
-  light: '#84D2CB',
-
-  disabled: '#484848',
-  lightDisabled: '#DBDBDB',
-
-  grid: '#DBDBDB',
-  gridDark: '#484848',
-  label: '#767676',
-  tickLabel: '#767676',
-
-  categories: [
-    '#00A699', // aqua
-    '#84D2CB', // light aqua
-    '#FFB400', // yellow-orange
-    '#7b0051', // purple
-    '#FC642D', // red-orange
-    '#9BE382', // lime
-    '#484848', // dark grey
-    '#FFBAA0', // peach
-    '#008C99', // dark aqua
-  ],
-};
+export const colors = color;
 
 export const gridStyles = {
   stroke: colors.grid,
   strokeWidth: 1,
-};
-
-export const fontFamily = 'BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif';
-
-const baseLabel = {
-  fill: colors.label,
-  fontFamily,
-  fontSize: 12,
-  fontWeight: 700,
-  textAnchor: 'middle',
 };
 
 export const xAxisStyles = {
@@ -46,10 +12,10 @@ export const xAxisStyles = {
   strokeWidth: 2,
   label: {
     bottom: {
-      ...baseLabel,
+      ...svgLabel.baseLabel,
     },
     top: {
-      ...baseLabel,
+      ...svgLabel.baseLabel,
     },
   },
 };
@@ -59,19 +25,12 @@ export const yAxisStyles = {
   strokeWidth: 1,
   label: {
     left: {
-      ...baseLabel,
+      ...svgLabel.baseLabel,
     },
     right: {
-      ...baseLabel,
+      ...svgLabel.baseLabel,
     },
   },
-};
-
-const baseTickLabel = {
-  fill: colors.tickLabel,
-  fontFamily,
-  fontSize: 12,
-  fontWeight: 200,
 };
 
 export const xTickStyles = {
@@ -79,14 +38,10 @@ export const xTickStyles = {
   length: 1 * unit,
   label: {
     bottom: {
-      ...baseTickLabel,
-      textAnchor: 'middle',
-      dy: '0.25em',
+      ...svgLabel.tickLabels.bottom,
     },
     top: {
-      ...baseTickLabel,
-      textAnchor: 'middle',
-      dy: '-0.25em',
+      ...svgLabel.tickLabels.top,
     },
   },
 };
@@ -96,36 +51,19 @@ export const yTickStyles = {
   length: 1 * unit,
   label: {
     left: {
-      ...baseTickLabel,
-      textAnchor: 'end',
-      dx: '-0.25em',
-      dy: '0.25em',
+      ...svgLabel.tickLabels.left,
     },
     right: {
-      ...baseTickLabel,
-      textAnchor: 'start',
-      dx: '0.25em',
-      dy: '0.25em',
+      ...svgLabel.tickLabels.right,
     },
   },
-};
-
-export const labelStyles = {
-  fill: colors.label,
-  fontFamily,
-  fontSize: 12,
-  fontWeight: 200,
-  dx: '0.5em',
-  dy: '0.5em',
 };
 
 export default {
   colors,
   gridStyles,
-  unit,
   xAxisStyles,
   xTickStyles,
   yAxisStyles,
   yTickStyles,
-  labelStyles,
 };


### PR DESCRIPTION
This PR consolidates themes across packages into a unified `@data-ui/theme` package. The new theme includes colors from the [open-color project](https://yeun.github.io/open-color/) which will be beneficial for more diverse color palettes.

![image](https://user-images.githubusercontent.com/4496521/27654180-49350636-5bf6-11e7-8009-5ecc8403b8ac.png)
