### PR TITLE
bugfixes for leaf node trimming + overflow in control panel

### DIFF
--- a/packages/event-flow/src/components/App.jsx
+++ b/packages/event-flow/src/components/App.jsx
@@ -233,7 +233,11 @@ class App extends React.PureComponent {
       minEventCount,
     });
 
-    const scales = this.getScales(graph, visualizationWidth, height);
+    const scales = { // use the previous color scale in case event types are hidden
+      ...this.getScales(graph, visualizationWidth, height),
+      [NODE_COLOR_SCALE]: this.state.scales[NODE_COLOR_SCALE],
+    };
+
     this.setState({ graph, scales, minEventCount });
   }
 
@@ -253,7 +257,6 @@ class App extends React.PureComponent {
       selectedNode,
     } = this.state;
 
-    console.log('graph', graph);
     const { width, height } = this.props;
 
     let metaData = graph.metaData;

--- a/packages/event-flow/src/components/ControlPanel.jsx
+++ b/packages/event-flow/src/components/ControlPanel.jsx
@@ -32,7 +32,7 @@ const styles = StyleSheet.create({
     fontFamily,
     fontSize: 12,
     fontColor: '#767676',
-    width: `calc(100% - ${2 * padding}px)`,
+    width: 'auto',
     height: '100%',
     padding: `${0}px ${padding}px`,
     background: '#fff',
@@ -40,6 +40,7 @@ const styles = StyleSheet.create({
 
   innerContainer: {
     overflowY: 'auto',
+    height: 'inherit',
   },
 
   flexRow: {


### PR DESCRIPTION
fixes a bug where hidden event types (from legend) are filtered from the vis upon leaf node trimming. also prevents overflow in control panel when it's unnecessary. 