### PR TITLE
[xy-chart] add <AreaSeries />, examples, and tests. 

### DIFF
--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -7,6 +7,7 @@ import {
   XAxis,
   YAxis,
 
+  AreaSeries,
   BarSeries,
   IntervalSeries,
   LineSeries,
@@ -54,7 +55,7 @@ export default {
   usage: readme,
   examples: [
     {
-      description: 'XYChart, BarSeries, PatternLines, Gradient',
+      description: 'BarSeries -- no axes',
       components: [XYChart, BarSeries, LinearGradient, PatternLines],
       example: () => (
         <ResponsiveXYChart
@@ -69,15 +70,16 @@ export default {
           />
           <PatternLines
             id="lines"
-            height={5}
-            width={5}
-            stroke={colors.default}
+            height={8}
+            width={8}
+            stroke={colors.categories[2]}
             strokeWidth={1}
-            orientation={['diagonal']}
+            orientation={['horizontal', 'vertical']}
           />
           <BarSeries
             data={timeSeriesData.map((d, i) => ({
-              ...d, fill: `url(#${i === 2 ? 'lines' : 'gradient'})`,
+              ...d,
+              fill: `url(#${i === 2 ? 'lines' : 'gradient'})`,
             }))}
             label="Apple Stock"
             fill="url(#aqua_lightaqua_gradient)"
@@ -86,60 +88,7 @@ export default {
       ),
     },
     {
-      description: 'BarSeries, LineSeries, XAxis, YAxis',
-      components: [BarSeries, LineSeries, XAxis, YAxis],
-      example: () => (
-        <ResponsiveXYChart
-          ariaLabel="Required label"
-          xScale={{ type: 'time' }}
-          yScale={{ type: 'linear' }}
-        >
-          <YAxis label="Price ($)" numTicks={4} />
-          <LinearGradient
-            id="aqua_lightaqua_gradient"
-            from={colors.default}
-            to={colors.dark}
-          />
-          <BarSeries
-            data={timeSeriesData}
-            label="Apple Stock"
-            fill="url(#aqua_lightaqua_gradient)"
-          />
-          <LineSeries
-            data={timeSeriesData}
-            label="Apple Stock"
-            stroke={colors.text}
-          />
-          <XAxis label="Time" numTicks={5} />
-        </ResponsiveXYChart>
-      ),
-    },
-    {
-      description: 'XAxis, YAxis -- orientation',
-      components: [XAxis, YAxis],
-      example: () => (
-        <ResponsiveXYChart
-          ariaLabel="Required label"
-          xScale={{ type: 'time' }}
-          yScale={{ type: 'linear' }}
-        >
-          <YAxis label="Price ($)" numTicks={4} orientation="left" />
-          <LinearGradient
-            id="aqua_lightaqua_gradient"
-            from={colors.default}
-            to={colors.dark}
-          />
-          <BarSeries
-            data={timeSeriesData}
-            label="Apple Stock"
-            fill="url(#aqua_lightaqua_gradient)"
-          />
-          <XAxis label="Time" numTicks={5} orientation="top" />
-        </ResponsiveXYChart>
-      ),
-    },
-    {
-      description: 'Multiple <LineSeries />',
+      description: 'LineSeries',
       components: [LineSeries],
       example: () => (
         <ResponsiveXYChart
@@ -158,6 +107,45 @@ export default {
             label="Apple Stock 2"
             stroke={colors.black}
             strokeDasharray="3 3"
+            strokeLinecap="butt"
+          />
+          <XAxis label="Time" numTicks={5} />
+        </ResponsiveXYChart>
+      ),
+    },
+    {
+      description: 'AreaSeries',
+      components: [AreaSeries],
+      example: () => (
+        <ResponsiveXYChart
+          ariaLabel="Required label"
+          xScale={{ type: 'time' }}
+          yScale={{ type: 'linear' }}
+        >
+          <LinearGradient
+            id="area_gradient"
+            from={colors.categories[2]}
+            to="#fff"
+          />
+          <PatternLines
+            id="area_pattern"
+            height={12}
+            width={12}
+            stroke={colors.categories[2]}
+            strokeWidth={1}
+            orientation={['diagonal']}
+          />
+          <AreaSeries
+            data={timeSeriesData}
+            label="Apple Stock"
+            fill="url(#area_gradient)"
+            strokeWidth={null}
+          />
+          <AreaSeries
+            data={timeSeriesData}
+            label="Apple Stock 2"
+            fill="url(#area_pattern)"
+            stroke={colors.categories[2]}
           />
           <XAxis label="Time" numTicks={5} />
         </ResponsiveXYChart>
@@ -224,7 +212,7 @@ export default {
       ),
     },
     {
-      description: 'Categorical <BarSeries />',
+      description: 'Categorical BarSeries',
       components: [XYChart, BarSeries],
       example: () => (
         <ResponsiveXYChart
@@ -247,7 +235,7 @@ export default {
       ),
     },
     {
-      description: '<IntervalSeries />',
+      description: 'IntervalSeries',
       components: [IntervalSeries, LineSeries],
       example: () => (
         <ResponsiveXYChart
@@ -275,6 +263,59 @@ export default {
             showPoints
           />
           <XAxis />
+        </ResponsiveXYChart>
+      ),
+    },
+    {
+      description: 'Mixed series',
+      components: [BarSeries, LineSeries, XAxis, YAxis],
+      example: () => (
+        <ResponsiveXYChart
+          ariaLabel="Required label"
+          xScale={{ type: 'time' }}
+          yScale={{ type: 'linear' }}
+        >
+          <YAxis label="Price ($)" numTicks={4} />
+          <LinearGradient
+            id="aqua_lightaqua_gradient"
+            to="#faa2c1"
+            from="#e64980"
+          />
+          <BarSeries
+            data={timeSeriesData}
+            label="Apple Stock"
+            fill="url(#aqua_lightaqua_gradient)"
+          />
+          <LineSeries
+            data={timeSeriesData}
+            label="Apple Stock"
+            stroke={colors.text}
+          />
+          <XAxis label="Time" numTicks={5} />
+        </ResponsiveXYChart>
+      ),
+    },
+    {
+      description: 'XAxis, YAxis -- orientation',
+      components: [XAxis, YAxis],
+      example: () => (
+        <ResponsiveXYChart
+          ariaLabel="Required label"
+          xScale={{ type: 'time' }}
+          yScale={{ type: 'linear' }}
+        >
+          <YAxis label="Price ($)" numTicks={4} orientation="left" />
+          <LinearGradient
+            id="aqua_lightaqua_gradient"
+            from={colors.default}
+            to={colors.dark}
+          />
+          <BarSeries
+            data={timeSeriesData}
+            label="Apple Stock"
+            fill="url(#aqua_lightaqua_gradient)"
+          />
+          <XAxis label="Time" numTicks={5} orientation="top" />
         </ResponsiveXYChart>
       ),
     },

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -30,7 +30,7 @@
     "@vx/pattern": "0.0.120",
     "@vx/responsive": "0.0.120",
     "@vx/scale": "0.0.117",
-    "@vx/shape": "0.0.120",
+    "@vx/shape": "0.0.131",
     "d3-array": "^1.2.0",
     "prop-types": "^15.5.10"
   },

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -2,6 +2,7 @@ export { default as XAxis } from './axis/XAxis';
 export { default as YAxis } from './axis/YAxis';
 export { default as XYChart } from './chart/XYChart';
 
+export { default as AreaSeries } from './series/AreaSeries';
 export { default as BarSeries } from './series/BarSeries';
 export { default as GroupedBarSeries } from './series/GroupedBarSeries';
 export { default as IntervalSeries } from './series/IntervalSeries';

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { AreaClosed, LinePath } from '@vx/shape';
+import { Group } from '@vx/group';
+
+import interpolatorLookup from '../utils/interpolatorLookup';
+import { callOrValue, isDefined } from '../utils/chartUtils';
+import { colors } from '../theme';
+import { lineSeriesDataShape } from '../utils/propShapes';
+
+const propTypes = {
+  data: lineSeriesDataShape.isRequired,
+  fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  fillOpacity: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  interpolation: PropTypes.oneOf(['linear', 'cardinal']), // @todo add more
+  label: PropTypes.string.isRequired,
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  strokeLinecap: PropTypes.oneOf(['butt', 'square', 'round', 'inherit']),
+  // these will likely be injected by the parent chart
+  xScale: PropTypes.func,
+  yScale: PropTypes.func,
+};
+
+const defaultProps = {
+  interpolation: 'cardinal',
+  stroke: colors.default,
+  strokeWidth: 3,
+  strokeDasharray: null,
+  strokeLinecap: 'round',
+  fill: colors.default,
+  fillOpacity: 0.3,
+  xScale: null,
+  yScale: null,
+};
+
+const x = d => d.x;
+const y = d => d.y;
+const defined = d => isDefined(y(d));
+
+export default function AreaSeries({
+  data,
+  xScale,
+  yScale,
+  stroke,
+  strokeWidth,
+  strokeDasharray,
+  strokeLinecap,
+  fill,
+  fillOpacity,
+  interpolation,
+  label,
+}) {
+  if (!xScale || !yScale) return null;
+  const strokeWidthValue = callOrValue(strokeWidth, data);
+  const curve = interpolatorLookup[interpolation] || interpolatorLookup.cardinal;
+  return (
+    <Group>
+      <AreaClosed
+        key={`${label}-area`}
+        data={data}
+        x={x}
+        y={y}
+        xScale={xScale}
+        yScale={yScale}
+        fill={callOrValue(fill, data)}
+        fillOpacity={callOrValue(fillOpacity, data)}
+        stroke="transparent"
+        strokeWidth={strokeWidthValue}
+        curve={curve}
+        defined={defined}
+      />
+      {strokeWidthValue > 0 &&
+        <LinePath
+          key={`${label}-line`}
+          data={data}
+          x={x}
+          y={y}
+          xScale={xScale}
+          yScale={yScale}
+          stroke={callOrValue(stroke, data)}
+          strokeWidth={strokeWidthValue}
+          strokeDasharray={callOrValue(strokeDasharray, data)}
+          strokeLinecap={strokeLinecap}
+          curve={curve}
+          glyph={null}
+          defined={defined}
+        />}
+    </Group>
+  );
+}
+
+AreaSeries.propTypes = propTypes;
+AreaSeries.defaultProps = defaultProps;
+AreaSeries.displayName = 'AreaSeries';

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -18,7 +18,7 @@ const propTypes = {
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
-
+  strokeLinecap: PropTypes.oneOf(['butt', 'square', 'round', 'inherit']),
   // these will likely be injected by the parent chart
   xScale: PropTypes.func,
   yScale: PropTypes.func,
@@ -30,12 +30,14 @@ const defaultProps = {
   stroke: colors.default,
   strokeDasharray: null,
   strokeWidth: 3,
+  strokeLinecap: 'round',
   xScale: null,
   yScale: null,
 };
 
 const x = d => d.x;
 const y = d => d.y;
+const defined = d => isDefined(y(d));
 
 export default function LineSeries({
   data,
@@ -45,6 +47,7 @@ export default function LineSeries({
   stroke,
   strokeDasharray,
   strokeWidth,
+  strokeLinecap,
   xScale,
   yScale,
 }) {
@@ -61,7 +64,9 @@ export default function LineSeries({
       stroke={callOrValue(stroke)}
       strokeWidth={callOrValue(strokeWidth)}
       strokeDasharray={callOrValue(strokeDasharray)}
+      strokeLinecap={strokeLinecap}
       curve={interpolation === 'linear' ? curveLinear : curveCardinal}
+      defined={defined}
       glyph={showPoints && ((d, i) => (
         isDefined(x(d)) && isDefined(y(d)) &&
           <GlyphDot

--- a/packages/xy-chart/src/utils/interpolatorLookup.js
+++ b/packages/xy-chart/src/utils/interpolatorLookup.js
@@ -1,0 +1,6 @@
+import { curveCardinal, curveLinear } from '@vx/curve';
+
+export default {
+  linear: curveLinear,
+  cardinal: curveCardinal,
+};

--- a/packages/xy-chart/test/AreaSeries.test.js
+++ b/packages/xy-chart/test/AreaSeries.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { AreaClosed, LinePath } from '@vx/shape';
+
+import { XYChart, AreaSeries } from '../src/';
+
+describe('<LineSeries />', () => {
+  const mockProps = {
+    xScale: { type: 'time' },
+    yScale: { type: 'linear' },
+    width: 100,
+    height: 100,
+    margin: { top: 10, right: 10, bottom: 10, left: 10 },
+    ariaLabel: 'label',
+  };
+
+  const mockData = [
+    { date: new Date('2017-01-05'), cat: 'a', num: 15 },
+    { date: new Date('2018-01-05'), cat: 'b', num: 51 },
+    { date: new Date('2019-01-05'), cat: 'c', num: 377 },
+  ];
+
+  test('it should be defined', () => {
+    expect(AreaSeries).toBeDefined();
+  });
+
+  test('it should not render without x- and y-scales', () => {
+    expect(shallow(<AreaSeries label="" data={[]} />).type()).toBeNull();
+  });
+
+  test('it should render an AreaClosed for each AreaSeries', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <AreaSeries label="l" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <AreaSeries label="l2" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+      </XYChart>,
+    );
+    expect(wrapper.find(AreaSeries).length).toBe(2);
+    expect(wrapper.find(AreaSeries).first().dive().find(AreaClosed).length).toBe(1);
+  });
+
+  test('it should render a LinePath if strokeWidth is non-zero', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const wrapperWithLine = shallow(
+      <XYChart {...mockProps} >
+        <AreaSeries label="l" data={data} strokeWidth={3} />
+      </XYChart>,
+    );
+    const areaSeriesWithLinePath = wrapperWithLine.find(AreaSeries).dive();
+    expect(areaSeriesWithLinePath.find(LinePath).length).toBe(1);
+
+    const wrapperNoLine = shallow(
+      <XYChart {...mockProps} >
+        <AreaSeries label="l" data={data} strokeWidth={0} />
+      </XYChart>,
+    );
+
+    const areaSeriesNoLinePath = wrapperNoLine.find(AreaSeries).dive();
+    expect(areaSeriesNoLinePath.find(LinePath).length).toBe(0);
+  });
+});


### PR DESCRIPTION
This PR adds `<AreaSeries />` to `@data-ui/xy-chart` and fixes some issues when bumping the `@vx/shape` package.

![image](https://user-images.githubusercontent.com/4496521/28600497-30665354-7167-11e7-8c0b-d893ed2b7869.png)
