### PR TITLE
[xy-chart] add displayName to CrossHair and Voronoi for minimization robustness

### DIFF
--- a/packages/xy-chart/src/chart/CrossHair.jsx
+++ b/packages/xy-chart/src/chart/CrossHair.jsx
@@ -110,5 +110,6 @@ function CrossHair({
 
 CrossHair.propTypes = propTypes;
 CrossHair.defaultProps = defaultProps;
+CrossHair.displayName = 'CrossHair';
 
 export default CrossHair;

--- a/packages/xy-chart/src/chart/Voronoi.jsx
+++ b/packages/xy-chart/src/chart/Voronoi.jsx
@@ -68,5 +68,6 @@ class Voronoi extends React.PureComponent {
 
 Voronoi.propTypes = propTypes;
 Voronoi.defaultProps = defaultProps;
+Voronoi.displayName = 'Voronoi';
 
 export default Voronoi;


### PR DESCRIPTION
This PR explicitly sets the `displayName` of the `CrossHair` and `Voronoi` components. This fixes a bug where, upon minimization, function names are lost and `XYChart` cannot accurately find and render the `CrossHair` component.