### PR TITLE
[demo] displayName fixes.

### DIFF
--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -39,6 +39,8 @@ import {
 import WithToggle from '../shared/WithToggle';
 
 const { colors } = theme;
+PatternLines.displayName = 'PatternLines';
+LinearGradient.displayName = 'LinearGradient';
 
 export default {
   usage: readme,

--- a/packages/demo/examples/02-histogram/index.jsx
+++ b/packages/demo/examples/02-histogram/index.jsx
@@ -20,6 +20,9 @@ import HistogramPlayground from './HistogramPlayground';
 import { normal, logNormal, mus, categorical, binnedCategorical, binnedNumeric } from './data';
 import renderTooltip from './renderHistogramTooltip';
 
+PatternLines.displayName = 'PatternLines';
+LinearGradient.displayName = 'LinearGradient';
+
 const ResponsiveHistogram = withScreenSize(({ screenWidth, children, ...rest }) => (
   <Histogram
     width={Math.min(1000, screenWidth / 1.3)}

--- a/packages/demo/examples/03-sparkline/BarSeriesExamples.jsx
+++ b/packages/demo/examples/03-sparkline/BarSeriesExamples.jsx
@@ -18,6 +18,9 @@ import { color, allColors } from '@data-ui/theme';
 import Example from './Example';
 import Spacer from '../shared/Spacer';
 
+PatternLines.displayName = 'PatternLines';
+LinearGradient.displayName = 'LinearGradient';
+
 const sparklineProps = {
   ariaLabel: 'This is a Sparkline of...',
   width: 500,
@@ -35,7 +38,7 @@ export default [
       BarSeries,
     ],
     example: () => (
-      <Spacer top={2} left={2}>
+      <Spacer top={2} left={2} flexDirection="column">
         <Example title="Default">
           <Sparkline
             {...sparklineProps}

--- a/packages/demo/examples/03-sparkline/Example.jsx
+++ b/packages/demo/examples/03-sparkline/Example.jsx
@@ -6,7 +6,7 @@ import Title from '../shared/Title';
 
 export default function Example({ title, children }) {
   return (
-    <Spacer>
+    <Spacer flexDirection="column">
       {title && <Title>{title}</Title>}
       {children}
     </Spacer>

--- a/packages/demo/examples/03-sparkline/KitchenSinkExamples.jsx
+++ b/packages/demo/examples/03-sparkline/KitchenSinkExamples.jsx
@@ -18,6 +18,9 @@ import {
 } from '@data-ui/sparkline';
 
 import Example from './Example';
+import Spacer from '../shared/Spacer';
+
+PatternLines.displayName = 'PatternLines';
 
 const sparklineProps = {
   ariaLabel: 'This is a Sparkline of...',
@@ -42,7 +45,7 @@ export default [
       BandLine,
     ],
     example: () => (
-      <div>
+      <Spacer top={2} left={2} flexDirection="column">
         <Example>
           <Sparkline
             {...sparklineProps}
@@ -214,7 +217,7 @@ export default [
             />
           </Sparkline>
         </Example>
-      </div>
+      </Spacer>
     ),
   },
 ];

--- a/packages/demo/examples/03-sparkline/LineSeriesExamples.jsx
+++ b/packages/demo/examples/03-sparkline/LineSeriesExamples.jsx
@@ -21,6 +21,9 @@ import { color, allColors } from '@data-ui/theme';
 import Example from './Example';
 import Spacer from '../shared/Spacer';
 
+PatternLines.displayName = 'PatternLines';
+LinearGradient.displayName = 'LinearGradient';
+
 const sparklineProps = {
   ariaLabel: 'This is a Sparkline of...',
   width: 500,
@@ -39,7 +42,7 @@ export default [
       LineSeries,
     ],
     example: () => (
-      <Spacer top={2} left={2}>
+      <Spacer top={2} left={2} flexDirection="column">
         <Example title="Default with last point">
           <Sparkline
             {...sparklineProps}

--- a/packages/demo/examples/03-sparkline/PointsAndBandsExamples.jsx
+++ b/packages/demo/examples/03-sparkline/PointsAndBandsExamples.jsx
@@ -20,6 +20,8 @@ import { allColors } from '@data-ui/theme';
 import Example from './Example';
 import Spacer from '../shared/Spacer';
 
+PatternLines.displayName = 'PatternLines';
+
 const sparklineProps = {
   ariaLabel: 'This is a Sparkline of...',
   width: 500,
@@ -46,7 +48,7 @@ export default [
       LineSeries,
     ],
     example: () => (
-      <Spacer top={2} left={2}>
+      <Spacer top={2} left={2} flexDirection="column">
         <Example title="All points">
           <Sparkline
             {...sparklineProps}
@@ -62,7 +64,7 @@ export default [
         </Example>
 
         <Example title="Same scales for comparison">
-          <Spacer>
+          <Spacer flexDirection="column"r>
             {[9, 3].map(multiplier => (
               <Sparkline
                 key={multiplier}

--- a/packages/demo/examples/shared/Spacer.jsx
+++ b/packages/demo/examples/shared/Spacer.jsx
@@ -39,5 +39,5 @@ Spacer.defaultProps = {
   right: 0,
   bottom: 1,
   left: 0,
-  flexDirection: 'column',
+  flexDirection: 'row',
 };

--- a/packages/demo/storybook-config/components/PropTable.jsx
+++ b/packages/demo/storybook-config/components/PropTable.jsx
@@ -24,6 +24,7 @@ const defaultProps = {
 };
 
 function PropTable({ instance, component: HOCComponent, useHOC, styles }) {
+  debugger;
   let component = HOCComponent || instance;
   if (HOCComponent && !useHOC) {
     component = componentFromHOC(HOCComponent);
@@ -51,7 +52,7 @@ function PropTable({ instance, component: HOCComponent, useHOC, styles }) {
       <div {...css(styles.title)}>
         <code>
           <span {...css(codeStyles.brace)}>{'<'}</span>
-          <span {...css(codeStyles.component)}>{component.name}</span>
+          <span {...css(codeStyles.component)}>{component.displayName || component.name}</span>
           <span {...css(codeStyles.brace)}>{' /> '}</span>
         </code>
       </div>

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -242,5 +242,6 @@ class XYChart extends React.PureComponent {
 
 XYChart.propTypes = propTypes;
 XYChart.defaultProps = defaultProps;
+XYChart.displayName = 'XYChart';
 
 export default XYChart;


### PR DESCRIPTION
This PR 
- fixes some bugs where demo was not using `displayName` when possible in `PropTables`
- sets `displayName` on `@vx` components so minimized names do not come up.
- updates `@data-ui/xy-chart` to set a `displayName` for `XYChart` to appear in `PropTables`
- fixes the flex direction of `<Spacer />` so it doesn't break all checkboxes.
 