### PR TITLE
[xy-chart] add `<CirclePackSeries />` 

### DIFF
--- a/packages/demo/examples/01-xy-chart/data.js
+++ b/packages/demo/examples/01-xy-chart/data.js
@@ -59,15 +59,16 @@ const dateBetween = (startDate, endDate) => (
 
 const start = new Date('2017-01-05');
 const end = new Date('2017-01-06');
-const minSize = 4;
-const maxSize = 15;
+const minSize = 2;
+const maxSize = 7;
 
-export const circlePackData = Array(200).fill(null).map(() => {
+export const circlePackData = Array(800).fill(null).map(() => {
   const importance = Math.random();
   return {
     x: dateBetween(start, end),
     importance,
     size: minSize + (importance * (maxSize - minSize)),
     fillOpacity: importance,
+    fill: theme.colors.categories[Math.floor(Math.random() * 3)],
   };
 });

--- a/packages/demo/examples/01-xy-chart/data.js
+++ b/packages/demo/examples/01-xy-chart/data.js
@@ -49,3 +49,25 @@ export const intervalData = intervals.reduce((ret, [i0, i1]) => {
   });
   return ret;
 }, []);
+
+// circle pack
+const dateBetween = (startDate, endDate) => (
+  new Date(
+    startDate.getTime() + (Math.random() * (endDate.getTime() - startDate.getTime())),
+  )
+);
+
+const start = new Date('2017-01-05');
+const end = new Date('2017-01-06');
+const minSize = 4;
+const maxSize = 15;
+
+export const circlePackData = Array(200).fill(null).map(() => {
+  const importance = Math.random();
+  return {
+    x: dateBetween(start, end),
+    importance,
+    size: minSize + (importance * (maxSize - minSize)),
+    fillOpacity: importance,
+  };
+});

--- a/packages/demo/examples/01-xy-chart/data.js
+++ b/packages/demo/examples/01-xy-chart/data.js
@@ -58,13 +58,13 @@ const dateBetween = (startDate, endDate) => (
 );
 
 const start = new Date('2017-01-05');
-const end = new Date('2018-02-05');
+const end = new Date('2017-02-05');
 const minSize = 2;
 const maxSize = 10;
 
-export const circlePackData = Array(400).fill(null).map(() => ({
+export const circlePackData = Array(400).fill(null).map((_, i) => ({
   x: dateBetween(start, end),
-  size: minSize + (Math.random() * (maxSize - minSize)),
+  r: minSize + (Math.random() * (maxSize - minSize)),
   fillOpacity: Math.max(0.4, Math.random()),
-  fill: theme.colors.categories[Math.floor(Math.random() * 2)],
+  fill: theme.colors.categories[i % 2 === 0 ? 1: 3],
 }));

--- a/packages/demo/examples/01-xy-chart/data.js
+++ b/packages/demo/examples/01-xy-chart/data.js
@@ -58,17 +58,13 @@ const dateBetween = (startDate, endDate) => (
 );
 
 const start = new Date('2017-01-05');
-const end = new Date('2017-01-06');
+const end = new Date('2018-02-05');
 const minSize = 2;
-const maxSize = 7;
+const maxSize = 10;
 
-export const circlePackData = Array(800).fill(null).map(() => {
-  const importance = Math.random();
-  return {
-    x: dateBetween(start, end),
-    importance,
-    size: minSize + (importance * (maxSize - minSize)),
-    fillOpacity: importance,
-    fill: theme.colors.categories[Math.floor(Math.random() * 3)],
-  };
-});
+export const circlePackData = Array(400).fill(null).map(() => ({
+  x: dateBetween(start, end),
+  size: minSize + (Math.random() * (maxSize - minSize)),
+  fillOpacity: Math.max(0.4, Math.random()),
+  fill: theme.colors.categories[Math.floor(Math.random() * 2)],
+}));

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -306,7 +306,7 @@ export default {
         <ResponsiveXYChart
           ariaLabel="Required label"
           xScale={{ type: 'time' }}
-          yScale={{ type: 'linear', domain: [-3, 3] }}
+          yScale={{ type: 'linear' }}
         >
           <HorizontalReferenceLine reference={0} />
           <CirclePackSeries
@@ -317,6 +317,7 @@ export default {
             showHorizontalLine={false}
             fullHeight
             stroke={colors.categories[0]}
+            circleFill="transparent"
           />
           <XAxis label="Time" numTicks={5} />
         </ResponsiveXYChart>

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -9,12 +9,14 @@ import {
 
   AreaSeries,
   BarSeries,
+  CirclePackSeries,
+  GroupedBarSeries,
   IntervalSeries,
   LineSeries,
-  GroupedBarSeries,
-  StackedBarSeries,
   PointSeries,
+  StackedBarSeries,
 
+  HorizontalReferenceLine,
   PatternLines,
   LinearGradient,
   theme,
@@ -26,6 +28,7 @@ import ResponsiveXYChart, { dateFormatter } from './ResponsiveXYChart';
 import ScatterWithHistogram from './ScatterWithHistograms';
 
 import {
+  circlePackData,
   timeSeriesData,
   categoricalData,
   groupKeys,
@@ -293,6 +296,24 @@ export default {
             fill="url(#interval_pattern)"
           />
           <XAxis numTicks={0} />
+        </ResponsiveXYChart>
+      ),
+    },
+    {
+      description: 'CirclePackSeries',
+      components: [CirclePackSeries],
+      example: () => (
+        <ResponsiveXYChart
+          ariaLabel="Required label"
+          xScale={{ type: 'time' }}
+          yScale={{ type: 'linear', domain: [-3, 3] }}
+        >
+          <HorizontalReferenceLine reference={0} />
+          <CirclePackSeries
+            data={circlePackData}
+            label="Time pack"
+          />
+          <XAxis label="Time" numTicks={5} />
         </ResponsiveXYChart>
       ),
     },

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -313,6 +313,11 @@ export default {
             data={circlePackData}
             label="Time pack"
           />
+          <CrossHair
+            showHorizontalLine={false}
+            fullHeight
+            stroke={colors.categories[0]}
+          />
           <XAxis label="Time" numTicks={5} />
         </ResponsiveXYChart>
       ),

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -308,16 +308,20 @@ export default {
           xScale={{ type: 'time' }}
           yScale={{ type: 'linear' }}
         >
-          <HorizontalReferenceLine reference={0} />
           <CirclePackSeries
             data={circlePackData}
-            label="Time pack"
+            label="Circle time pack"
+            size={d => d.r}
+          />
+          <HorizontalReferenceLine
+            reference={0}
           />
           <CrossHair
             showHorizontalLine={false}
             fullHeight
-            stroke={colors.categories[0]}
-            circleFill="transparent"
+            stroke={colors.default}
+            circleFill="white"
+            circleStroke={colors.default}
           />
           <XAxis label="Time" numTicks={5} />
         </ResponsiveXYChart>

--- a/packages/demo/examples/03-sparkline/index.jsx
+++ b/packages/demo/examples/03-sparkline/index.jsx
@@ -5,10 +5,6 @@ import BarSeriesExamples from './BarSeriesExamples';
 import LineSeriesExamples from './LineSeriesExamples';
 import PointsAndBandsExamples from './PointsAndBandsExamples';
 
-// @TODO
-// - functional child ruins source view
-// - getData(n) helper func.
-
 export default {
   usage: readme,
   examples: [

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -27,7 +27,6 @@
     "@data-ui/radial-chart": "0.0.8",
     "@data-ui/sparkline": "0.0.1",
     "@data-ui/theme": "0.0.9",
-    "@data-ui/time-pack": "0.0.0",
     "@data-ui/xy-chart": "0.0.21",
     "@storybook/addon-options": "^3.1.6",
     "@storybook/react": "3.1.8",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -27,6 +27,7 @@
     "@data-ui/radial-chart": "0.0.8",
     "@data-ui/sparkline": "0.0.1",
     "@data-ui/theme": "0.0.9",
+    "@data-ui/time-pack": "0.0.0",
     "@data-ui/xy-chart": "0.0.21",
     "@storybook/addon-options": "^3.1.6",
     "@storybook/react": "3.1.8",

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -143,9 +143,9 @@ export const themeShape = PropTypes.shape({
 
 Name | Type | Default | Description
 ------------ | ------------- | ------- | ----
-axisStyles | axisStylesShape | `{}` | config object for axis and axis label styles, see theme above. 
+axisStyles | axisStylesShape | `{}` | config object for axis and axis label styles, see theme above.
 label | PropTypes.oneOfType( [PropTypes.string, PropTypes.element] ) | `<text {...axisStyles.label[ orientation ]} />` | string or component for axis labels
-numTicks | PropTypes.number | null | *approximate* number of ticks (actual number depends on the data and d3's algorithm) 
+numTicks | PropTypes.number | null | *approximate* number of ticks (actual number depends on the data and d3's algorithm)
 orientation | PropTypes.oneOf(['top', 'right', 'bottom', 'left']) | bottom (XAxis), right (YAxis) | orientation of axis
 tickStyles | tickStylesShape | `{}` | config object for styling ticks and tick labels, see theme above.
 tickLabelComponent | PropTypes.element | `<text {...tickStyles.label[ orientation ]} />` | component to use for tick labels
@@ -162,10 +162,21 @@ Series | supported x scale type | supported y scale types | data shape | voronoi
 `<AreaSeries/>` | time, linear | linear | `{ x, y [, fill, stroke] }` | yes
 `<BarSeries/>` | time, linear, band | linear | `{ x, y [, fill, stroke] }` | no
 `<LineSeries/>` | time, linear | linear | `{ x, y [, stroke] }` | yes
-`<PointSeries/>` | time, linear | time, linear | `{ x, y [, fill, stroke, label] }` | yes
+`<PointSeries/>` | time, linear | time, linear | `{ x, y [size, fill, stroke, label] }` | yes
 `<StackedBarSeries/>` | band | linear | `{ x, y }` (colors controlled with stackFills & stackKeys) | no
 `<GroupedBarSeries/>` | band | linear | `{ x, y }` (colors controlled with groupFills & groupKeys) | no
+`<CirclePackSeries/>` | time, linear | y is computed | `{ x [, size] }` | not compatible
 `<IntervalSeries/>` | time, linear | linear | `{ x0, x1 [, fill, stroke] }` | no
+
+#### CirclePackSeries
+
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/4496521/30147216-07514a16-9352-11e7-9459-5802b771c750.png" width="500" />
+</p>
+
+This series implements the Circle packing algorithm described by <a href="https://www.researchgate.net/publication/221516201_Visualization_of_large_hierarchical_data_by_circle_packing" target="_blank">Wang et al. Visualization of large hierarchical data by circle packing</a>, but attempts to preserve datum x values (although they may be modified slightly). It is useful for visualizing e.g., atomic events where x values may partially overlap, and provides an alternative to an atomic histogram without a requirement for binning x values.
+
+Note that only `x` values are needed for `CirclePackSeries`, `y` values are computed based on `x` and `size` (if specified). Similar to `PointSeries`, `size`, `fill`, and `fillOpacity` may be set on datum themseleves or passed as props to the `CirclePackSeries` component.
 
 
 ### Tooltips

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -30,6 +30,7 @@
     "@vx/grid": "0.0.120",
     "@vx/group": "0.0.127",
     "@vx/pattern": "0.0.120",
+    "@vx/point": "0.0.136",
     "@vx/responsive": "0.0.120",
     "@vx/scale": "0.0.117",
     "@vx/shape": "0.0.131",

--- a/packages/xy-chart/src/annotation/HorizontalReferenceLine.jsx
+++ b/packages/xy-chart/src/annotation/HorizontalReferenceLine.jsx
@@ -1,0 +1,59 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Line from '@vx/shape/build/shapes/Line';
+import Point from '@vx/point/build/Point';
+
+import color from '@data-ui/theme/build/color';
+
+export const propTypes = {
+  reference: PropTypes.number.isRequired,
+  stroke: PropTypes.string,
+  strokeDasharray: PropTypes.string,
+  strokeLinecap: PropTypes.oneOf(['butt', 'square', 'round', 'inherit']),
+  strokeWidth: PropTypes.number,
+  xScale: PropTypes.func,
+  yScale: PropTypes.func,
+};
+
+const defaultProps = {
+  stroke: color.darkGray,
+  strokeDasharray: null,
+  strokeLinecap: 'round',
+  strokeWidth: 1,
+  xScale: null,
+  yScale: null,
+};
+
+function HorizontalReferenceLine({
+  reference,
+  stroke,
+  strokeDasharray,
+  strokeLinecap,
+  strokeWidth,
+  xScale,
+  yScale,
+}) {
+  if (!xScale || !yScale) return null;
+  const [x0, x1] = xScale.range();
+  const scaledRef = yScale(reference);
+  const fromPoint = new Point({ x: x0, y: scaledRef });
+  const toPoint = new Point({ x: x1, y: scaledRef });
+  return (
+    <Line
+      from={fromPoint}
+      to={toPoint}
+      stroke={stroke}
+      strokeDasharray={strokeDasharray}
+      strokeLinecap={strokeLinecap}
+      strokeWidth={strokeWidth}
+      vectorEffect="non-scaling-stroke"
+    />
+  );
+}
+
+HorizontalReferenceLine.propTypes = propTypes;
+HorizontalReferenceLine.defaultProps = defaultProps;
+HorizontalReferenceLine.displayName = 'HorizontalReferenceLine';
+
+export default HorizontalReferenceLine;

--- a/packages/xy-chart/src/axis/XAxis.jsx
+++ b/packages/xy-chart/src/axis/XAxis.jsx
@@ -36,48 +36,51 @@ const defaultProps = {
   tickValues: undefined,
 };
 
-export default function XAxis({
-  axisStyles,
-  innerHeight,
-  hideZero,
-  label,
-  numTicks,
-  orientation,
-  rangePadding,
-  scale,
-  tickFormat,
-  tickLabelComponent,
-  tickStyles,
-  tickValues,
-}) {
-  if (!scale || !innerHeight) return null;
-  const Axis = orientation === 'bottom' ? AxisBottom : AxisTop;
-  return (
-    <Axis
-      top={orientation === 'bottom' ? innerHeight : 0}
-      left={0}
-      rangePadding={rangePadding}
-      hideTicks={numTicks === 0}
-      hideZero={hideZero}
-      label={typeof label === 'string' && axisStyles.label ?
-        <text {...(axisStyles.label || {})[orientation]}>
-          {label}
-        </text>
-        : label
-      }
-      numTicks={numTicks}
-      scale={scale}
-      stroke={axisStyles.stroke}
-      strokeWidth={axisStyles.strokeWidth}
-      tickFormat={tickFormat}
-      tickLength={tickStyles.tickLength}
-      tickStroke={tickStyles.stroke}
-      tickLabelComponent={tickLabelComponent || (tickStyles.label &&
-        <text {...(tickStyles.label || {})[orientation]} />
-      )}
-      tickValues={tickValues}
-    />
-  );
+export default class XAxis extends React.PureComponent {
+  render() {
+    const {
+      axisStyles,
+      innerHeight,
+      hideZero,
+      label,
+      numTicks,
+      orientation,
+      rangePadding,
+      scale,
+      tickFormat,
+      tickLabelComponent,
+      tickStyles,
+      tickValues,
+    } = this.props;
+    if (!scale || !innerHeight) return null;
+    const Axis = orientation === 'bottom' ? AxisBottom : AxisTop;
+    return (
+      <Axis
+        top={orientation === 'bottom' ? innerHeight : 0}
+        left={0}
+        rangePadding={rangePadding}
+        hideTicks={numTicks === 0}
+        hideZero={hideZero}
+        label={typeof label === 'string' && axisStyles.label ?
+          <text {...(axisStyles.label || {})[orientation]}>
+            {label}
+          </text>
+          : label
+        }
+        numTicks={numTicks}
+        scale={scale}
+        stroke={axisStyles.stroke}
+        strokeWidth={axisStyles.strokeWidth}
+        tickFormat={tickFormat}
+        tickLength={tickStyles.tickLength}
+        tickStroke={tickStyles.stroke}
+        tickLabelComponent={tickLabelComponent || (tickStyles.label &&
+          <text {...(tickStyles.label || {})[orientation]} />
+        )}
+        tickValues={tickValues}
+      />
+    );
+  }
 }
 
 XAxis.propTypes = propTypes;

--- a/packages/xy-chart/src/axis/YAxis.jsx
+++ b/packages/xy-chart/src/axis/YAxis.jsx
@@ -38,51 +38,54 @@ const defaultProps = {
   tickValues: undefined,
 };
 
-export default function YAxis({
-  axisStyles,
-  hideZero,
-  innerWidth,
-  label,
-  labelOffset,
-  numTicks,
-  orientation,
-  rangePadding,
-  scale,
-  tickFormat,
-  tickLabelComponent,
-  tickStyles,
-  tickValues,
-}) {
-  if (!scale || !innerWidth) return null;
+export default class YAxis extends React.PureComponent {
+  render() {
+    const {
+      axisStyles,
+      hideZero,
+      innerWidth,
+      label,
+      labelOffset,
+      numTicks,
+      orientation,
+      rangePadding,
+      scale,
+      tickFormat,
+      tickLabelComponent,
+      tickStyles,
+      tickValues,
+    } = this.props;
+    if (!scale || !innerWidth) return null;
 
-  const Axis = orientation === 'left' ? AxisLeft : AxisRight;
-  return (
-    <Axis
-      top={0}
-      left={orientation === 'right' ? innerWidth : 0}
-      rangePadding={rangePadding}
-      hideTicks={numTicks === 0}
-      hideZero={hideZero}
-      label={typeof label === 'string' && axisStyles.label ?
-        <text {...(axisStyles.label || {})[orientation]}>
-          {label}
-        </text>
-        : label
-      }
-      labelOffset={labelOffset}
-      numTicks={numTicks}
-      scale={scale}
-      stroke={axisStyles.stroke}
-      strokeWidth={axisStyles.strokeWidth}
-      tickFormat={tickFormat}
-      tickLength={tickStyles.tickLength}
-      tickStroke={tickStyles.stroke}
-      tickLabelComponent={tickLabelComponent || (tickStyles.label &&
-        <text {...(tickStyles.label || {})[orientation]} />
-      )}
-      tickValues={tickValues}
-    />
-  );
+    const Axis = orientation === 'left' ? AxisLeft : AxisRight;
+    return (
+      <Axis
+        top={0}
+        left={orientation === 'right' ? innerWidth : 0}
+        rangePadding={rangePadding}
+        hideTicks={numTicks === 0}
+        hideZero={hideZero}
+        label={typeof label === 'string' && axisStyles.label ?
+          <text {...(axisStyles.label || {})[orientation]}>
+            {label}
+          </text>
+          : label
+        }
+        labelOffset={labelOffset}
+        numTicks={numTicks}
+        scale={scale}
+        stroke={axisStyles.stroke}
+        strokeWidth={axisStyles.strokeWidth}
+        tickFormat={tickFormat}
+        tickLength={tickStyles.tickLength}
+        tickStroke={tickStyles.stroke}
+        tickLabelComponent={tickLabelComponent || (tickStyles.label &&
+          <text {...(tickStyles.label || {})[orientation]} />
+        )}
+        tickValues={tickValues}
+      />
+    );
+  }
 }
 
 YAxis.propTypes = propTypes;

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -13,6 +13,7 @@ import {
   isAxis,
   isCrossHair,
   isBarSeries,
+  isReferenceLine,
   isSeries,
   getChildWithName,
   getScaleForAccessor,
@@ -89,8 +90,8 @@ class XYChart extends React.PureComponent {
   collectScalesFromProps() {
     const { xScale, yScale, children } = this.props;
     const { innerWidth, innerHeight } = this.getDimmensions();
-    const { allData, dataBySeriesType } = collectDataFromChildSeries(children);
-    const result = { allData };
+    const { allData, dataByIndex, dataBySeriesType } = collectDataFromChildSeries(children);
+    const result = { allData, dataByIndex };
 
     result.xScale = getScaleForAccessor({
       allData,
@@ -156,7 +157,7 @@ class XYChart extends React.PureComponent {
 
     const { margin, innerWidth, innerHeight } = this.getDimmensions();
     const { numXTicks, numYTicks } = this.getNumTicks(innerWidth, innerHeight);
-    const { xScale, yScale, allData } = this.collectScalesFromProps(); // @TODO cache these?
+    const { xScale, yScale, allData, dataByIndex } = this.collectScalesFromProps();
     const barWidth = xScale.barWidth || (xScale.bandwidth && xScale.bandwidth()) || 0;
 
     const voronoiX = d => xScale(getX(d) || 0);
@@ -183,7 +184,7 @@ class XYChart extends React.PureComponent {
               strokeWidth={theme.gridStyles && theme.gridStyles.strokeWidth}
             />}
 
-          {React.Children.map(children, (Child) => {
+          {React.Children.map(children, (Child, childIndex) => {
             const name = componentName(Child);
             if (isAxis(name)) {
               const styleKey = name[0].toLowerCase();
@@ -199,6 +200,7 @@ class XYChart extends React.PureComponent {
               });
             } else if (isSeries(name)) {
               return React.cloneElement(Child, {
+                data: dataByIndex[childIndex],
                 xScale,
                 yScale,
                 barWidth,
@@ -208,6 +210,8 @@ class XYChart extends React.PureComponent {
             } else if (isCrossHair(name)) {
               CrossHair = Child;
               return null;
+            } else if (isReferenceLine(name)) {
+              return React.cloneElement(Child, { xScale, yScale });
             }
             return Child;
           })}

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -11,6 +11,7 @@ import {
   collectDataFromChildSeries,
   componentName,
   isAxis,
+  isCirclePackSeries,
   isCrossHair,
   isBarSeries,
   isReferenceLine,
@@ -68,28 +69,9 @@ const getY = d => d.y;
 const xString = d => d.x.toString();
 
 class XYChart extends React.PureComponent {
-  getDimmensions() {
-    const { margin, width, height } = this.props;
-    const completeMargin = { ...defaultProps.margin, ...margin };
-    return {
-      margin: completeMargin,
-      innerHeight: height - completeMargin.top - completeMargin.bottom,
-      innerWidth: width - completeMargin.left - completeMargin.right,
-    };
-  }
-
-  getNumTicks(innerWidth, innerHeight) {
-    const xAxis = getChildWithName('XAxis', this.props.children);
-    const yAxis = getChildWithName('YAxis', this.props.children);
-    return {
-      numXTicks: propOrFallback(xAxis && xAxis.props, 'numTicks', numTicksForWidth(innerWidth)),
-      numYTicks: propOrFallback(yAxis && yAxis.props, 'numTicks', numTicksForHeight(innerHeight)),
-    };
-  }
-
-  collectScalesFromProps() {
-    const { xScale, yScale, children } = this.props;
-    const { innerWidth, innerHeight } = this.getDimmensions();
+  static collectScalesFromProps(props) {
+    const { xScale, yScale, children } = props;
+    const { innerWidth, innerHeight } = XYChart.getDimmensions(props);
     const { allData, dataByIndex, dataBySeriesType } = collectDataFromChildSeries(children);
     const result = { allData, dataByIndex };
 
@@ -126,9 +108,66 @@ class XYChart extends React.PureComponent {
         result.xScale.barWidth = dummyBand.bandwidth();
         result.xScale.offset = offset;
       }
+      if (isCirclePackSeries(name)) {
+        result.yScale.domain([-innerHeight / 2, innerHeight / 2]);
+      }
     });
 
     return result;
+  }
+
+  static getDimmensions(props) {
+    const { margin, width, height } = props;
+    const completeMargin = { ...defaultProps.margin, ...margin };
+    return {
+      margin: completeMargin,
+      innerHeight: height - completeMargin.top - completeMargin.bottom,
+      innerWidth: width - completeMargin.left - completeMargin.right,
+    };
+  }
+
+  static getStateFromProps(props) {
+    const { margin, innerWidth, innerHeight } = XYChart.getDimmensions(props);
+    const { allData, dataByIndex, xScale, yScale } = XYChart.collectScalesFromProps(props);
+
+    return {
+      allData,
+      dataByIndex,
+      innerHeight,
+      innerWidth,
+      margin,
+      xScale,
+      yScale,
+      voronoiX: d => xScale(getX(d)),
+      voronoiY: d => yScale(getY(d)),
+    };
+  }
+
+  constructor(props) {
+    super(props);
+    this.state = props.renderTooltip ? {} : XYChart.getStateFromProps(props);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if ([ // recompute scales if any of the following change
+      'children',
+      'height',
+      'margin',
+      'width',
+      'xScale',
+      'yScale',
+    ].some(prop => this.props[prop] !== nextProps[prop])) {
+      this.setState(XYChart.getStateFromProps(nextProps));
+    }
+  }
+
+  getNumTicks(innerWidth, innerHeight) {
+    const xAxis = getChildWithName('XAxis', this.props.children);
+    const yAxis = getChildWithName('YAxis', this.props.children);
+    return {
+      numXTicks: propOrFallback(xAxis && xAxis.props, 'numTicks', numTicksForWidth(innerWidth)),
+      numYTicks: propOrFallback(yAxis && yAxis.props, 'numTicks', numTicksForHeight(innerHeight)),
+    };
   }
 
   render() {
@@ -155,13 +194,20 @@ class XYChart extends React.PureComponent {
       useVoronoi,
     } = this.props;
 
-    const { margin, innerWidth, innerHeight } = this.getDimmensions();
-    const { numXTicks, numYTicks } = this.getNumTicks(innerWidth, innerHeight);
-    const { xScale, yScale, allData, dataByIndex } = this.collectScalesFromProps();
-    const barWidth = xScale.barWidth || (xScale.bandwidth && xScale.bandwidth()) || 0;
+    const {
+      allData,
+      dataByIndex,
+      innerWidth,
+      innerHeight,
+      margin,
+      voronoiX,
+      voronoiY,
+      xScale,
+      yScale,
+    } = this.state;
 
-    const voronoiX = d => xScale(getX(d) || 0);
-    const voronoiY = d => yScale(getY(d) || 0);
+    const { numXTicks, numYTicks } = this.getNumTicks(innerWidth, innerHeight);
+    const barWidth = xScale.barWidth || (xScale.bandwidth && xScale.bandwidth()) || 0;
     let CrossHair; // ensure this is the top-most layer
 
     return innerWidth > 0 && innerHeight > 0 && (

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -4,12 +4,14 @@ export { default as XYChart, propTypes as xyChartPropTypes } from './chart/XYCha
 
 export { default as AreaSeries } from './series/AreaSeries';
 export { default as BarSeries } from './series/BarSeries';
+export { default as CirclePackSeries } from './series/CirclePackSeries';
 export { default as GroupedBarSeries } from './series/GroupedBarSeries';
 export { default as IntervalSeries } from './series/IntervalSeries';
 export { default as LineSeries } from './series/LineSeries';
 export { default as PointSeries } from './series/PointSeries';
 export { default as StackedBarSeries } from './series/StackedBarSeries';
 
+export { default as HorizontalReferenceLine } from './annotation/HorizontalReferenceLine';
 export { default as CrossHair } from './chart/CrossHair';
 export { default as WithTooltip, withTooltipPropTypes } from './enhancer/WithTooltip';
 

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -45,65 +45,69 @@ const x = d => d.x;
 const y = d => d.y;
 const defined = d => isDefined(y(d));
 
-export default function AreaSeries({
-  data,
-  xScale,
-  yScale,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  strokeLinecap,
-  fill,
-  fillOpacity,
-  interpolation,
-  label,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
-  const strokeWidthValue = callOrValue(strokeWidth, data);
-  const fillValue = callOrValue(fill, data);
-  const curve = interpolatorLookup[interpolation] || interpolatorLookup.cardinal;
-  return (
-    <Group
-      onMouseMove={onMouseMove && ((event) => {
-        const d = findClosestDatum({ data, getX: x, event, xScale });
-        onMouseMove({ event, data, datum: d, color: fillValue });
-      })}
-      onMouseLeave={onMouseLeave}
-    >
-      <AreaClosed
-        key={`${label}-area`}
-        data={data}
-        x={x}
-        y={y}
-        xScale={xScale}
-        yScale={yScale}
-        fill={fillValue}
-        fillOpacity={callOrValue(fillOpacity, data)}
-        stroke="transparent"
-        strokeWidth={strokeWidthValue}
-        curve={curve}
-        defined={defined}
-      />
-      {strokeWidthValue > 0 &&
-        <LinePath
-          key={`${label}-line`}
+export default class AreaSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      xScale,
+      yScale,
+      stroke,
+      strokeWidth,
+      strokeDasharray,
+      strokeLinecap,
+      fill,
+      fillOpacity,
+      interpolation,
+      label,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+
+    if (!xScale || !yScale) return null;
+    const strokeWidthValue = callOrValue(strokeWidth, data);
+    const fillValue = callOrValue(fill, data);
+    const curve = interpolatorLookup[interpolation] || interpolatorLookup.cardinal;
+    return (
+      <Group
+        onMouseMove={onMouseMove && ((event) => {
+          const d = findClosestDatum({ data, getX: x, event, xScale });
+          onMouseMove({ event, data, datum: d, color: fillValue });
+        })}
+        onMouseLeave={onMouseLeave}
+      >
+        <AreaClosed
+          key={`${label}-area`}
           data={data}
           x={x}
           y={y}
           xScale={xScale}
           yScale={yScale}
-          stroke={callOrValue(stroke, data)}
+          fill={fillValue}
+          fillOpacity={callOrValue(fillOpacity, data)}
+          stroke="transparent"
           strokeWidth={strokeWidthValue}
-          strokeDasharray={callOrValue(strokeDasharray, data)}
-          strokeLinecap={strokeLinecap}
           curve={curve}
-          glyph={null}
           defined={defined}
-        />}
-    </Group>
-  );
+        />
+        {strokeWidthValue > 0 &&
+          <LinePath
+            key={`${label}-line`}
+            data={data}
+            x={x}
+            y={y}
+            xScale={xScale}
+            yScale={yScale}
+            stroke={callOrValue(stroke, data)}
+            strokeWidth={strokeWidthValue}
+            strokeDasharray={callOrValue(strokeDasharray, data)}
+            strokeLinecap={strokeLinecap}
+            curve={curve}
+            glyph={null}
+            defined={defined}
+          />}
+      </Group>
+    );
+  }
 }
 
 AreaSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/BarSeries.jsx
+++ b/packages/xy-chart/src/series/BarSeries.jsx
@@ -40,46 +40,50 @@ const defaultProps = {
 const x = d => d.x;
 const y = d => d.y;
 
-export default function BarSeries({
-  barWidth,
-  data,
-  fill,
-  stroke,
-  strokeWidth,
-  label,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale || !barWidth) return null;
+export default class BarSeries extends React.PureComponent {
+  render() {
+    const {
+      barWidth,
+      data,
+      fill,
+      stroke,
+      strokeWidth,
+      label,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
 
-  const maxHeight = (yScale.range() || [0])[0];
-  const offset = xScale.offset || 0;
-  return (
-    <Group key={label}>
-      {data.map((d, i) => {
-        const barHeight = maxHeight - yScale(y(d));
-        const color = d.fill || callOrValue(fill, d, i);
-        return isDefined(d.y) && (
-          <Bar
-            key={`bar-${label}-${xScale(x(d))}`}
-            x={xScale(x(d)) - offset}
-            y={maxHeight - barHeight}
-            width={barWidth}
-            height={barHeight}
-            fill={color}
-            stroke={d.stroke || callOrValue(stroke, d, i)}
-            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-            onMouseMove={onMouseMove && (() => (event) => {
-              onMouseMove({ event, data, datum: d, color });
-            })}
-            onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-          />
-        );
-      })}
-    </Group>
-  );
+    if (!xScale || !yScale || !barWidth) return null;
+
+    const maxHeight = (yScale.range() || [0])[0];
+    const offset = xScale.offset || 0;
+    return (
+      <Group key={label}>
+        {data.map((d, i) => {
+          const barHeight = maxHeight - yScale(y(d));
+          const color = d.fill || callOrValue(fill, d, i);
+          return isDefined(d.y) && (
+            <Bar
+              key={`bar-${label}-${xScale(x(d))}`}
+              x={xScale(x(d)) - offset}
+              y={maxHeight - barHeight}
+              width={barWidth}
+              height={barHeight}
+              fill={color}
+              stroke={d.stroke || callOrValue(stroke, d, i)}
+              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              onMouseMove={onMouseMove && (() => (event) => {
+                onMouseMove({ event, data, datum: d, color });
+              })}
+              onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+            />
+          );
+        })}
+      </Group>
+    );
+  }
 }
 
 BarSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/CirclePackSeries.jsx
+++ b/packages/xy-chart/src/series/CirclePackSeries.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import PointSeries from './PointSeries';
+
+const propTypes = {
+  ...PointSeries.propTypes,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      x: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.instanceOf(Date)]),
+      size: PropTypes.number,
+      importance: PropTypes.number,
+    }),
+  ).isRequired,
+};
+
+const defaultProps = {
+  ...PointSeries.defaultProps,
+};
+
+function CirclePackSeries(props) {
+  return <PointSeries {...props} />;
+}
+
+CirclePackSeries.propTypes = propTypes;
+CirclePackSeries.defaultProps = defaultProps;
+CirclePackSeries.displayName = 'CirclePackSeries';
+
+export default CirclePackSeries;

--- a/packages/xy-chart/src/series/CirclePackSeries.jsx
+++ b/packages/xy-chart/src/series/CirclePackSeries.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 import PointSeries from './PointSeries';
 
+import computeCirclePack from '../utils/computeCirclePack';
+
 const propTypes = {
   ...PointSeries.propTypes,
   data: PropTypes.arrayOf(
@@ -19,7 +21,16 @@ const defaultProps = {
 };
 
 function CirclePackSeries(props) {
-  return <PointSeries {...props} />;
+  const { data, xScale, yScale } = props;
+  const { data: modifiedData,
+          yScale: modifiedYScale } = computeCirclePack(data, xScale, yScale);
+  return (
+    <PointSeries
+      {...props}
+      data={modifiedData}
+      yScale={modifiedYScale}
+    />
+  );
 }
 
 CirclePackSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/CirclePackSeries.jsx
+++ b/packages/xy-chart/src/series/CirclePackSeries.jsx
@@ -9,9 +9,9 @@ const propTypes = {
   ...PointSeries.propTypes,
   data: PropTypes.arrayOf(
     PropTypes.shape({
+      // x should be anything sortable
       x: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.instanceOf(Date)]),
       size: PropTypes.number,
-      importance: PropTypes.number,
     }),
   ).isRequired,
 };
@@ -20,17 +20,18 @@ const defaultProps = {
   ...PointSeries.defaultProps,
 };
 
-function CirclePackSeries(props) {
-  const { data, xScale, yScale } = props;
-  const { data: modifiedData,
-          yScale: modifiedYScale } = computeCirclePack(data, xScale, yScale);
-  return (
-    <PointSeries
-      {...props}
-      data={modifiedData}
-      yScale={modifiedYScale}
-    />
-  );
+// eslint-disable-next-line react/prefer-stateless-function
+class CirclePackSeries extends React.PureComponent {
+  render() {
+    const { data: rawData, xScale } = this.props;
+    const data = computeCirclePack(rawData, xScale);
+    return (
+      <PointSeries
+        {...this.props}
+        data={data}
+      />
+    );
+  }
 }
 
 CirclePackSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/CirclePackSeries.jsx
+++ b/packages/xy-chart/src/series/CirclePackSeries.jsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import PointSeries from './PointSeries';
+import PointSeries, {
+  propTypes as pointSeriesPropTypes,
+  defaultProps as pointSeriesDefaultProps,
+} from './PointSeries';
 
 import computeCirclePack from '../utils/computeCirclePack';
 
 const propTypes = {
-  ...PointSeries.propTypes,
+  ...pointSeriesPropTypes,
   data: PropTypes.arrayOf(
     PropTypes.shape({
       // x should be anything sortable
@@ -17,14 +20,15 @@ const propTypes = {
 };
 
 const defaultProps = {
-  ...PointSeries.defaultProps,
+  ...pointSeriesDefaultProps,
+  size: d => d.size || 4,
 };
 
 // eslint-disable-next-line react/prefer-stateless-function
 class CirclePackSeries extends React.PureComponent {
   render() {
-    const { data: rawData, xScale } = this.props;
-    const data = computeCirclePack(rawData, xScale);
+    const { data: rawData, xScale, size } = this.props;
+    const data = computeCirclePack(rawData, xScale, size);
     return (
       <PointSeries
         {...this.props}

--- a/packages/xy-chart/src/series/GroupedBarSeries.jsx
+++ b/packages/xy-chart/src/series/GroupedBarSeries.jsx
@@ -36,49 +36,53 @@ const defaultProps = {
 
 const x = d => d.x;
 
-export default function GroupedBarSeries({
-  data,
-  groupKeys,
-  groupFills,
-  groupPadding,
-  stroke,
-  strokeWidth,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
-  if (!xScale.bandwidth) { // @todo figure this out/be more graceful
-    throw new Error("'GroupedBarSeries' requires a 'band' type xScale");
+export default class GroupedBarSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      groupKeys,
+      groupFills,
+      groupPadding,
+      stroke,
+      strokeWidth,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+
+    if (!xScale || !yScale) return null;
+    if (!xScale.bandwidth) { // @todo figure this out/be more graceful
+      throw new Error("'GroupedBarSeries' requires a 'band' type xScale");
+    }
+    const maxHeight = (yScale.range() || [0])[0];
+    const x1Scale = scaleTypeToScale.band({
+      rangeRound: [0, xScale.bandwidth()],
+      domain: groupKeys,
+      padding: groupPadding,
+    });
+    const zScale = scaleTypeToScale.ordinal({ range: groupFills, domain: groupKeys });
+    return (
+      <BarGroup
+        data={data}
+        keys={groupKeys}
+        height={maxHeight}
+        x0={x}
+        x0Scale={xScale}
+        x1Scale={x1Scale}
+        yScale={yScale}
+        zScale={zScale}
+        rx={2}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        onMouseMove={onMouseMove && (d => (event) => {
+          const { key, data: datum } = d;
+          onMouseMove({ event, data, datum, key, color: zScale(key) });
+        })}
+        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+      />
+    );
   }
-  const maxHeight = (yScale.range() || [0])[0];
-  const x1Scale = scaleTypeToScale.band({
-    rangeRound: [0, xScale.bandwidth()],
-    domain: groupKeys,
-    padding: groupPadding,
-  });
-  const zScale = scaleTypeToScale.ordinal({ range: groupFills, domain: groupKeys });
-  return (
-    <BarGroup
-      data={data}
-      keys={groupKeys}
-      height={maxHeight}
-      x0={x}
-      x0Scale={xScale}
-      x1Scale={x1Scale}
-      yScale={yScale}
-      zScale={zScale}
-      rx={2}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      onMouseMove={onMouseMove && (d => (event) => {
-        const { key, data: datum } = d;
-        onMouseMove({ event, data, datum, key, color: zScale(key) });
-      })}
-      onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-    />
-  );
 }
 
 GroupedBarSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/IntervalSeries.jsx
+++ b/packages/xy-chart/src/series/IntervalSeries.jsx
@@ -36,45 +36,48 @@ const defaultProps = {
 const x0 = d => d.x0;
 const x1 = d => d.x1;
 
-export default function IntervalSeries({
-  data,
-  fill,
-  label,
-  stroke,
-  strokeWidth,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
+export default class IntervalSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      fill,
+      label,
+      stroke,
+      strokeWidth,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
 
-  const barHeight = (yScale.range() || [0])[0];
-  return (
-    <Group key={label}>
-      {data.map((d, i) => {
-        const x = xScale(x0(d));
-        const barWidth = xScale(x1(d)) - x;
-        const intervalFill = d.fill || callOrValue(fill, d, i);
-        return (
-          <Bar
-            key={`interval-${label}-${x}`}
-            x={x}
-            y={0}
-            width={barWidth}
-            height={barHeight}
-            fill={intervalFill}
-            stroke={d.stroke || callOrValue(stroke, d, i)}
-            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-            onMouseMove={onMouseMove && (() => (event) => {
-              onMouseMove({ event, datum: d, data, color: intervalFill });
-            })}
-            onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-          />
-        );
-      })}
-    </Group>
-  );
+    const barHeight = (yScale.range() || [0])[0];
+    return (
+      <Group key={label}>
+        {data.map((d, i) => {
+          const x = xScale(x0(d));
+          const barWidth = xScale(x1(d)) - x;
+          const intervalFill = d.fill || callOrValue(fill, d, i);
+          return (
+            <Bar
+              key={`interval-${label}-${x}`}
+              x={x}
+              y={0}
+              width={barWidth}
+              height={barHeight}
+              fill={intervalFill}
+              stroke={d.stroke || callOrValue(stroke, d, i)}
+              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              onMouseMove={onMouseMove && (() => (event) => {
+                onMouseMove({ event, datum: d, data, color: intervalFill });
+              })}
+              onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+            />
+          );
+        })}
+      </Group>
+    );
+  }
 }
 
 IntervalSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -45,69 +45,72 @@ const x = d => d.x;
 const y = d => d.y;
 const defined = d => isDefined(y(d));
 
-export default function LineSeries({
-  data,
-  interpolation,
-  label,
-  showPoints,
-  stroke,
-  strokeDasharray,
-  strokeWidth,
-  strokeLinecap,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
-  const strokeValue = callOrValue(stroke);
-  return (
-    <LinePath
-      key={label}
-      data={data}
-      xScale={xScale}
-      yScale={yScale}
-      x={x}
-      y={y}
-      stroke={strokeValue}
-      strokeWidth={callOrValue(strokeWidth)}
-      strokeDasharray={callOrValue(strokeDasharray)}
-      strokeLinecap={strokeLinecap}
-      curve={interpolation === 'linear' ? curveLinear : curveCardinal}
-      defined={defined}
-      onMouseMove={onMouseMove && (() => (event) => {
-        const d = findClosestDatum({ data, getX: x, event, xScale });
-        onMouseMove({ event, data, datum: d, color: strokeValue });
-      })}
-      onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-      glyph={showPoints && ((d, i) => (
-        isDefined(x(d)) && isDefined(y(d)) &&
-          <GlyphDot
-            key={`${label}-${i}-${x(d)}`}
-            cx={xScale(x(d))}
-            cy={yScale(y(d))}
-            r={4}
-            fill={d.stroke || callOrValue(stroke, d, i)}
-            stroke="#FFFFFF"
-            strokeWidth={1}
-            style={{ pointerEvents: 'none' }}
-          >
-            {d.label &&
-              <text
-                x={xScale(x(d))}
-                y={yScale(y(d))}
-                dx={10}
-                fill={d.stroke || callOrValue(stroke, d, i)}
-                stroke={'#fff'}
-                strokeWidth={1}
-                fontSize={12}
-              >
-                {d.label}
-              </text>}
-          </GlyphDot>
-      ))}
-    />
-  );
+export default class LineSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      interpolation,
+      label,
+      showPoints,
+      stroke,
+      strokeDasharray,
+      strokeWidth,
+      strokeLinecap,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
+    const strokeValue = callOrValue(stroke);
+    return (
+      <LinePath
+        key={label}
+        data={data}
+        xScale={xScale}
+        yScale={yScale}
+        x={x}
+        y={y}
+        stroke={strokeValue}
+        strokeWidth={callOrValue(strokeWidth)}
+        strokeDasharray={callOrValue(strokeDasharray)}
+        strokeLinecap={strokeLinecap}
+        curve={interpolation === 'linear' ? curveLinear : curveCardinal}
+        defined={defined}
+        onMouseMove={onMouseMove && (() => (event) => {
+          const d = findClosestDatum({ data, getX: x, event, xScale });
+          onMouseMove({ event, data, datum: d, color: strokeValue });
+        })}
+        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+        glyph={showPoints && ((d, i) => (
+          isDefined(x(d)) && isDefined(y(d)) &&
+            <GlyphDot
+              key={`${label}-${i}-${x(d)}`}
+              cx={xScale(x(d))}
+              cy={yScale(y(d))}
+              r={4}
+              fill={d.stroke || callOrValue(stroke, d, i)}
+              stroke="#FFFFFF"
+              strokeWidth={1}
+              style={{ pointerEvents: 'none' }}
+            >
+              {d.label &&
+                <text
+                  x={xScale(x(d))}
+                  y={yScale(y(d))}
+                  dx={10}
+                  fill={d.stroke || callOrValue(stroke, d, i)}
+                  stroke={'#fff'}
+                  strokeWidth={1}
+                  fontSize={12}
+                >
+                  {d.label}
+                </text>}
+            </GlyphDot>
+        ))}
+      />
+    );
+  }
 }
 
 LineSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -8,7 +8,7 @@ import { chartTheme, color } from '@data-ui/theme';
 import { callOrValue, isDefined } from '../utils/chartUtils';
 import { pointSeriesDataShape } from '../utils/propShapes';
 
-const propTypes = {
+export const propTypes = {
   data: pointSeriesDataShape.isRequired,
   label: PropTypes.string.isRequired,
   labelComponent: PropTypes.element,
@@ -28,7 +28,7 @@ const propTypes = {
   onMouseLeave: PropTypes.func,
 };
 
-const defaultProps = {
+export const defaultProps = {
   labelComponent: <text {...chartTheme.labelStyles} />,
   size: 4,
   fill: color.default,

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -72,7 +72,7 @@ export default function PointSeries({
         const cx = xScale(xVal);
         const cy = yScale(yVal);
         const circleFill = d.fill || callOrValue(fill, d, i);
-        const key = `${label}-${x(d)}`;
+        const key = `${label}-${x(d)}-${i}`;
         if (defined && d.label) {
           labels.push({ x: cx, y: cy, label: d.label, key: `${key}-label` });
         }
@@ -81,9 +81,9 @@ export default function PointSeries({
             key={key}
             cx={cx}
             cy={cy}
-            r={callOrValue(size, d, i)}
+            r={d.size || callOrValue(size, d, i)}
             fill={circleFill}
-            fillOpacity={fillOpacity}
+            fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
             stroke={d.stroke || callOrValue(stroke, d, i)}
             strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
             strokeDasharray={d.strokeDasharray || callOrValue(strokeDasharray, d, i)}

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -45,59 +45,62 @@ const defaultProps = {
 const x = d => d.x;
 const y = d => d.y;
 
-export default function PointSeries({
-  data,
-  label,
-  labelComponent,
-  fill,
-  fillOpacity,
-  size,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
+export default class PointSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      label,
+      labelComponent,
+      fill,
+      fillOpacity,
+      size,
+      stroke,
+      strokeWidth,
+      strokeDasharray,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
 
-  const labels = [];
-  return (
-    <Group key={label}>
-      {data.map((d, i) => {
-        const xVal = x(d);
-        const yVal = y(d);
-        const defined = isDefined(xVal) && isDefined(yVal);
-        const cx = xScale(xVal);
-        const cy = yScale(yVal);
-        const circleFill = d.fill || callOrValue(fill, d, i);
-        const key = `${label}-${x(d)}-${i}`;
-        if (defined && d.label) {
-          labels.push({ x: cx, y: cy, label: d.label, key: `${key}-label` });
-        }
-        return defined && (
-          <GlyphDot
-            key={key}
-            cx={cx}
-            cy={cy}
-            r={d.size || callOrValue(size, d, i)}
-            fill={circleFill}
-            fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
-            stroke={d.stroke || callOrValue(stroke, d, i)}
-            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-            strokeDasharray={d.strokeDasharray || callOrValue(strokeDasharray, d, i)}
-            onMouseMove={onMouseMove && ((event) => {
-              onMouseMove({ event, data, datum: d, color: circleFill });
-            })}
-            onMouseLeave={onMouseLeave}
-          />
-        );
-      })}
-      {/* Put labels on top */}
-      {labels.map(d => React.cloneElement(labelComponent, d, d.label))}
-    </Group>
-  );
+    const labels = [];
+    return (
+      <Group key={label}>
+        {data.map((d, i) => {
+          const xVal = x(d);
+          const yVal = y(d);
+          const defined = isDefined(xVal) && isDefined(yVal);
+          const cx = xScale(xVal);
+          const cy = yScale(yVal);
+          const circleFill = d.fill || callOrValue(fill, d, i);
+          const key = `${label}-${x(d)}-${i}`;
+          if (defined && d.label) {
+            labels.push({ x: cx, y: cy, label: d.label, key: `${key}-label` });
+          }
+          return defined && (
+            <GlyphDot
+              key={key}
+              cx={cx}
+              cy={cy}
+              r={d.size || callOrValue(size, d, i)}
+              fill={circleFill}
+              fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
+              stroke={d.stroke || callOrValue(stroke, d, i)}
+              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              strokeDasharray={d.strokeDasharray || callOrValue(strokeDasharray, d, i)}
+              onMouseMove={onMouseMove && ((event) => {
+                onMouseMove({ event, data, datum: d, color: circleFill });
+              })}
+              onMouseLeave={onMouseLeave}
+            />
+          );
+        })}
+        {/* Put labels on top */}
+        {labels.map(d => React.cloneElement(labelComponent, d, d.label))}
+      </Group>
+    );
+  }
 }
 
 PointSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/StackedBarSeries.jsx
+++ b/packages/xy-chart/src/series/StackedBarSeries.jsx
@@ -33,41 +33,44 @@ const defaultProps = {
 
 const x = d => d.x;
 
-export default function StackedBarSeries({
-  data,
-  stackKeys,
-  stackFills,
-  stroke,
-  strokeWidth,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
-  if (!xScale.bandwidth) { // @todo figure this out/be more graceful
-    throw new Error("'StackedBarSeries' requires a 'band' type xScale");
+export default class StackedBarSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      stackKeys,
+      stackFills,
+      stroke,
+      strokeWidth,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
+    if (!xScale.bandwidth) { // @todo figure this out/be more graceful
+      throw new Error("'StackedBarSeries' requires a 'band' type xScale");
+    }
+    const maxHeight = (yScale.range() || [0])[0];
+    const zScale = scaleTypeToScale.ordinal({ range: stackFills, domain: stackKeys });
+    return (
+      <BarStack
+        data={data}
+        keys={stackKeys}
+        height={maxHeight}
+        x={x}
+        xScale={xScale}
+        yScale={yScale}
+        zScale={zScale}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        onMouseMove={onMouseMove && (d => (event) => {
+          const { data: datum, key } = d;
+          onMouseMove({ event, data, datum, key, color: zScale(key) });
+        })}
+        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+      />
+    );
   }
-  const maxHeight = (yScale.range() || [0])[0];
-  const zScale = scaleTypeToScale.ordinal({ range: stackFills, domain: stackKeys });
-  return (
-    <BarStack
-      data={data}
-      keys={stackKeys}
-      height={maxHeight}
-      x={x}
-      xScale={xScale}
-      yScale={yScale}
-      zScale={zScale}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      onMouseMove={onMouseMove && (d => (event) => {
-        const { data: datum, key } = d;
-        onMouseMove({ event, data, datum, key, color: zScale(key) });
-      })}
-      onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-    />
-  );
 }
 
 StackedBarSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/utils/chartUtils.js
+++ b/packages/xy-chart/src/utils/chartUtils.js
@@ -2,8 +2,6 @@ import { Children } from 'react';
 import { scaleLinear, scaleTime, scaleBand, scaleOrdinal } from '@vx/scale';
 import { extent } from 'd3-array';
 
-import computeCirclePack from './computeCirclePack';
-
 export function callOrValue(maybeFn, ...args) {
   if (typeof maybeFn === 'function') {
     return maybeFn(...args);
@@ -70,11 +68,8 @@ export function collectDataFromChildSeries(children) {
   Children.forEach(children, (Child, i) => {
     if (Child && Child.props && Child.props.data) {
       const name = componentName(Child);
-      let { data } = Child.props;
+      const { data } = Child.props;
       if (data && isSeries(name)) {
-        if (isCirclePackSeries(name)) {
-          data = computeCirclePack(data);
-        }
         dataByIndex[i] = data;
         allData = allData.concat(data);
         dataBySeriesType[name] = (dataBySeriesType[name] || []).concat(data);

--- a/packages/xy-chart/src/utils/chartUtils.js
+++ b/packages/xy-chart/src/utils/chartUtils.js
@@ -2,6 +2,8 @@ import { Children } from 'react';
 import { scaleLinear, scaleTime, scaleBand, scaleOrdinal } from '@vx/scale';
 import { extent } from 'd3-array';
 
+import computeCirclePack from './computeCirclePack';
+
 export function callOrValue(maybeFn, ...args) {
   if (typeof maybeFn === 'function') {
     return maybeFn(...args);
@@ -26,23 +28,31 @@ export function isDefined(val) {
 }
 
 export function isAxis(name) {
-  return name.match(/axis/gi);
+  return (/axis/gi).test(name);
 }
 
 export function isBarSeries(name) {
-  return name.match(/Bar/g);
+  return (/bar/gi).test(name);
+}
+
+export function isCirclePackSeries(name) {
+  return name === 'CirclePackSeries';
 }
 
 export function isCrossHair(name) {
-  return name.match(/crosshair/gi);
+  return (/crosshair/gi).test(name);
+}
+
+export function isReferenceLine(name) {
+  return (/reference/gi).test(name);
 }
 
 export function isSeries(name) {
-  return name.match(/series/gi);
+  return (/series/gi).test(name);
 }
 
 export function isStackedSeries(name) {
-  return name.match(/stacked/gi);
+  return (/stacked/gi).test(name);
 }
 
 export const scaleTypeToScale = {
@@ -60,8 +70,11 @@ export function collectDataFromChildSeries(children) {
   Children.forEach(children, (Child, i) => {
     if (Child && Child.props && Child.props.data) {
       const name = componentName(Child);
-      const { data } = Child.props;
+      let { data } = Child.props;
       if (data && isSeries(name)) {
+        if (isCirclePackSeries(name)) {
+          data = computeCirclePack(data);
+        }
         dataByIndex[i] = data;
         allData = allData.concat(data);
         dataBySeriesType[name] = (dataBySeriesType[name] || []).concat(data);

--- a/packages/xy-chart/src/utils/computeCirclePack.js
+++ b/packages/xy-chart/src/utils/computeCirclePack.js
@@ -1,0 +1,7 @@
+export default function computeCirclePack(data) {
+  const sorted = data.sort((a, b) => a.x - b.x);
+  return sorted.map(d => ({
+    ...d,
+    y: ((1 - d.importance) * (Math.random() > 0.5 ? 1 : -1)),
+  }));
+}

--- a/packages/xy-chart/src/utils/computeCirclePack.js
+++ b/packages/xy-chart/src/utils/computeCirclePack.js
@@ -1,7 +1,279 @@
-export default function computeCirclePack(data) {
+/* eslint no-param-reassign: 0 */
+/**
+  * Assume that the position of x and the size of circles have been scaled.
+  * And each circle has the following properties:
+  *  x: the position of x,
+  *  size: the radius,
+  */
+
+
+/**
+  * The algorthm is an implementation of the paper
+  *   Wang et al. Visualization of large hierarchical data by circle packing.
+  * by adding horizontal constrains for each circle.
+  */
+function packCircles(data, xScale) {
+  const packBounds = [];
+  const packOutline = [];
+  const rect = {
+    xMin: 0,
+    yMin: 0,
+    xMax: 0,
+    yMax: 0,
+  };
+
+  const outline = {
+    up: [],
+    down: [],
+  };
+
+  function bound(node, bd) {
+    bd.xMin = Math.min(node.px - node.r, bd.xMin);
+    bd.xMax = Math.max(node.px + node.r, bd.xMax);
+    bd.yMin = Math.min(node.py - node.r, bd.yMin);
+    bd.yMax = Math.max(node.py + node.r, bd.yMax);
+  }
+
+  function outside(node, bd) {
+    return node.x + node.r < bd.xMin || node.x - node.r > bd.xMax;
+  }
+
+  function xpackBestPlace(startn, node) {
+    const goodnodes = [];
+    for (let p = startn.nextPack; p !== startn; p = p.nextPack) {
+      if (!(p.px + p.r < node.x - node.r || p.px - p.r > node.x + node.r)) {
+        goodnodes.push(p);
+      }
+    }
+
+    if (goodnodes.length === 0) {
+      return startn;
+    }
+    goodnodes.sort((a, b) => (Math.abs(a.py) - Math.abs(b.py)));
+    return goodnodes[0];
+  }
+
+  function xpackInsert(a, b) {
+    const c = a.nextPack;
+    a.nextPack = b;
+    b.prevPack = a;
+    b.nextPack = c;
+    c.prevPack = b;
+  }
+
+  function xpackPlace(a, b, c) {
+    let db = a.r + c.r;
+    const dx = b.px - a.px;
+    const dy = b.py - a.py;
+    if (db && (dx || dy)) {
+      let da = b.r + c.r;
+      const dc = (dx * dx) + (dy * dy);
+      da *= da;
+      db *= db;
+      const x = 0.5 + ((db - da) / (2 * dc));
+      const y = Math.sqrt(Math.max(0,
+        (2 * da * (db + dc)) - ((db -= dc) * db) - (da * da))) / (2 * dc);
+      c.px = a.px + (x * dx) + (y * dy);
+      c.py = (a.py + (x * dy)) - (y * dx);
+    } else {
+      c.px = a.px + db;
+      c.py = a.py;
+    }
+  }
+
+  function xpackIntersects(a, b) {
+    const dx = b.px - a.px;
+    const dy = b.py - a.py;
+    const dr = a.r + b.r;
+    return 0.999 * dr * dr > (dx * dx) + (dy * dy);
+  }
+
+  function xpackSplice(a, b) {
+    a.nextPack = b;
+    b.prevPack = a;
+  }
+
+  function xpackLink(node) {
+    node.nextPack = node;
+    node.prevPack = node;
+  }
+
+  function packNodes(nodes, start, n) {
+    const bd = packBounds[n];
+    let a;
+    let b;
+    let c;
+    let i;
+    let j;
+    let k;
+
+    if (nodes.length - start >= 1) {
+      // the first node
+      a = nodes[start];
+      a.px = a.x;
+      a.py = 0;
+      bound(a, bd);
+
+      if (nodes.length - start >= 2) {
+          // the second node
+        if (outside(nodes[start + 1], bd)) {
+          return start + 1;
+        }
+
+        b = nodes[start + 1];
+        b.px = a.x + a.r + b.r;
+        b.py = 0;
+        bound(b, bd);
+
+        xpackInsert(a, b);
+
+        if (nodes.length - start >= 3) {
+            // the third node
+          if (outside(nodes[start + 2], bd)) {
+            return start + 2;
+          }
+
+          c = nodes[start + 2];
+          xpackPlace(a, b, c);
+          bound(c, bd);
+
+          xpackInsert(a, c);
+
+          // iterate through the rest
+          let preiter = false;
+          for (i = start + 3; i < nodes.length; i += 1) {
+            if (!preiter) {
+              if (outside(nodes[i], bd)) {
+                return i;
+              }
+              a = xpackBestPlace(a, nodes[i]);
+              b = a.nextPack;
+            }
+
+            xpackPlace(a, b, c = nodes[i]);
+            // search for the closest intersection
+            let isect = 0;
+            let s1 = 1;
+            let s2 = 1;
+            for (j = b.nextPack; j !== b; j = j.nextPack, s1 += 1) {
+              if (xpackIntersects(j, c)) {
+                isect = 1;
+                break;
+              }
+            }
+            if (isect === 1) {
+              for (k = a.prevPack; k !== j.prevPack; k = k.prevPack, s2 += 1) {
+                if (xpackIntersects(k, c)) {
+                  break;
+                }
+              }
+            }
+            // update front chain
+            if (isect) {
+              if (s1 < s2 || (s1 === s2 && b.r < a.r)) {
+                xpackSplice(a, b = j);
+              } else {
+                xpackSplice(a = k, b);
+              }
+              i -= 1;
+              preiter = true;
+            } else {
+              xpackInsert(a, c);
+              b = c;
+              bound(c, bd);
+              preiter = false;
+            }
+          }
+        }
+      }
+    }
+    return nodes.length;
+  }
+
+  if (data.length === 0) {
+    return data;
+  }
+
+  const nodes = [];
+  data.forEach((node) => {
+    nodes.push({ ...node, x: xScale(node.x), r: node.size });
+  });
+
+  for (let i = 0; i < nodes.length; i += 1) {
+    xpackLink(nodes[i]);
+  }
+
+  let i = 0;
+  let n = 0;
+  while (i < nodes.length) {
+    packBounds.push({
+      xMin: Infinity,
+      yMin: Infinity,
+      xMax: -Infinity,
+      yMax: -Infinity,
+    });
+
+    // pack this nodes group
+    i = packNodes(nodes, i, n);
+
+    // get the packing outline
+    packOutline.push(nodes[i - 1]);
+    for (let p = nodes[i - 1].nextPack; p !== nodes[i - 1]; p = p.nextPack) {
+      packOutline.push(p);
+    }
+    n += 1;
+  }
+
+  rect.xMin = Infinity;
+  rect.xMax = -Infinity;
+  rect.yMin = Infinity;
+  rect.yMax = -Infinity;
+  packBounds.forEach((bd) => {
+    rect.xMin = Math.min(rect.xMin, bd.xMin);
+    rect.xMax = Math.max(rect.xMax, bd.xMax);
+    rect.yMin = Math.min(rect.yMin, bd.yMin);
+    rect.yMax = Math.max(rect.yMax, bd.yMax);
+  });
+
+  // compute the global outline
+  packOutline.sort((a, b) => (a.px - b.px));
+  packOutline.forEach((p) => {
+    if (p.py < 0) {
+      outline.up.push(p);
+    } else if (p.py > 0) {
+      outline.down.push(p);
+    } else {
+      outline.up.push(p);
+      outline.down.push(p);
+    }
+  });
+  return nodes;
+}
+
+function rescale(yScale) {
+  const modifiedYScale = yScale.copy();
+  const [rangemin, rangemax] = modifiedYScale.range();
+  const height = Math.abs(rangemin - rangemax);
+  modifiedYScale.domain([-height / 2, height / 2]);
+  return modifiedYScale;
+}
+
+export default function computeCirclePack(data, xScale, yScale) {
   const sorted = data.sort((a, b) => a.x - b.x);
-  return sorted.map(d => ({
-    ...d,
-    y: ((1 - d.importance) * (Math.random() > 0.5 ? 1 : -1)),
-  }));
+  const calculatedNodes = packCircles(data, xScale);
+  const result = [];
+  for (let i = 0; i < calculatedNodes.length; i += 1) {
+    result.push({
+      ...sorted[i],
+      x: xScale.invert(calculatedNodes[i].px),
+      y: calculatedNodes[i].py,
+    });
+  }
+
+  const modifiedYScale = rescale(yScale);
+
+  return {
+    data: result,
+    yScale: modifiedYScale,
+  };
 }

--- a/packages/xy-chart/src/utils/computeCirclePack.js
+++ b/packages/xy-chart/src/utils/computeCirclePack.js
@@ -12,7 +12,7 @@
   *   Wang et al. Visualization of large hierarchical data by circle packing.
   * by adding horizontal constrains for each circle.
   */
-function packCircles(data, xScale) {
+function packCircles(data, xScale, getSize = d => d.size || 4) {
   const packBounds = [];
   const packOutline = [];
   const rect = {
@@ -196,7 +196,7 @@ function packCircles(data, xScale) {
 
   const nodes = [];
   data.forEach((node) => {
-    nodes.push({ ...node, x: xScale(node.x), r: node.size });
+    nodes.push({ ...node, x: xScale(node.x), r: getSize(node) });
   });
 
   for (let i = 0; i < nodes.length; i += 1) {
@@ -250,9 +250,9 @@ function packCircles(data, xScale) {
   return nodes;
 }
 
-export default function computeCirclePack(data, xScale) {
+export default function computeCirclePack(data, xScale, getSize) {
   const sorted = data.sort((a, b) => a.x - b.x);
-  const calculatedNodes = packCircles(data, xScale);
+  const calculatedNodes = packCircles(data, xScale, getSize);
   const result = [];
   for (let i = 0; i < calculatedNodes.length; i += 1) {
     result.push({

--- a/packages/xy-chart/src/utils/computeCirclePack.js
+++ b/packages/xy-chart/src/utils/computeCirclePack.js
@@ -250,15 +250,7 @@ function packCircles(data, xScale) {
   return nodes;
 }
 
-function rescale(yScale) {
-  const modifiedYScale = yScale.copy();
-  const [rangemin, rangemax] = modifiedYScale.range();
-  const height = Math.abs(rangemin - rangemax);
-  modifiedYScale.domain([-height / 2, height / 2]);
-  return modifiedYScale;
-}
-
-export default function computeCirclePack(data, xScale, yScale) {
+export default function computeCirclePack(data, xScale) {
   const sorted = data.sort((a, b) => a.x - b.x);
   const calculatedNodes = packCircles(data, xScale);
   const result = [];
@@ -270,10 +262,5 @@ export default function computeCirclePack(data, xScale, yScale) {
     });
   }
 
-  const modifiedYScale = rescale(yScale);
-
-  return {
-    data: result,
-    yScale: modifiedYScale,
-  };
+  return result;
 }

--- a/packages/xy-chart/test/CirclePackSeries.test.js
+++ b/packages/xy-chart/test/CirclePackSeries.test.js
@@ -14,9 +14,9 @@ describe('<PointSeries />', () => {
   };
 
   const mockData = [
-    { x: new Date('2017-01-05 00:00:00'), importance: 0, size: 1 },
-    { x: new Date('2017-01-05 01:00:00'), importance: 1, size: 3 },
-    { x: new Date('2017-01-05 02:00:00'), importance: 5, size: 5 },
+    { x: new Date('2017-01-05 00:00:00'), size: 1 },
+    { x: new Date('2017-01-05 01:00:00'), size: 3 },
+    { x: new Date('2017-01-05 02:00:00'), size: 5 },
   ];
 
   test('it should be defined', () => {
@@ -26,12 +26,25 @@ describe('<PointSeries />', () => {
   test('it should render a PointSeries', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <CirclePackSeries label="" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <CirclePackSeries label="" data={mockData} />
       </XYChart>,
     );
     const circleSeries = wrapper.find(CirclePackSeries);
     expect(circleSeries.length).toBe(1);
     expect(circleSeries.dive().find(PointSeries).length).toBe(1);
+  });
+
+  test('data passed to PointSeries should include computed y values', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <CirclePackSeries label="" data={mockData} />
+      </XYChart>,
+    );
+    const circleSeries = wrapper.find(CirclePackSeries);
+    const pointSeries = circleSeries.dive().find(PointSeries);
+    const data = pointSeries.prop('data');
+    expect(mockData[0].y).toBeUndefined();
+    expect(data[0].y).toEqual(expect.any(Number));
   });
 
   test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {

--- a/packages/xy-chart/test/CirclePackSeries.test.js
+++ b/packages/xy-chart/test/CirclePackSeries.test.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+
+import { XYChart, CirclePackSeries, PointSeries } from '../src/';
+
+describe('<PointSeries />', () => {
+  const mockProps = {
+    xScale: { type: 'time' },
+    yScale: { type: 'linear', includeZero: false },
+    width: 100,
+    height: 100,
+    margin: { top: 10, right: 10, bottom: 10, left: 10 },
+    ariaLabel: 'label',
+  };
+
+  const mockData = [
+    { x: new Date('2017-01-05 00:00:00'), importance: 0, size: 1 },
+    { x: new Date('2017-01-05 01:00:00'), importance: 1, size: 3 },
+    { x: new Date('2017-01-05 02:00:00'), importance: 5, size: 5 },
+  ];
+
+  test('it should be defined', () => {
+    expect(CirclePackSeries).toBeDefined();
+  });
+
+  test('it should render a PointSeries', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <CirclePackSeries label="" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+      </XYChart>,
+    );
+    const circleSeries = wrapper.find(CirclePackSeries);
+    expect(circleSeries.length).toBe(1);
+    expect(circleSeries.dive().find(PointSeries).length).toBe(1);
+  });
+
+  test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+
+    const wrapper = mount(
+      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+        <CirclePackSeries label="" data={mockData} fill="army-green" />
+      </XYChart>,
+    );
+
+    const point = wrapper.find('circle').first();
+    point.simulate('mousemove');
+
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+    const args = onMouseMove.mock.calls[0][0];
+    expect(args.data).toMatchObject(mockData);
+    expect(args.datum).toMatchObject(mockData[0]);
+    expect(args.event).toBeDefined();
+    expect(args.color).toBe('army-green');
+
+    point.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/xy-chart/test/HorizontalReferenceLine.test.js
+++ b/packages/xy-chart/test/HorizontalReferenceLine.test.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Line from '@vx/shape/build/shapes/Line';
+
+import { XYChart, HorizontalReferenceLine } from '../src/';
+
+describe('<HorizontalReferenceLine />', () => {
+  const reference = 12;
+
+  const mockProps = {
+    xScale: { type: 'time' },
+    yScale: { type: 'linear', domain: [0, 10] },
+    width: 100,
+    height: 100,
+    margin: { top: 0, right: 0, bottom: 0, left: 0 },
+    ariaLabel: 'label',
+  };
+
+  test('it should be defined', () => {
+    expect(HorizontalReferenceLine).toBeDefined();
+  });
+
+  test('it should render null if no accessors or scales are passed', () => {
+    expect(shallow(<HorizontalReferenceLine reference={reference} />).type()).toBeNull();
+  });
+
+  test('it should render a Line', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <HorizontalReferenceLine reference={reference} />
+      </XYChart>,
+    ).find(HorizontalReferenceLine).dive();
+
+    expect(wrapper.find(Line).length).toBe(1);
+  });
+
+  test('the Line should span the entire width of the chart', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <HorizontalReferenceLine reference={reference} />
+      </XYChart>,
+    ).find(HorizontalReferenceLine).dive();
+
+    const line = wrapper.find(Line);
+    expect(line.prop('from').x).toBe(0);
+    expect(line.prop('to').x).toBe(mockProps.width);
+  });
+
+  test('it should render a line at the passed reference number', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <HorizontalReferenceLine reference={reference} />
+      </XYChart>,
+    ).find(HorizontalReferenceLine);
+
+    const yScale = wrapper.prop('yScale');
+    const scaledValue = yScale(reference);
+    const line = wrapper.dive().find(Line);
+    expect(line.prop('from').y).toBe(scaledValue);
+    expect(line.prop('to').y).toBe(scaledValue);
+  });
+});

--- a/packages/xy-chart/test/PointSeries.test.js
+++ b/packages/xy-chart/test/PointSeries.test.js
@@ -38,16 +38,6 @@ describe('<PointSeries />', () => {
     expect(wrapper.find(PointSeries).dive().find(GlyphDot).length).toBe(mockData.length);
   });
 
-  test('it should render a GlyphDot for each datum', () => {
-    const wrapper = shallow(
-      <XYChart {...mockProps} >
-        <PointSeries label="" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
-      </XYChart>,
-    );
-    expect(wrapper.find(PointSeries).length).toBe(1);
-    expect(wrapper.find(PointSeries).dive().find(GlyphDot).length).toBe(mockData.length);
-  });
-
   test('it should not render points for null data', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >

--- a/packages/xy-chart/test/computeCirclePack.test.js
+++ b/packages/xy-chart/test/computeCirclePack.test.js
@@ -1,0 +1,62 @@
+import { scaleLinear } from '@vx/scale';
+import computeCirclePack from '../src/utils/computeCirclePack';
+
+describe('computeCirclePack', () => {
+  const mockData = [
+    { x: 10, size: 1, id: '1' },
+    { x: 9, size: 3, id: '2' },
+    { x: 1, size: 5, id: '3' },
+    { x: 100, size: 5, id: '4' },
+    { x: 3, size: 5, id: '5' },
+  ];
+
+  const xScale = scaleLinear({
+    range: [0, 100],
+    domain: [1, 100],
+  });
+
+  test('it should be defined', () => {
+    expect(computeCirclePack).toBeDefined();
+  });
+
+  test('input data length should match output data length', () => {
+    const output = computeCirclePack(mockData, xScale);
+    expect(output.length).toBe(mockData.length);
+  });
+
+  test('input data with lower x values should have lower x values in output', () => {
+    const output = computeCirclePack(mockData, xScale);
+    expect(output.length).toBe(mockData.length);
+  });
+
+  test('numeric y values should be added to output data', () => {
+    expect.assertions(mockData.length);
+
+    const output = computeCirclePack(mockData, xScale);
+    output.forEach((d) => {
+      expect(d.y).toEqual(expect.any(Number));
+    });
+  });
+
+  test('x, size, and other datum properties should be copied to output data', () => {
+    expect.assertions(mockData.length);
+
+    const output = computeCirclePack(mockData, xScale);
+    output.forEach((outputDatum) => {
+      const inputIndex = mockData.findIndex(inputDatum => inputDatum.id === outputDatum.id);
+      const inputDatum = mockData[inputIndex];
+      expect(Object.keys(outputDatum)).toEqual(expect.arrayContaining(Object.keys(inputDatum)));
+    });
+  });
+
+  test('input datum should not be modified', () => {
+    expect.assertions(mockData.length);
+
+    const output = computeCirclePack(mockData, xScale);
+    output.forEach((outputDatum) => {
+      const inputIndex = mockData.findIndex(inputDatum => inputDatum.id === outputDatum.id);
+      const inputDatum = mockData[inputIndex];
+      expect(outputDatum).not.toBe(inputDatum);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a `<CirclePackSeries />` which implements the [`Wang et al. Visualization of large hierarchical data by circle packing.`](https://www.researchgate.net/publication/221516201_Visualization_of_large_hierarchical_data_by_circle_packing)

![image](https://user-images.githubusercontent.com/4496521/30147216-07514a16-9352-11e7-9459-5802b771c750.png)

Remaining items to address:
- [x] update readme (@williaster)
- [x] cache scales etc in `xychart` (@williaster)
- [x] cache packed data in `circlepackseries` (@williaster)
- [x] figure out a way to not require domain setting to center around an expected value (y-scale is somewhat meaningless) (@williaster)
- [x] basic tests for circle packing  (@williaster)
- [ ] possibly add prop on `<CirclePackSeries />` for flat bttom (@conglei)