### PR TITLE
[xy-chart] component update optimizations

### DIFF
--- a/packages/demo/examples/01-xy-chart/data.js
+++ b/packages/demo/examples/01-xy-chart/data.js
@@ -58,17 +58,13 @@ const dateBetween = (startDate, endDate) => (
 );
 
 const start = new Date('2017-01-05');
-const end = new Date('2017-01-06');
+const end = new Date('2018-02-05');
 const minSize = 2;
-const maxSize = 7;
+const maxSize = 10;
 
-export const circlePackData = Array(800).fill(null).map(() => {
-  const importance = Math.random();
-  return {
-    x: dateBetween(start, end),
-    importance,
-    size: minSize + (importance * (maxSize - minSize)),
-    fillOpacity: importance,
-    fill: theme.colors.categories[Math.floor(Math.random() * 3)],
-  };
-});
+export const circlePackData = Array(400).fill(null).map(() => ({
+  x: dateBetween(start, end),
+  size: minSize + (Math.random() * (maxSize - minSize)),
+  fillOpacity: Math.max(0.4, Math.random()),
+  fill: theme.colors.categories[Math.floor(Math.random() * 2)],
+}));

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -306,7 +306,7 @@ export default {
         <ResponsiveXYChart
           ariaLabel="Required label"
           xScale={{ type: 'time' }}
-          yScale={{ type: 'linear', domain: [-3, 3] }}
+          yScale={{ type: 'linear' }}
         >
           <HorizontalReferenceLine reference={0} />
           <CirclePackSeries
@@ -317,6 +317,7 @@ export default {
             showHorizontalLine={false}
             fullHeight
             stroke={colors.categories[0]}
+            circleFill="transparent"
           />
           <XAxis label="Time" numTicks={5} />
         </ResponsiveXYChart>

--- a/packages/xy-chart/src/axis/XAxis.jsx
+++ b/packages/xy-chart/src/axis/XAxis.jsx
@@ -36,48 +36,51 @@ const defaultProps = {
   tickValues: undefined,
 };
 
-export default function XAxis({
-  axisStyles,
-  innerHeight,
-  hideZero,
-  label,
-  numTicks,
-  orientation,
-  rangePadding,
-  scale,
-  tickFormat,
-  tickLabelComponent,
-  tickStyles,
-  tickValues,
-}) {
-  if (!scale || !innerHeight) return null;
-  const Axis = orientation === 'bottom' ? AxisBottom : AxisTop;
-  return (
-    <Axis
-      top={orientation === 'bottom' ? innerHeight : 0}
-      left={0}
-      rangePadding={rangePadding}
-      hideTicks={numTicks === 0}
-      hideZero={hideZero}
-      label={typeof label === 'string' && axisStyles.label ?
-        <text {...(axisStyles.label || {})[orientation]}>
-          {label}
-        </text>
-        : label
-      }
-      numTicks={numTicks}
-      scale={scale}
-      stroke={axisStyles.stroke}
-      strokeWidth={axisStyles.strokeWidth}
-      tickFormat={tickFormat}
-      tickLength={tickStyles.tickLength}
-      tickStroke={tickStyles.stroke}
-      tickLabelComponent={tickLabelComponent || (tickStyles.label &&
-        <text {...(tickStyles.label || {})[orientation]} />
-      )}
-      tickValues={tickValues}
-    />
-  );
+export default class XAxis extends React.PureComponent {
+  render() {
+    const {
+      axisStyles,
+      innerHeight,
+      hideZero,
+      label,
+      numTicks,
+      orientation,
+      rangePadding,
+      scale,
+      tickFormat,
+      tickLabelComponent,
+      tickStyles,
+      tickValues,
+    } = this.props;
+    if (!scale || !innerHeight) return null;
+    const Axis = orientation === 'bottom' ? AxisBottom : AxisTop;
+    return (
+      <Axis
+        top={orientation === 'bottom' ? innerHeight : 0}
+        left={0}
+        rangePadding={rangePadding}
+        hideTicks={numTicks === 0}
+        hideZero={hideZero}
+        label={typeof label === 'string' && axisStyles.label ?
+          <text {...(axisStyles.label || {})[orientation]}>
+            {label}
+          </text>
+          : label
+        }
+        numTicks={numTicks}
+        scale={scale}
+        stroke={axisStyles.stroke}
+        strokeWidth={axisStyles.strokeWidth}
+        tickFormat={tickFormat}
+        tickLength={tickStyles.tickLength}
+        tickStroke={tickStyles.stroke}
+        tickLabelComponent={tickLabelComponent || (tickStyles.label &&
+          <text {...(tickStyles.label || {})[orientation]} />
+        )}
+        tickValues={tickValues}
+      />
+    );
+  }
 }
 
 XAxis.propTypes = propTypes;

--- a/packages/xy-chart/src/axis/YAxis.jsx
+++ b/packages/xy-chart/src/axis/YAxis.jsx
@@ -38,51 +38,54 @@ const defaultProps = {
   tickValues: undefined,
 };
 
-export default function YAxis({
-  axisStyles,
-  hideZero,
-  innerWidth,
-  label,
-  labelOffset,
-  numTicks,
-  orientation,
-  rangePadding,
-  scale,
-  tickFormat,
-  tickLabelComponent,
-  tickStyles,
-  tickValues,
-}) {
-  if (!scale || !innerWidth) return null;
+export default class YAxis extends React.PureComponent {
+  render() {
+    const {
+      axisStyles,
+      hideZero,
+      innerWidth,
+      label,
+      labelOffset,
+      numTicks,
+      orientation,
+      rangePadding,
+      scale,
+      tickFormat,
+      tickLabelComponent,
+      tickStyles,
+      tickValues,
+    } = this.props;
+    if (!scale || !innerWidth) return null;
 
-  const Axis = orientation === 'left' ? AxisLeft : AxisRight;
-  return (
-    <Axis
-      top={0}
-      left={orientation === 'right' ? innerWidth : 0}
-      rangePadding={rangePadding}
-      hideTicks={numTicks === 0}
-      hideZero={hideZero}
-      label={typeof label === 'string' && axisStyles.label ?
-        <text {...(axisStyles.label || {})[orientation]}>
-          {label}
-        </text>
-        : label
-      }
-      labelOffset={labelOffset}
-      numTicks={numTicks}
-      scale={scale}
-      stroke={axisStyles.stroke}
-      strokeWidth={axisStyles.strokeWidth}
-      tickFormat={tickFormat}
-      tickLength={tickStyles.tickLength}
-      tickStroke={tickStyles.stroke}
-      tickLabelComponent={tickLabelComponent || (tickStyles.label &&
-        <text {...(tickStyles.label || {})[orientation]} />
-      )}
-      tickValues={tickValues}
-    />
-  );
+    const Axis = orientation === 'left' ? AxisLeft : AxisRight;
+    return (
+      <Axis
+        top={0}
+        left={orientation === 'right' ? innerWidth : 0}
+        rangePadding={rangePadding}
+        hideTicks={numTicks === 0}
+        hideZero={hideZero}
+        label={typeof label === 'string' && axisStyles.label ?
+          <text {...(axisStyles.label || {})[orientation]}>
+            {label}
+          </text>
+          : label
+        }
+        labelOffset={labelOffset}
+        numTicks={numTicks}
+        scale={scale}
+        stroke={axisStyles.stroke}
+        strokeWidth={axisStyles.strokeWidth}
+        tickFormat={tickFormat}
+        tickLength={tickStyles.tickLength}
+        tickStroke={tickStyles.stroke}
+        tickLabelComponent={tickLabelComponent || (tickStyles.label &&
+          <text {...(tickStyles.label || {})[orientation]} />
+        )}
+        tickValues={tickValues}
+      />
+    );
+  }
 }
 
 YAxis.propTypes = propTypes;

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -208,9 +208,7 @@ class XYChart extends React.PureComponent {
 
     const { numXTicks, numYTicks } = this.getNumTicks(innerWidth, innerHeight);
     const barWidth = xScale.barWidth || (xScale.bandwidth && xScale.bandwidth()) || 0;
-
     let CrossHair; // ensure this is the top-most layer
-    console.log('xy-chart render');
 
     return innerWidth > 0 && innerHeight > 0 && (
       <svg

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -45,65 +45,69 @@ const x = d => d.x;
 const y = d => d.y;
 const defined = d => isDefined(y(d));
 
-export default function AreaSeries({
-  data,
-  xScale,
-  yScale,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  strokeLinecap,
-  fill,
-  fillOpacity,
-  interpolation,
-  label,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
-  const strokeWidthValue = callOrValue(strokeWidth, data);
-  const fillValue = callOrValue(fill, data);
-  const curve = interpolatorLookup[interpolation] || interpolatorLookup.cardinal;
-  return (
-    <Group
-      onMouseMove={onMouseMove && ((event) => {
-        const d = findClosestDatum({ data, getX: x, event, xScale });
-        onMouseMove({ event, data, datum: d, color: fillValue });
-      })}
-      onMouseLeave={onMouseLeave}
-    >
-      <AreaClosed
-        key={`${label}-area`}
-        data={data}
-        x={x}
-        y={y}
-        xScale={xScale}
-        yScale={yScale}
-        fill={fillValue}
-        fillOpacity={callOrValue(fillOpacity, data)}
-        stroke="transparent"
-        strokeWidth={strokeWidthValue}
-        curve={curve}
-        defined={defined}
-      />
-      {strokeWidthValue > 0 &&
-        <LinePath
-          key={`${label}-line`}
+export default class AreaSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      xScale,
+      yScale,
+      stroke,
+      strokeWidth,
+      strokeDasharray,
+      strokeLinecap,
+      fill,
+      fillOpacity,
+      interpolation,
+      label,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+
+    if (!xScale || !yScale) return null;
+    const strokeWidthValue = callOrValue(strokeWidth, data);
+    const fillValue = callOrValue(fill, data);
+    const curve = interpolatorLookup[interpolation] || interpolatorLookup.cardinal;
+    return (
+      <Group
+        onMouseMove={onMouseMove && ((event) => {
+          const d = findClosestDatum({ data, getX: x, event, xScale });
+          onMouseMove({ event, data, datum: d, color: fillValue });
+        })}
+        onMouseLeave={onMouseLeave}
+      >
+        <AreaClosed
+          key={`${label}-area`}
           data={data}
           x={x}
           y={y}
           xScale={xScale}
           yScale={yScale}
-          stroke={callOrValue(stroke, data)}
+          fill={fillValue}
+          fillOpacity={callOrValue(fillOpacity, data)}
+          stroke="transparent"
           strokeWidth={strokeWidthValue}
-          strokeDasharray={callOrValue(strokeDasharray, data)}
-          strokeLinecap={strokeLinecap}
           curve={curve}
-          glyph={null}
           defined={defined}
-        />}
-    </Group>
-  );
+        />
+        {strokeWidthValue > 0 &&
+          <LinePath
+            key={`${label}-line`}
+            data={data}
+            x={x}
+            y={y}
+            xScale={xScale}
+            yScale={yScale}
+            stroke={callOrValue(stroke, data)}
+            strokeWidth={strokeWidthValue}
+            strokeDasharray={callOrValue(strokeDasharray, data)}
+            strokeLinecap={strokeLinecap}
+            curve={curve}
+            glyph={null}
+            defined={defined}
+          />}
+      </Group>
+    );
+  }
 }
 
 AreaSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/BarSeries.jsx
+++ b/packages/xy-chart/src/series/BarSeries.jsx
@@ -40,46 +40,50 @@ const defaultProps = {
 const x = d => d.x;
 const y = d => d.y;
 
-export default function BarSeries({
-  barWidth,
-  data,
-  fill,
-  stroke,
-  strokeWidth,
-  label,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale || !barWidth) return null;
+export default class BarSeries extends React.PureComponent {
+  render() {
+    const {
+      barWidth,
+      data,
+      fill,
+      stroke,
+      strokeWidth,
+      label,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
 
-  const maxHeight = (yScale.range() || [0])[0];
-  const offset = xScale.offset || 0;
-  return (
-    <Group key={label}>
-      {data.map((d, i) => {
-        const barHeight = maxHeight - yScale(y(d));
-        const color = d.fill || callOrValue(fill, d, i);
-        return isDefined(d.y) && (
-          <Bar
-            key={`bar-${label}-${xScale(x(d))}`}
-            x={xScale(x(d)) - offset}
-            y={maxHeight - barHeight}
-            width={barWidth}
-            height={barHeight}
-            fill={color}
-            stroke={d.stroke || callOrValue(stroke, d, i)}
-            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-            onMouseMove={onMouseMove && (() => (event) => {
-              onMouseMove({ event, data, datum: d, color });
-            })}
-            onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-          />
-        );
-      })}
-    </Group>
-  );
+    if (!xScale || !yScale || !barWidth) return null;
+
+    const maxHeight = (yScale.range() || [0])[0];
+    const offset = xScale.offset || 0;
+    return (
+      <Group key={label}>
+        {data.map((d, i) => {
+          const barHeight = maxHeight - yScale(y(d));
+          const color = d.fill || callOrValue(fill, d, i);
+          return isDefined(d.y) && (
+            <Bar
+              key={`bar-${label}-${xScale(x(d))}`}
+              x={xScale(x(d)) - offset}
+              y={maxHeight - barHeight}
+              width={barWidth}
+              height={barHeight}
+              fill={color}
+              stroke={d.stroke || callOrValue(stroke, d, i)}
+              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              onMouseMove={onMouseMove && (() => (event) => {
+                onMouseMove({ event, data, datum: d, color });
+              })}
+              onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+            />
+          );
+        })}
+      </Group>
+    );
+  }
 }
 
 BarSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/CirclePackSeries.jsx
+++ b/packages/xy-chart/src/series/CirclePackSeries.jsx
@@ -9,9 +9,9 @@ const propTypes = {
   ...PointSeries.propTypes,
   data: PropTypes.arrayOf(
     PropTypes.shape({
+      // x should be anything sortable
       x: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.instanceOf(Date)]),
       size: PropTypes.number,
-      importance: PropTypes.number,
     }),
   ).isRequired,
 };
@@ -20,17 +20,18 @@ const defaultProps = {
   ...PointSeries.defaultProps,
 };
 
-function CirclePackSeries(props) {
-  const { data, xScale, yScale } = props;
-  const { data: modifiedData,
-          yScale: modifiedYScale } = computeCirclePack(data, xScale, yScale);
-  return (
-    <PointSeries
-      {...props}
-      data={modifiedData}
-      yScale={modifiedYScale}
-    />
-  );
+// eslint-disable-next-line react/prefer-stateless-function
+class CirclePackSeries extends React.PureComponent {
+  render() {
+    const { data: rawData, xScale } = this.props;
+    const data = computeCirclePack(rawData, xScale);
+    return (
+      <PointSeries
+        {...this.props}
+        data={data}
+      />
+    );
+  }
 }
 
 CirclePackSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/GroupedBarSeries.jsx
+++ b/packages/xy-chart/src/series/GroupedBarSeries.jsx
@@ -36,49 +36,53 @@ const defaultProps = {
 
 const x = d => d.x;
 
-export default function GroupedBarSeries({
-  data,
-  groupKeys,
-  groupFills,
-  groupPadding,
-  stroke,
-  strokeWidth,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
-  if (!xScale.bandwidth) { // @todo figure this out/be more graceful
-    throw new Error("'GroupedBarSeries' requires a 'band' type xScale");
+export default class GroupedBarSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      groupKeys,
+      groupFills,
+      groupPadding,
+      stroke,
+      strokeWidth,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+
+    if (!xScale || !yScale) return null;
+    if (!xScale.bandwidth) { // @todo figure this out/be more graceful
+      throw new Error("'GroupedBarSeries' requires a 'band' type xScale");
+    }
+    const maxHeight = (yScale.range() || [0])[0];
+    const x1Scale = scaleTypeToScale.band({
+      rangeRound: [0, xScale.bandwidth()],
+      domain: groupKeys,
+      padding: groupPadding,
+    });
+    const zScale = scaleTypeToScale.ordinal({ range: groupFills, domain: groupKeys });
+    return (
+      <BarGroup
+        data={data}
+        keys={groupKeys}
+        height={maxHeight}
+        x0={x}
+        x0Scale={xScale}
+        x1Scale={x1Scale}
+        yScale={yScale}
+        zScale={zScale}
+        rx={2}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        onMouseMove={onMouseMove && (d => (event) => {
+          const { key, data: datum } = d;
+          onMouseMove({ event, data, datum, key, color: zScale(key) });
+        })}
+        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+      />
+    );
   }
-  const maxHeight = (yScale.range() || [0])[0];
-  const x1Scale = scaleTypeToScale.band({
-    rangeRound: [0, xScale.bandwidth()],
-    domain: groupKeys,
-    padding: groupPadding,
-  });
-  const zScale = scaleTypeToScale.ordinal({ range: groupFills, domain: groupKeys });
-  return (
-    <BarGroup
-      data={data}
-      keys={groupKeys}
-      height={maxHeight}
-      x0={x}
-      x0Scale={xScale}
-      x1Scale={x1Scale}
-      yScale={yScale}
-      zScale={zScale}
-      rx={2}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      onMouseMove={onMouseMove && (d => (event) => {
-        const { key, data: datum } = d;
-        onMouseMove({ event, data, datum, key, color: zScale(key) });
-      })}
-      onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-    />
-  );
 }
 
 GroupedBarSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/IntervalSeries.jsx
+++ b/packages/xy-chart/src/series/IntervalSeries.jsx
@@ -36,45 +36,48 @@ const defaultProps = {
 const x0 = d => d.x0;
 const x1 = d => d.x1;
 
-export default function IntervalSeries({
-  data,
-  fill,
-  label,
-  stroke,
-  strokeWidth,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
+export default class IntervalSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      fill,
+      label,
+      stroke,
+      strokeWidth,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
 
-  const barHeight = (yScale.range() || [0])[0];
-  return (
-    <Group key={label}>
-      {data.map((d, i) => {
-        const x = xScale(x0(d));
-        const barWidth = xScale(x1(d)) - x;
-        const intervalFill = d.fill || callOrValue(fill, d, i);
-        return (
-          <Bar
-            key={`interval-${label}-${x}`}
-            x={x}
-            y={0}
-            width={barWidth}
-            height={barHeight}
-            fill={intervalFill}
-            stroke={d.stroke || callOrValue(stroke, d, i)}
-            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-            onMouseMove={onMouseMove && (() => (event) => {
-              onMouseMove({ event, datum: d, data, color: intervalFill });
-            })}
-            onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-          />
-        );
-      })}
-    </Group>
-  );
+    const barHeight = (yScale.range() || [0])[0];
+    return (
+      <Group key={label}>
+        {data.map((d, i) => {
+          const x = xScale(x0(d));
+          const barWidth = xScale(x1(d)) - x;
+          const intervalFill = d.fill || callOrValue(fill, d, i);
+          return (
+            <Bar
+              key={`interval-${label}-${x}`}
+              x={x}
+              y={0}
+              width={barWidth}
+              height={barHeight}
+              fill={intervalFill}
+              stroke={d.stroke || callOrValue(stroke, d, i)}
+              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              onMouseMove={onMouseMove && (() => (event) => {
+                onMouseMove({ event, datum: d, data, color: intervalFill });
+              })}
+              onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+            />
+          );
+        })}
+      </Group>
+    );
+  }
 }
 
 IntervalSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -45,69 +45,72 @@ const x = d => d.x;
 const y = d => d.y;
 const defined = d => isDefined(y(d));
 
-export default function LineSeries({
-  data,
-  interpolation,
-  label,
-  showPoints,
-  stroke,
-  strokeDasharray,
-  strokeWidth,
-  strokeLinecap,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
-  const strokeValue = callOrValue(stroke);
-  return (
-    <LinePath
-      key={label}
-      data={data}
-      xScale={xScale}
-      yScale={yScale}
-      x={x}
-      y={y}
-      stroke={strokeValue}
-      strokeWidth={callOrValue(strokeWidth)}
-      strokeDasharray={callOrValue(strokeDasharray)}
-      strokeLinecap={strokeLinecap}
-      curve={interpolation === 'linear' ? curveLinear : curveCardinal}
-      defined={defined}
-      onMouseMove={onMouseMove && (() => (event) => {
-        const d = findClosestDatum({ data, getX: x, event, xScale });
-        onMouseMove({ event, data, datum: d, color: strokeValue });
-      })}
-      onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-      glyph={showPoints && ((d, i) => (
-        isDefined(x(d)) && isDefined(y(d)) &&
-          <GlyphDot
-            key={`${label}-${i}-${x(d)}`}
-            cx={xScale(x(d))}
-            cy={yScale(y(d))}
-            r={4}
-            fill={d.stroke || callOrValue(stroke, d, i)}
-            stroke="#FFFFFF"
-            strokeWidth={1}
-            style={{ pointerEvents: 'none' }}
-          >
-            {d.label &&
-              <text
-                x={xScale(x(d))}
-                y={yScale(y(d))}
-                dx={10}
-                fill={d.stroke || callOrValue(stroke, d, i)}
-                stroke={'#fff'}
-                strokeWidth={1}
-                fontSize={12}
-              >
-                {d.label}
-              </text>}
-          </GlyphDot>
-      ))}
-    />
-  );
+export default class LineSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      interpolation,
+      label,
+      showPoints,
+      stroke,
+      strokeDasharray,
+      strokeWidth,
+      strokeLinecap,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
+    const strokeValue = callOrValue(stroke);
+    return (
+      <LinePath
+        key={label}
+        data={data}
+        xScale={xScale}
+        yScale={yScale}
+        x={x}
+        y={y}
+        stroke={strokeValue}
+        strokeWidth={callOrValue(strokeWidth)}
+        strokeDasharray={callOrValue(strokeDasharray)}
+        strokeLinecap={strokeLinecap}
+        curve={interpolation === 'linear' ? curveLinear : curveCardinal}
+        defined={defined}
+        onMouseMove={onMouseMove && (() => (event) => {
+          const d = findClosestDatum({ data, getX: x, event, xScale });
+          onMouseMove({ event, data, datum: d, color: strokeValue });
+        })}
+        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+        glyph={showPoints && ((d, i) => (
+          isDefined(x(d)) && isDefined(y(d)) &&
+            <GlyphDot
+              key={`${label}-${i}-${x(d)}`}
+              cx={xScale(x(d))}
+              cy={yScale(y(d))}
+              r={4}
+              fill={d.stroke || callOrValue(stroke, d, i)}
+              stroke="#FFFFFF"
+              strokeWidth={1}
+              style={{ pointerEvents: 'none' }}
+            >
+              {d.label &&
+                <text
+                  x={xScale(x(d))}
+                  y={yScale(y(d))}
+                  dx={10}
+                  fill={d.stroke || callOrValue(stroke, d, i)}
+                  stroke={'#fff'}
+                  strokeWidth={1}
+                  fontSize={12}
+                >
+                  {d.label}
+                </text>}
+            </GlyphDot>
+        ))}
+      />
+    );
+  }
 }
 
 LineSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -45,59 +45,62 @@ const defaultProps = {
 const x = d => d.x;
 const y = d => d.y;
 
-export default function PointSeries({
-  data,
-  label,
-  labelComponent,
-  fill,
-  fillOpacity,
-  size,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
+export default class PointSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      label,
+      labelComponent,
+      fill,
+      fillOpacity,
+      size,
+      stroke,
+      strokeWidth,
+      strokeDasharray,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
 
-  const labels = [];
-  return (
-    <Group key={label}>
-      {data.map((d, i) => {
-        const xVal = x(d);
-        const yVal = y(d);
-        const defined = isDefined(xVal) && isDefined(yVal);
-        const cx = xScale(xVal);
-        const cy = yScale(yVal);
-        const circleFill = d.fill || callOrValue(fill, d, i);
-        const key = `${label}-${x(d)}-${i}`;
-        if (defined && d.label) {
-          labels.push({ x: cx, y: cy, label: d.label, key: `${key}-label` });
-        }
-        return defined && (
-          <GlyphDot
-            key={key}
-            cx={cx}
-            cy={cy}
-            r={d.size || callOrValue(size, d, i)}
-            fill={circleFill}
-            fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
-            stroke={d.stroke || callOrValue(stroke, d, i)}
-            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-            strokeDasharray={d.strokeDasharray || callOrValue(strokeDasharray, d, i)}
-            onMouseMove={onMouseMove && ((event) => {
-              onMouseMove({ event, data, datum: d, color: circleFill });
-            })}
-            onMouseLeave={onMouseLeave}
-          />
-        );
-      })}
-      {/* Put labels on top */}
-      {labels.map(d => React.cloneElement(labelComponent, d, d.label))}
-    </Group>
-  );
+    const labels = [];
+    return (
+      <Group key={label}>
+        {data.map((d, i) => {
+          const xVal = x(d);
+          const yVal = y(d);
+          const defined = isDefined(xVal) && isDefined(yVal);
+          const cx = xScale(xVal);
+          const cy = yScale(yVal);
+          const circleFill = d.fill || callOrValue(fill, d, i);
+          const key = `${label}-${x(d)}-${i}`;
+          if (defined && d.label) {
+            labels.push({ x: cx, y: cy, label: d.label, key: `${key}-label` });
+          }
+          return defined && (
+            <GlyphDot
+              key={key}
+              cx={cx}
+              cy={cy}
+              r={d.size || callOrValue(size, d, i)}
+              fill={circleFill}
+              fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
+              stroke={d.stroke || callOrValue(stroke, d, i)}
+              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              strokeDasharray={d.strokeDasharray || callOrValue(strokeDasharray, d, i)}
+              onMouseMove={onMouseMove && ((event) => {
+                onMouseMove({ event, data, datum: d, color: circleFill });
+              })}
+              onMouseLeave={onMouseLeave}
+            />
+          );
+        })}
+        {/* Put labels on top */}
+        {labels.map(d => React.cloneElement(labelComponent, d, d.label))}
+      </Group>
+    );
+  }
 }
 
 PointSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/series/StackedBarSeries.jsx
+++ b/packages/xy-chart/src/series/StackedBarSeries.jsx
@@ -33,41 +33,44 @@ const defaultProps = {
 
 const x = d => d.x;
 
-export default function StackedBarSeries({
-  data,
-  stackKeys,
-  stackFills,
-  stroke,
-  strokeWidth,
-  xScale,
-  yScale,
-  onMouseMove,
-  onMouseLeave,
-}) {
-  if (!xScale || !yScale) return null;
-  if (!xScale.bandwidth) { // @todo figure this out/be more graceful
-    throw new Error("'StackedBarSeries' requires a 'band' type xScale");
+export default class StackedBarSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      stackKeys,
+      stackFills,
+      stroke,
+      strokeWidth,
+      xScale,
+      yScale,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
+    if (!xScale.bandwidth) { // @todo figure this out/be more graceful
+      throw new Error("'StackedBarSeries' requires a 'band' type xScale");
+    }
+    const maxHeight = (yScale.range() || [0])[0];
+    const zScale = scaleTypeToScale.ordinal({ range: stackFills, domain: stackKeys });
+    return (
+      <BarStack
+        data={data}
+        keys={stackKeys}
+        height={maxHeight}
+        x={x}
+        xScale={xScale}
+        yScale={yScale}
+        zScale={zScale}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        onMouseMove={onMouseMove && (d => (event) => {
+          const { data: datum, key } = d;
+          onMouseMove({ event, data, datum, key, color: zScale(key) });
+        })}
+        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+      />
+    );
   }
-  const maxHeight = (yScale.range() || [0])[0];
-  const zScale = scaleTypeToScale.ordinal({ range: stackFills, domain: stackKeys });
-  return (
-    <BarStack
-      data={data}
-      keys={stackKeys}
-      height={maxHeight}
-      x={x}
-      xScale={xScale}
-      yScale={yScale}
-      zScale={zScale}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      onMouseMove={onMouseMove && (d => (event) => {
-        const { data: datum, key } = d;
-        onMouseMove({ event, data, datum, key, color: zScale(key) });
-      })}
-      onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-    />
-  );
 }
 
 StackedBarSeries.propTypes = propTypes;

--- a/packages/xy-chart/src/utils/computeCirclePack.js
+++ b/packages/xy-chart/src/utils/computeCirclePack.js
@@ -250,15 +250,7 @@ function packCircles(data, xScale) {
   return nodes;
 }
 
-function rescale(yScale) {
-  const modifiedYScale = yScale.copy();
-  const [rangemin, rangemax] = modifiedYScale.range();
-  const height = Math.abs(rangemin - rangemax);
-  modifiedYScale.domain([-height / 2, height / 2]);
-  return modifiedYScale;
-}
-
-export default function computeCirclePack(data, xScale, yScale) {
+export default function computeCirclePack(data, xScale) {
   const sorted = data.sort((a, b) => a.x - b.x);
   const calculatedNodes = packCircles(data, xScale);
   const result = [];
@@ -270,10 +262,5 @@ export default function computeCirclePack(data, xScale, yScale) {
     });
   }
 
-  const modifiedYScale = rescale(yScale);
-
-  return {
-    data: result,
-    yScale: modifiedYScale,
-  };
+  return result;
 }

--- a/packages/xy-chart/test/CirclePackSeries.test.js
+++ b/packages/xy-chart/test/CirclePackSeries.test.js
@@ -14,9 +14,9 @@ describe('<PointSeries />', () => {
   };
 
   const mockData = [
-    { x: new Date('2017-01-05 00:00:00'), importance: 0, size: 1 },
-    { x: new Date('2017-01-05 01:00:00'), importance: 1, size: 3 },
-    { x: new Date('2017-01-05 02:00:00'), importance: 5, size: 5 },
+    { x: new Date('2017-01-05 00:00:00'), size: 1 },
+    { x: new Date('2017-01-05 01:00:00'), size: 3 },
+    { x: new Date('2017-01-05 02:00:00'), size: 5 },
   ];
 
   test('it should be defined', () => {
@@ -26,12 +26,25 @@ describe('<PointSeries />', () => {
   test('it should render a PointSeries', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <CirclePackSeries label="" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <CirclePackSeries label="" data={mockData} />
       </XYChart>,
     );
     const circleSeries = wrapper.find(CirclePackSeries);
     expect(circleSeries.length).toBe(1);
     expect(circleSeries.dive().find(PointSeries).length).toBe(1);
+  });
+
+  test('data passed to PointSeries should include computed y values', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <CirclePackSeries label="" data={mockData} />
+      </XYChart>,
+    );
+    const circleSeries = wrapper.find(CirclePackSeries);
+    const pointSeries = circleSeries.dive().find(PointSeries);
+    const data = pointSeries.prop('data');
+    expect(mockData[0].y).toBeUndefined();
+    expect(data[0].y).toEqual(expect.any(Number));
   });
 
   test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {

--- a/packages/xy-chart/test/computeCirclePack.test.js
+++ b/packages/xy-chart/test/computeCirclePack.test.js
@@ -1,0 +1,62 @@
+import { scaleLinear } from '@vx/scale';
+import computeCirclePack from '../src/utils/computeCirclePack';
+
+describe('computeCirclePack', () => {
+  const mockData = [
+    { x: 10, size: 1, id: '1' },
+    { x: 9, size: 3, id: '2' },
+    { x: 1, size: 5, id: '3' },
+    { x: 100, size: 5, id: '4' },
+    { x: 3, size: 5, id: '5' },
+  ];
+
+  const xScale = scaleLinear({
+    range: [0, 100],
+    domain: [1, 100],
+  });
+
+  test('it should be defined', () => {
+    expect(computeCirclePack).toBeDefined();
+  });
+
+  test('input data length should match output data length', () => {
+    const output = computeCirclePack(mockData, xScale);
+    expect(output.length).toBe(mockData.length);
+  });
+
+  test('input data with lower x values should have lower x values in output', () => {
+    const output = computeCirclePack(mockData, xScale);
+    expect(output.length).toBe(mockData.length);
+  });
+
+  test('numeric y values should be added to output data', () => {
+    expect.assertions(mockData.length);
+
+    const output = computeCirclePack(mockData, xScale);
+    output.forEach((d) => {
+      expect(d.y).toEqual(expect.any(Number));
+    });
+  });
+
+  test('x, size, and other datum properties should be copied to output data', () => {
+    expect.assertions(mockData.length);
+
+    const output = computeCirclePack(mockData, xScale);
+    output.forEach((outputDatum) => {
+      const inputIndex = mockData.findIndex(inputDatum => inputDatum.id === outputDatum.id);
+      const inputDatum = mockData[inputIndex];
+      expect(Object.keys(outputDatum)).toEqual(expect.arrayContaining(Object.keys(inputDatum)));
+    });
+  });
+
+  test('input datum should not be modified', () => {
+    expect.assertions(mockData.length);
+
+    const output = computeCirclePack(mockData, xScale);
+    output.forEach((outputDatum) => {
+      const inputIndex = mockData.findIndex(inputDatum => inputDatum.id === outputDatum.id);
+      const inputDatum = mockData[inputIndex];
+      expect(outputDatum).not.toBe(inputDatum);
+    });
+  });
+});


### PR DESCRIPTION
this PR makes the following changes to address remaining todos in https://github.com/williaster/data-ui/pull/54

- caches scales in xychart
- use PureComponents for all series for perf
- moves yScale modifications from `CirclePackSeries` to `XYChart` so all series and axes share a single scale.

UPDATE:
- added tests for `computeCirclePack.js`
- use PureComponents for all axes for perf as well

cc @conglei 