### PR TITLE
Conglei customized point renderer

### DIFF
--- a/packages/demo/examples/01-xy-chart/RectPointComponent.jsx
+++ b/packages/demo/examples/01-xy-chart/RectPointComponent.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export default function RectComponent({
+  key,
+  x,
+  y,
+  size,
+  fill,
+  fillOpacity,
+  stroke,
+  strokeWidth,
+  strokeDasharray,
+  onMouseMove,
+  onMouseLeave,
+  data,
+  datum,
+}) {
+  const rectSize = size * 1.414;
+  return (
+    <rect
+      key={key}
+      x={x - rectSize / 2}
+      y={y - rectSize / 2}
+      width={rectSize}
+      height={rectSize}
+      fill={fill}
+      fillOpacity={fillOpacity}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      strokeDasharray={strokeDasharray}
+      onMouseMove={onMouseMove && ((event) => {
+        onMouseMove({ event, data, datum, color: fill });
+      })}
+      onMouseLeave={onMouseLeave}
+    />
+  )
+}

--- a/packages/demo/examples/01-xy-chart/RectPointComponent.jsx
+++ b/packages/demo/examples/01-xy-chart/RectPointComponent.jsx
@@ -1,3 +1,4 @@
+/* eslint react/prop-types: 0 */
 import React from 'react';
 
 export default function RectComponent({
@@ -33,5 +34,5 @@ export default function RectComponent({
       })}
       onMouseLeave={onMouseLeave}
     />
-  )
+  );
 }

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -26,6 +26,7 @@ import readme from '../../node_modules/@data-ui/xy-chart/README.md';
 
 import ResponsiveXYChart, { dateFormatter } from './ResponsiveXYChart';
 import ScatterWithHistogram from './ScatterWithHistograms';
+import RectPointComponent from './RectPointComponent';
 
 import {
   circlePackData,
@@ -200,6 +201,26 @@ export default {
       ),
     },
     {
+      description: 'PointSeries With Customized Renderer',
+      components: [PointSeries],
+      example: () => (
+        <ResponsiveXYChart
+          ariaLabel="Required label"
+          xScale={{ type: 'linear', nice: true }}
+          yScale={{ type: 'linear', nice: true }}
+        >
+          <YAxis label="Y" numTicks={4} />
+          <XAxis label="X" numTicks={4} />
+          <PointSeries
+            data={pointData}
+            label="Random"
+            size={d => d.size}
+            pointComponent={RectPointComponent}
+          />
+        </ResponsiveXYChart>
+      ),
+    },
+    {
       description: 'StackedBarSeries',
       components: [StackedBarSeries],
       example: () => (
@@ -312,6 +333,35 @@ export default {
             data={circlePackData}
             label="Circle time pack"
             size={d => d.r}
+          />
+          <HorizontalReferenceLine
+            reference={0}
+          />
+          <CrossHair
+            showHorizontalLine={false}
+            fullHeight
+            stroke={colors.default}
+            circleFill="white"
+            circleStroke={colors.default}
+          />
+          <XAxis label="Time" numTicks={5} />
+        </ResponsiveXYChart>
+      ),
+    },
+    {
+      description: 'CirclePackSeries With Customized Renderer',
+      components: [CirclePackSeries],
+      example: () => (
+        <ResponsiveXYChart
+          ariaLabel="Required label"
+          xScale={{ type: 'time' }}
+          yScale={{ type: 'linear' }}
+        >
+          <CirclePackSeries
+            data={circlePackData}
+            label="Circle time pack"
+            size={d => d.r}
+            pointComponent={RectPointComponent}
           />
           <HorizontalReferenceLine
             reference={0}

--- a/packages/xy-chart/src/glyph/GlyphDotComponent.jsx
+++ b/packages/xy-chart/src/glyph/GlyphDotComponent.jsx
@@ -1,7 +1,16 @@
 import React from 'react';
-import { PointComponentPropTypes } from '@data-ui/xy-chart';
+import { GlyphDot } from '@vx/glyph';
 
-export default function RectComponent({
+import { PointComponentPropTypes } from '../utils/propShapes';
+
+
+const GlyphDotComponentDefaultPropTypes = {
+  onMouseMove: null,
+  onMouseLeave: null,
+  strokeDasharray: null,
+};
+
+export default function GlyphDotComponent({
   x,
   y,
   size,
@@ -15,13 +24,11 @@ export default function RectComponent({
   data,
   datum,
 }) {
-  const rectSize = size * 1.414;
   return (
-    <rect
-      x={x - (rectSize / 2)}
-      y={y - (rectSize / 2)}
-      width={rectSize}
-      height={rectSize}
+    <GlyphDot
+      cx={x}
+      cy={y}
+      r={size}
       fill={fill}
       fillOpacity={fillOpacity}
       stroke={stroke}
@@ -35,11 +42,5 @@ export default function RectComponent({
   );
 }
 
-const defaultProps = {
-  strokeDasharray: null,
-  onMouseMove: null,
-  onMouseLeave: null,
-};
-
-RectComponent.propTypes = PointComponentPropTypes;
-RectComponent.defaultProps = defaultProps;
+GlyphDotComponent.propTypes = PointComponentPropTypes;
+GlyphDotComponent.defaultProps = GlyphDotComponentDefaultPropTypes;

--- a/packages/xy-chart/src/glyph/GlyphDotComponent.jsx
+++ b/packages/xy-chart/src/glyph/GlyphDotComponent.jsx
@@ -1,24 +1,7 @@
 import React from 'react';
 import { GlyphDot } from '@vx/glyph';
-import PropTypes from 'prop-types';
 
-import { pointSeriesDataShape } from '../utils/propShapes';
-
-
-export const propTypes = {
-  x: PropTypes.number.isRequired,
-  y: PropTypes.number.isRequired,
-  size: PropTypes.number.isRequired,
-  fill: PropTypes.string.isRequired,
-  fillOpacity: PropTypes.number.isRequired,
-  stroke: PropTypes.string.isRequired,
-  strokeWidth: PropTypes.number.isRequired,
-  strokeDasharray: PropTypes.string,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
-  data: pointSeriesDataShape.isRequired,
-  datum: PropTypes.object.isRequired,
-};
+import { pointComponentPropTypes } from '../series/PointSeries';
 
 const defaultPropTypes = {
   onMouseMove: null,
@@ -58,5 +41,5 @@ export default function GlyphDotComponent({
   );
 }
 
-GlyphDotComponent.propTypes = propTypes;
+GlyphDotComponent.propTypes = pointComponentPropTypes;
 GlyphDotComponent.defaultProps = defaultPropTypes;

--- a/packages/xy-chart/src/glyph/GlyphDotComponent.jsx
+++ b/packages/xy-chart/src/glyph/GlyphDotComponent.jsx
@@ -1,10 +1,26 @@
 import React from 'react';
 import { GlyphDot } from '@vx/glyph';
+import PropTypes from 'prop-types';
 
-import { PointComponentPropTypes } from '../utils/propShapes';
+import { pointSeriesDataShape } from '../utils/propShapes';
 
 
-const GlyphDotComponentDefaultPropTypes = {
+export const propTypes = {
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired,
+  size: PropTypes.number.isRequired,
+  fill: PropTypes.string.isRequired,
+  fillOpacity: PropTypes.number.isRequired,
+  stroke: PropTypes.string.isRequired,
+  strokeWidth: PropTypes.number.isRequired,
+  strokeDasharray: PropTypes.string,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  data: pointSeriesDataShape.isRequired,
+  datum: PropTypes.object.isRequired,
+};
+
+const defaultPropTypes = {
   onMouseMove: null,
   onMouseLeave: null,
   strokeDasharray: null,
@@ -42,5 +58,5 @@ export default function GlyphDotComponent({
   );
 }
 
-GlyphDotComponent.propTypes = PointComponentPropTypes;
-GlyphDotComponent.defaultProps = GlyphDotComponentDefaultPropTypes;
+GlyphDotComponent.propTypes = propTypes;
+GlyphDotComponent.defaultProps = defaultPropTypes;

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -22,4 +22,4 @@ export { withScreenSize, withParentSize } from '@vx/responsive';
 export { default as withTheme } from './enhancer/withTheme';
 export { chartTheme as theme } from '@data-ui/theme';
 
-export { PointComponentPropTypes } from './utils/propShapes';
+export { propTypes as PointComponentPropTypes } from './glyph/GlyphDotComponent';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -21,3 +21,5 @@ export { withScreenSize, withParentSize } from '@vx/responsive';
 
 export { default as withTheme } from './enhancer/withTheme';
 export { chartTheme as theme } from '@data-ui/theme';
+
+export { PointComponentPropTypes } from './utils/propShapes';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -8,7 +8,7 @@ export { default as CirclePackSeries } from './series/CirclePackSeries';
 export { default as GroupedBarSeries } from './series/GroupedBarSeries';
 export { default as IntervalSeries } from './series/IntervalSeries';
 export { default as LineSeries } from './series/LineSeries';
-export { default as PointSeries } from './series/PointSeries';
+export { default as PointSeries, pointComponentPropTypes } from './series/PointSeries';
 export { default as StackedBarSeries } from './series/StackedBarSeries';
 
 export { default as HorizontalReferenceLine } from './annotation/HorizontalReferenceLine';
@@ -21,5 +21,3 @@ export { withScreenSize, withParentSize } from '@vx/responsive';
 
 export { default as withTheme } from './enhancer/withTheme';
 export { chartTheme as theme } from '@data-ui/theme';
-
-export { propTypes as PointComponentPropTypes } from './glyph/GlyphDotComponent';

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -65,7 +65,7 @@ export default class PointSeries extends React.PureComponent {
     return (
       <Group key={label}>
         {data.map((d, i) => {
-          const xVal = d.x
+          const xVal = d.x;
           const yVal = d.y;
           const defined = isDefined(xVal) && isDefined(yVal);
           const x = xScale(xVal);

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -7,8 +7,30 @@ import { chartTheme, color } from '@data-ui/theme';
 import { callOrValue, isDefined } from '../utils/chartUtils';
 import { pointSeriesDataShape } from '../utils/propShapes';
 
+
+const GlyphDotComponentPropType = {
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired,
+  size: PropTypes.number.isRequired,
+  fill: PropTypes.string.isRequired,
+  fillOpacity: PropTypes.number.isRequired,
+  stroke: PropTypes.string.isRequired,
+  strokeWidth: PropTypes.number.isRequired,
+  strokeDasharray: PropTypes.string,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  data: pointSeriesDataShape.isRequired,
+  datum: PropTypes.object.isRequired,
+}
+
+GlyphDotComponentDefaultPropType = {
+  onMouseMove: null,
+  onMouseLeave: null,
+  strokeDasharray: null,
+}
+
 function GlyphDotComponent({
-  key,
+  label,
   x,
   y,
   size,
@@ -22,9 +44,9 @@ function GlyphDotComponent({
   data,
   datum,
 }) {
+
   return (
     <GlyphDot
-      key={key}
       cx={x}
       cy={y}
       r={size}
@@ -38,14 +60,17 @@ function GlyphDotComponent({
       })}
       onMouseLeave={onMouseLeave}
     />
-  )
+  );
 }
+
+GlyphDotComponent.propTypes = GlyphDotComponentPropType;
+GlyphDotComponent.defaultProps = GlyphDotComponentDefaultPropType;
 
 export const propTypes = {
   data: pointSeriesDataShape.isRequired,
   label: PropTypes.string.isRequired,
   labelComponent: PropTypes.element,
-  pointComponent: PropTypes.element,
+  pointComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
   // attributes on data points will override these
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fillOpacity: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
@@ -98,7 +123,7 @@ export default class PointSeries extends React.PureComponent {
       pointComponent,
     } = this.props;
     if (!xScale || !yScale) return null;
-
+    const labelSet = new Set();
     const labels = [];
     return (
       <Group key={label}>
@@ -118,9 +143,8 @@ export default class PointSeries extends React.PureComponent {
           const computedStroke = d.stroke || callOrValue(stroke, d, i);
           const computedStrokeWidth = d.strokeWidth || callOrValue(strokeWidth, d, i);
           const computedStrokeDasharray = d.strokeDasharray || callOrValue(strokeDasharray, d, i);
-          return defined &&
-            React.createElement(pointComponent, {
-              key,
+          const props = {
+              key: key,
               x: cx,
               y: cy,
               size: computedSize,
@@ -133,7 +157,9 @@ export default class PointSeries extends React.PureComponent {
               onMouseLeave,
               data,
               datum: d,
-            });
+          };
+          return defined &&
+            React.createElement(pointComponent, props);
         })}
         {/* Put labels on top */}
         {labels.map(d => React.cloneElement(labelComponent, d, d.label))}

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -42,9 +42,6 @@ export const defaultProps = {
   onMouseLeave: null,
 };
 
-const x = d => d.x;
-const y = d => d.y;
-
 export default class PointSeries extends React.PureComponent {
   render() {
     const {
@@ -68,15 +65,15 @@ export default class PointSeries extends React.PureComponent {
     return (
       <Group key={label}>
         {data.map((d, i) => {
-          const xVal = x(d);
-          const yVal = y(d);
+          const xVal = d.x
+          const yVal = d.y;
           const defined = isDefined(xVal) && isDefined(yVal);
-          const cx = xScale(xVal);
-          const cy = yScale(yVal);
+          const x = xScale(xVal);
+          const y = yScale(yVal);
           const computedFill = d.fill || callOrValue(fill, d, i);
-          const key = `${label}-${x(d)}-${i}`;
+          const key = `${label}-${d.x}-${i}`;
           if (defined && d.label) {
-            labels.push({ x: cx, y: cy, label: d.label, key: `${key}-label` });
+            labels.push({ x, y, label: d.label, key: `${key}-label` });
           }
           const computedSize = d.size || callOrValue(size, d, i);
           const computedFillOpacity = d.fillOpacity || callOrValue(fillOpacity, d, i);
@@ -85,8 +82,8 @@ export default class PointSeries extends React.PureComponent {
           const computedStrokeDasharray = d.strokeDasharray || callOrValue(strokeDasharray, d, i);
           const props = {
             key,
-            x: cx,
-            y: cy,
+            x,
+            y,
             size: computedSize,
             fill: computedFill,
             fillOpacity: computedFillOpacity,

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -1,70 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { GlyphDot } from '@vx/glyph';
 import { Group } from '@vx/group';
 import { chartTheme, color } from '@data-ui/theme';
 
 import { callOrValue, isDefined } from '../utils/chartUtils';
 import { pointSeriesDataShape } from '../utils/propShapes';
-
-
-const GlyphDotComponentPropType = {
-  x: PropTypes.number.isRequired,
-  y: PropTypes.number.isRequired,
-  size: PropTypes.number.isRequired,
-  fill: PropTypes.string.isRequired,
-  fillOpacity: PropTypes.number.isRequired,
-  stroke: PropTypes.string.isRequired,
-  strokeWidth: PropTypes.number.isRequired,
-  strokeDasharray: PropTypes.string,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
-  data: pointSeriesDataShape.isRequired,
-  datum: PropTypes.object.isRequired,
-}
-
-GlyphDotComponentDefaultPropType = {
-  onMouseMove: null,
-  onMouseLeave: null,
-  strokeDasharray: null,
-}
-
-function GlyphDotComponent({
-  label,
-  x,
-  y,
-  size,
-  fill,
-  fillOpacity,
-  stroke,
-  strokeWidth,
-  strokeDasharray,
-  onMouseMove,
-  onMouseLeave,
-  data,
-  datum,
-}) {
-
-  return (
-    <GlyphDot
-      cx={x}
-      cy={y}
-      r={size}
-      fill={fill}
-      fillOpacity={fillOpacity}
-      stroke={stroke}
-      strokeWidth={strokeWidth}
-      strokeDasharray={strokeDasharray}
-      onMouseMove={onMouseMove && ((event) => {
-        onMouseMove({ event, data, datum, color: fill });
-      })}
-      onMouseLeave={onMouseLeave}
-    />
-  );
-}
-
-GlyphDotComponent.propTypes = GlyphDotComponentPropType;
-GlyphDotComponent.defaultProps = GlyphDotComponentDefaultPropType;
+import GlyphDotComponent from '../glyph/GlyphDotComponent';
 
 export const propTypes = {
   data: pointSeriesDataShape.isRequired,
@@ -123,7 +64,6 @@ export default class PointSeries extends React.PureComponent {
       pointComponent,
     } = this.props;
     if (!xScale || !yScale) return null;
-    const labelSet = new Set();
     const labels = [];
     return (
       <Group key={label}>
@@ -144,19 +84,19 @@ export default class PointSeries extends React.PureComponent {
           const computedStrokeWidth = d.strokeWidth || callOrValue(strokeWidth, d, i);
           const computedStrokeDasharray = d.strokeDasharray || callOrValue(strokeDasharray, d, i);
           const props = {
-              key: key,
-              x: cx,
-              y: cy,
-              size: computedSize,
-              fill: computedFill,
-              fillOpacity: computedFillOpacity,
-              stroke: computedStroke,
-              strokeWidth: computedStrokeWidth,
-              strokeDasharray: computedStrokeDasharray,
-              onMouseMove,
-              onMouseLeave,
-              data,
-              datum: d,
+            key,
+            x: cx,
+            y: cy,
+            size: computedSize,
+            fill: computedFill,
+            fillOpacity: computedFillOpacity,
+            stroke: computedStroke,
+            strokeWidth: computedStrokeWidth,
+            strokeDasharray: computedStrokeDasharray,
+            onMouseMove,
+            onMouseLeave,
+            data,
+            datum: d,
           };
           return defined &&
             React.createElement(pointComponent, props);

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -7,6 +7,21 @@ import { callOrValue, isDefined } from '../utils/chartUtils';
 import { pointSeriesDataShape } from '../utils/propShapes';
 import GlyphDotComponent from '../glyph/GlyphDotComponent';
 
+export const pointComponentPropTypes = {
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired,
+  size: PropTypes.number.isRequired,
+  fill: PropTypes.string.isRequired,
+  fillOpacity: PropTypes.number.isRequired,
+  stroke: PropTypes.string.isRequired,
+  strokeWidth: PropTypes.number.isRequired,
+  strokeDasharray: PropTypes.string,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  data: pointSeriesDataShape.isRequired,
+  datum: PropTypes.object.isRequired,
+};
+
 export const propTypes = {
   data: pointSeriesDataShape.isRequired,
   label: PropTypes.string.isRequired,

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -72,22 +72,6 @@ export const pointSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
   strokeDasharray: PropTypes.string,
 }));
 
-
-export const PointComponentPropTypes = {
-  x: PropTypes.number.isRequired,
-  y: PropTypes.number.isRequired,
-  size: PropTypes.number.isRequired,
-  fill: PropTypes.string.isRequired,
-  fillOpacity: PropTypes.number.isRequired,
-  stroke: PropTypes.string.isRequired,
-  strokeWidth: PropTypes.number.isRequired,
-  strokeDasharray: PropTypes.string,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
-  data: pointSeriesDataShape.isRequired,
-  datum: PropTypes.object.isRequired,
-};
-
 export const intervalSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
   x0: PropTypes.oneOfType([
     PropTypes.string,

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -72,6 +72,22 @@ export const pointSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
   strokeDasharray: PropTypes.string,
 }));
 
+
+export const PointComponentPropTypes = {
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired,
+  size: PropTypes.number.isRequired,
+  fill: PropTypes.string.isRequired,
+  fillOpacity: PropTypes.number.isRequired,
+  stroke: PropTypes.string.isRequired,
+  strokeWidth: PropTypes.number.isRequired,
+  strokeDasharray: PropTypes.string,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  data: pointSeriesDataShape.isRequired,
+  datum: PropTypes.object.isRequired,
+};
+
 export const intervalSeriesDataShape = PropTypes.arrayOf(PropTypes.shape({
   x0: PropTypes.oneOfType([
     PropTypes.string,

--- a/packages/xy-chart/test/PointSeries.test.js
+++ b/packages/xy-chart/test/PointSeries.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 
 import { XYChart, PointSeries } from '../src/';
+import GlyphDotComponent from '../src/glyph/GlyphDotComponent';
 
 describe('<PointSeries />', () => {
   const mockProps = {
@@ -27,18 +28,18 @@ describe('<PointSeries />', () => {
     expect(shallow(<PointSeries label="" data={[]} />).type()).toBeNull();
   });
 
-  test('it should render a circle for each datum', () => {
-    const wrapper = mount(
+  test('it should render a GlyphDotComponent for each datum', () => {
+    const wrapper = shallow(
       <XYChart {...mockProps} >
         <PointSeries label="" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
       </XYChart>,
     );
     expect(wrapper.find(PointSeries).length).toBe(1);
-    expect(wrapper.find(PointSeries).dive().find('circle').length).toBe(mockData.length);
+    expect(wrapper.find(PointSeries).dive().find(GlyphDotComponent).length).toBe(mockData.length);
   });
 
   test('it should not render points for null data', () => {
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart {...mockProps} >
         <PointSeries
           label=""
@@ -50,7 +51,7 @@ describe('<PointSeries />', () => {
       </XYChart>,
     );
     const series = wrapper.find(PointSeries).dive();
-    expect(series.find('circle').length).toBe(mockData.length - 2);
+    expect(series.find(GlyphDotComponent).length).toBe(mockData.length - 2);
   });
 
   test('it should render labels if present', () => {

--- a/packages/xy-chart/test/PointSeries.test.js
+++ b/packages/xy-chart/test/PointSeries.test.js
@@ -1,4 +1,3 @@
-import { GlyphDot } from '@vx/glyph';
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 

--- a/packages/xy-chart/test/PointSeries.test.js
+++ b/packages/xy-chart/test/PointSeries.test.js
@@ -28,18 +28,18 @@ describe('<PointSeries />', () => {
     expect(shallow(<PointSeries label="" data={[]} />).type()).toBeNull();
   });
 
-  test('it should render a GlyphDot for each datum', () => {
-    const wrapper = shallow(
+  test('it should render a circle for each datum', () => {
+    const wrapper = mount(
       <XYChart {...mockProps} >
         <PointSeries label="" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
       </XYChart>,
     );
     expect(wrapper.find(PointSeries).length).toBe(1);
-    expect(wrapper.find(PointSeries).dive().find(GlyphDot).length).toBe(mockData.length);
+    expect(wrapper.find(PointSeries).dive().find('circle').length).toBe(mockData.length);
   });
 
   test('it should not render points for null data', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <XYChart {...mockProps} >
         <PointSeries
           label=""
@@ -51,7 +51,7 @@ describe('<PointSeries />', () => {
       </XYChart>,
     );
     const series = wrapper.find(PointSeries).dive();
-    expect(series.find(GlyphDot).length).toBe(mockData.length - 2);
+    expect(series.find('circle').length).toBe(mockData.length - 2);
   });
 
   test('it should render labels if present', () => {


### PR DESCRIPTION
Added customized renderer support for PointSeries, allowing users to pass a PointComponent to PointSeries. 

CirclePackSeries will naturally support the customized renderer too. The testing file is also updated.  

Two examples are added to show how to use customized rendering.

<img width="600" alt="screen shot 2017-10-10 at 8 11 52 am" src="https://user-images.githubusercontent.com/2024960/31394338-e77022f2-ad92-11e7-9cf4-65aaa7e526d2.png">
<img width="600" alt="screen shot 2017-10-10 at 8 11 48 am" src="https://user-images.githubusercontent.com/2024960/31394339-e78620b6-ad92-11e7-8f08-352c048751eb.png">


