### PR TITLE
[network] optionally pass children to Network to render

### DIFF
--- a/packages/network/src/chart/Network.jsx
+++ b/packages/network/src/chart/Network.jsx
@@ -13,7 +13,12 @@ import Node from './Node';
 export const propTypes = {
   ...withTooltipPropTypes,
   ariaLabel: PropTypes.string.isRequired,
-  width: PropTypes.number.isRequired,
+  animated: PropTypes.bool,
+  children: PropTypes.node,
+  graph: PropTypes.shape({
+    nodes: PropTypes.array.isRequired,
+    links: PropTypes.array.isRequired,
+  }).isRequired,
   height: PropTypes.number.isRequired,
   margin: PropTypes.shape({
     top: PropTypes.number,
@@ -21,18 +26,15 @@ export const propTypes = {
     bottom: PropTypes.number,
     right: PropTypes.number,
   }),
-  graph: PropTypes.shape({
-    nodes: PropTypes.array.isRequired,
-    links: PropTypes.array.isRequired,
-  }).isRequired,
   renderTooltip: PropTypes.func,
-  animated: PropTypes.bool,
   waitingForLayoutLabel: PropTypes.string,
+  width: PropTypes.number.isRequired,
 };
 
 const defaultProps = {
-  renderTooltip: null,
   animated: false,
+  children: null,
+  renderTooltip: null,
   margin: {
     top: 20,
     left: 20,
@@ -156,15 +158,16 @@ class Network extends React.PureComponent {
   render() {
     const {
       ariaLabel,
+      children,
       height,
-      width,
       onNodeClick,
       onNodeMouseEnter,
       onNodeMouseLeave,
-      renderNode,
       renderLink,
+      renderNode,
       renderTooltip,
       waitingForLayoutLabel,
+      width,
     } = this.props;
 
     return (
@@ -196,6 +199,8 @@ class Network extends React.PureComponent {
                   onClick={onNodeClick}
                 />
               </Group>}
+
+            {children}
 
             {this.state.computingLayout && waitingForLayoutLabel &&
               <Group>

--- a/packages/network/test/chart/Network.test.js
+++ b/packages/network/test/chart/Network.test.js
@@ -27,6 +27,11 @@ describe('<Network />', () => {
     expect(wrapper.find('svg').length).toBe(1);
   });
 
+  test('it should render any additional children passed within the svg', () => {
+    const wrapper = mount(<Network {...props}><defs><filter id="test_filter" /></defs></Network>);
+    expect(wrapper.find('svg').find('#test_filter').length).toBe(1);
+  });
+
   test('it should show initial status of rendering', () => {
     const wrapper = mount(<Network {...props} />);
     expect(wrapper.find('text').length).toBe(1);


### PR DESCRIPTION
we need the ability to add svg filters within a network, so this PR updates `<Network />` to render any children passed within the svg.

@conglei 