### PR TITLE
[xy-chart][circlepackseries] add optional layout callback 

### DIFF
--- a/packages/demo/examples/01-xy-chart/CirclePackWithCallback.jsx
+++ b/packages/demo/examples/01-xy-chart/CirclePackWithCallback.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import {
+  XYChart,
+  CrossHair,
+  XAxis,
+  CirclePackSeries,
+  HorizontalReferenceLine,
+  theme,
+} from '@data-ui/xy-chart';
+
+import ResponsiveXYChart from './ResponsiveXYChart';
+import RectPointComponent from './RectPointComponent';
+import { circlePackData } from './data';
+
+const { colors } = theme;
+const { margin } = XYChart.defaultProps;
+const verticalMargin = margin.top + margin.bottom;
+
+export default class CirclePackWithCallback extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.resizeCallback = this.resizeCallback.bind(this);
+  }
+
+  resizeCallback({ domain }) {
+    const height = Math.abs(domain[1] - domain[0]) + verticalMargin;
+
+    // only update if we didn't already set this, or if height has changed significantly
+    // e.g., due to window resize
+    if (!this.state.height || Math.abs(height - this.state.height) > 10) {
+      this.setState(() => ({ height }));
+    }
+  }
+
+  render() {
+    const heightOverride = {};
+    if (this.state.height) heightOverride.height = this.state.height;
+
+    return (
+      <ResponsiveXYChart
+        ariaLabel="Required label"
+        xScale={{ type: 'time' }}
+        yScale={{ type: 'linear' }}
+        {...heightOverride}
+      >
+
+        <CirclePackSeries
+          data={circlePackData.concat(circlePackData)}
+          label="Circle time pack"
+          size={d => d.r}
+          pointComponent={RectPointComponent}
+          layoutCallback={this.resizeCallback}
+        />
+
+        <HorizontalReferenceLine reference={0} />
+
+        <CrossHair
+          showHorizontalLine={false}
+          fullHeight
+          stroke={colors.darkGray}
+          circleFill="white"
+          circleStroke={colors.darkGray}
+        />
+        <XAxis label="Time" numTicks={5} />
+      </ResponsiveXYChart>
+    );
+  }
+}

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -24,9 +24,10 @@ import {
 
 import readme from '../../node_modules/@data-ui/xy-chart/README.md';
 
+import CirclePackWithCallback from './CirclePackWithCallback';
+import RectPointComponent from './RectPointComponent';
 import ResponsiveXYChart, { dateFormatter } from './ResponsiveXYChart';
 import ScatterWithHistogram from './ScatterWithHistograms';
-import RectPointComponent from './RectPointComponent';
 
 import {
   circlePackData,
@@ -340,42 +341,18 @@ export default {
           <CrossHair
             showHorizontalLine={false}
             fullHeight
-            stroke={colors.default}
+            stroke={colors.darkGray}
             circleFill="white"
-            circleStroke={colors.default}
+            circleStroke={colors.darkGray}
           />
           <XAxis label="Time" numTicks={5} />
         </ResponsiveXYChart>
       ),
     },
     {
-      description: 'CirclePackSeries With Customized Renderer',
+      description: 'CirclePackSeries with custom renderer and height callback',
       components: [CirclePackSeries],
-      example: () => (
-        <ResponsiveXYChart
-          ariaLabel="Required label"
-          xScale={{ type: 'time' }}
-          yScale={{ type: 'linear' }}
-        >
-          <CirclePackSeries
-            data={circlePackData}
-            label="Circle time pack"
-            size={d => d.r}
-            pointComponent={RectPointComponent}
-          />
-          <HorizontalReferenceLine
-            reference={0}
-          />
-          <CrossHair
-            showHorizontalLine={false}
-            fullHeight
-            stroke={colors.default}
-            circleFill="white"
-            circleStroke={colors.default}
-          />
-          <XAxis label="Time" numTicks={5} />
-        </ResponsiveXYChart>
-      ),
+      example: () => <CirclePackWithCallback />,
     },
     {
       description: 'Mixed series',

--- a/packages/xy-chart/test/CirclePackSeries.test.js
+++ b/packages/xy-chart/test/CirclePackSeries.test.js
@@ -3,7 +3,7 @@ import { shallow, mount } from 'enzyme';
 
 import { XYChart, CirclePackSeries, PointSeries } from '../src/';
 
-describe('<PointSeries />', () => {
+describe('<CirclePackSeries />', () => {
   const mockProps = {
     xScale: { type: 'time' },
     yScale: { type: 'linear', includeZero: false },
@@ -69,5 +69,23 @@ describe('<PointSeries />', () => {
 
     point.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke layoutCallback if passed with y-range and -domain arguments', () => {
+    jest.useFakeTimers();
+    const layoutCallback = jest.fn();
+
+    mount(
+      <XYChart {...mockProps} >
+        <CirclePackSeries label="" data={mockData} layoutCallback={layoutCallback} />
+      </XYChart>,
+    );
+
+    jest.runAllTimers();
+
+    expect(layoutCallback).toHaveBeenCalledTimes(1);
+    const { domain, range } = layoutCallback.mock.calls[0][0];
+    expect(Array.isArray(domain)).toBe(true);
+    expect(Array.isArray(range)).toBe(true);
   });
 });


### PR DESCRIPTION
This PR adds an optional `layoutCallback` prop to the `@data-ui/xy-chart` `CirclePackSeries` in order to support height updates. 

Currently a user may specify a `height` to `XYChart` but due to the circle packing algorithm, the points may overflow the container and get clipped. Therefore the callback is invoked with the `domain` and `range` of the resultant layout. 

Also adds tests and an example in storybook.

@conglei 

with and without callback:
![circlepack-height-callback](https://user-images.githubusercontent.com/4496521/31693700-f4afcff4-b354-11e7-8805-f4b5530e5adb.gif)
