### PR TITLE
[xy-chart] add <StackedAreaSeries /> and `onClick` support to all series

### DIFF
--- a/packages/data-table/README.md
+++ b/packages/data-table/README.md
@@ -24,11 +24,3 @@ See the <a href="https://williaster.github.io/data-ui" target="_blank">@data-ui/
 npm install
 npm run dev # or 'npm run prod'
 ```
-
-## @data-ui packages
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/xy-chart" target="_blank">@data-ui/xy-chart</a>[![Version](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/histogram" target="_blank">@data-ui/histogram</a>[![Version](https://img.shields.io/npm/v/@data-ui/histogram.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/histogram.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/radial-chart" target="_blank">@data-ui/radial-chart</a> [![Version](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)
-- @data-ui/data-table [![Version](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/data-ui-theme" target="_blank">@data-ui/theme</a> [![Version](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/demo" target="_blank">@data-ui/demo</a>

--- a/packages/data-ui-theme/README.md
+++ b/packages/data-ui-theme/README.md
@@ -6,11 +6,3 @@ This package exports theme variables that can be used by other packages. On the 
 ```js
 import { font, svgFont, label, size, color, chartTheme } from `@data-ui/theme`;
 ```
-
-## @data-ui packages
-- [@data-ui/xy-chart](https://github.com/williaster/data-ui/tree/master/packages/xy-chart) [![Version](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/histogram" target="_blank">@data-ui/histogram</a> [![Version](https://img.shields.io/npm/v/@data-ui/histogram.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/histogram.svg?style=flat)
-- [@data-ui/radial-chart](https://github.com/williaster/data-ui/tree/master/packages/radial-chart) [![Version](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)
-- [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table) [![Version](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)
-- @data-ui/theme [![Version](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)
-- [@data-ui/demo](https://github.com/williaster/data-ui/tree/master/packages/demo)

--- a/packages/demo/README.md
+++ b/packages/demo/README.md
@@ -1,9 +1,2 @@
 # @data-ui/demo
 Storybook of @data-ui examples. See it live at [williaster.github.io/data-ui](https://williaster.github.io/data-ui).
-
-## @data-ui packages
-- [@data-ui/xy-chart](https://github.com/williaster/data-ui/tree/master/packages/xy-chart) [![Version](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat-square)](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat-square)
-- [@data-ui/radial-chart](https://github.com/williaster/data-ui/tree/master/packages/radial-chart) [![Version](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat-square)](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat-square)
-- [@data-ui/data-table](https://github.com/williaster/data-ui/tree/master/packages/data-table) [![Version](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat-square)](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat-square)
-- [@data-ui/theme](https://github.com/williaster/data-ui/tree/master/packages/theme)
-- @data-ui/demo

--- a/packages/demo/examples/01-xy-chart/CirclePackWithCallback.jsx
+++ b/packages/demo/examples/01-xy-chart/CirclePackWithCallback.jsx
@@ -48,7 +48,6 @@ export default class CirclePackWithCallback extends React.Component {
 
         <CirclePackSeries
           data={circlePackData.concat(circlePackData)}
-          label="Circle time pack"
           size={d => d.r}
           pointComponent={RectPointComponent}
           layoutCallback={this.resizeCallback}

--- a/packages/demo/examples/01-xy-chart/LinkedXYCharts.jsx
+++ b/packages/demo/examples/01-xy-chart/LinkedXYCharts.jsx
@@ -94,7 +94,7 @@ class LinkedXYCharts extends React.Component {
   }
 
   render() {
-    const { screenWidth } = this.props;
+    const { screenWidth } = this.props; // eslint-disable-line react/prop-types
     const { mousedOverDatum, mousedOverKey, selectedDatum } = this.state;
     const width = Math.max(400, Math.min(700, screenWidth / 1.5));
     const height = 100;
@@ -161,7 +161,7 @@ class LinkedXYCharts extends React.Component {
               data={[selectedDatum]}
               stackKeys={['y']}
               stackFills={[`url(#${PATTERN_ID})`]}
-              onClick={this.onClick}
+              disableMouseEvents
             />}
           {stackCrossHairData &&
             <CrossHair

--- a/packages/demo/examples/01-xy-chart/LinkedXYCharts.jsx
+++ b/packages/demo/examples/01-xy-chart/LinkedXYCharts.jsx
@@ -83,9 +83,9 @@ class LinkedXYCharts extends React.Component {
     }));
   }
 
-  onMouseMove({ datum, key }) {
-    if (this.state.mousedOverDatum !== datum || this.state.mousedOverKey !== key) {
-      this.setState(() => ({ mousedOverDatum: datum, mousedOverKey: key }));
+  onMouseMove({ datum, seriesKey }) {
+    if (this.state.mousedOverDatum !== datum || this.state.mousedOverKey !== seriesKey) {
+      this.setState(() => ({ mousedOverDatum: datum, mousedOverKey: seriesKey }));
     }
   }
 
@@ -172,10 +172,10 @@ class LinkedXYCharts extends React.Component {
           <XAxis tickFormat={formatDate} />
         </XYChart>
 
-        {stackKeys.map((stackKey, stackIndex) => (
+        {stackKeys.map((seriesKey, stackIndex) => (
           <XYChart
-            key={stackKey}
-            ariaLabel={stackKey}
+            key={seriesKey}
+            ariaLabel={seriesKey}
             {...areaChartProps}
             width={width}
             height={height}
@@ -184,18 +184,16 @@ class LinkedXYCharts extends React.Component {
           >
             <XAxis tickFormat={formatDate} tickValues={tickValues} />
             <AreaSeries
-              label={stackKey}
-              data={stackedData.map(d => ({ ...d, y: d[stackKey] }))}
+              data={stackedData.map(d => ({ ...d, y: d[seriesKey] }))}
               fill={stackFills[stackIndex]}
               fillOpacity={0.9}
               strokeWidth={1}
               stroke={stackFills[stackIndex]}
-              onMouseMove={({ datum }) => { this.onMouseMove({ datum, key: stackKey }); }}
+              onMouseMove={({ datum }) => { this.onMouseMove({ datum, seriesKey }); }}
               onMouseLeave={this.onMouseLeave}
             />
             {intervalData &&
               <IntervalSeries
-                label={stackKey}
                 fill={`url(#${PATTERN_ID})`}
                 opacity={0.3}
                 data={intervalData}
@@ -204,7 +202,7 @@ class LinkedXYCharts extends React.Component {
               <CrossHair
                 fullHeight
                 showHorizontalLine={false}
-                showCircle={stackKey === mousedOverKey}
+                showCircle={seriesKey === mousedOverKey}
                 circleFill={stackFills[stackIndex]}
               />}
           </XYChart>

--- a/packages/demo/examples/01-xy-chart/LinkedXYCharts.jsx
+++ b/packages/demo/examples/01-xy-chart/LinkedXYCharts.jsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { utcFormat } from 'd3-time-format';
+
+import {
+  AreaSeries,
+  StackedBarSeries,
+  CrossHair,
+  IntervalSeries,
+  PatternLines,
+  XAxis,
+  XYChart,
+  theme,
+  withScreenSize,
+} from '@data-ui/xy-chart';
+
+const PATTERN_ID = 'linked_pattern';
+const formatDate = utcFormat('%Y');
+const generateY = () => Math.max(10, Math.random() * 50);
+
+const data = [
+  { x: new Date('2010-01-01 UTC'), y: generateY() },
+  { x: new Date('2011-01-01 UTC'), y: generateY() },
+  { x: new Date('2012-01-01 UTC'), y: generateY() },
+  { x: new Date('2013-01-01 UTC'), y: generateY() },
+  { x: new Date('2014-01-01 UTC'), y: generateY() },
+  { x: new Date('2015-01-01 UTC'), y: generateY() },
+  { x: new Date('2016-01-01 UTC'), y: generateY() },
+  { x: new Date('2017-01-01 UTC'), y: generateY() },
+  { x: new Date('2018-01-01 UTC'), y: generateY() },
+  { x: new Date('2019-01-01 UTC'), y: generateY() },
+  { x: new Date('2020-01-01 UTC'), y: generateY() },
+];
+
+const tickValues = data.map(d => d.x);
+
+const stackKeys = ['a', 'b', 'c'];
+const stackFills = theme.colors.categories.slice(2);
+
+const stackedData = data.map((d) => {
+  let total = 1;
+
+  return stackKeys.reduce((ret, key, i) => {
+    const fraction = i === stackKeys.length - 1 ? total : 0.33;
+    total -= fraction;
+    return { ...ret, [key]: fraction * ret.y };
+  }, d);
+});
+
+const getYForKey = (d, key) => {
+  const index = stackKeys.indexOf(key);
+  return stackKeys.slice(0, index + 1).reduce((sum, currKey) => sum + d[currKey], 0);
+};
+
+const areaChartProps = {
+  xScale: { type: 'time' },
+  yScale: { type: 'linear' },
+  margin: { top: 6, left: 16, right: 16, bottom: 24 },
+};
+
+const stackedChartProps = {
+  xScale: { type: 'band', paddingInner: 0.1 },
+  yScale: { type: 'linear' },
+  margin: { top: 6, left: 16, right: 16, bottom: 24 },
+};
+
+class LinkedXYCharts extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onClick = this.onClick.bind(this);
+    this.onMouseMove = this.onMouseMove.bind(this);
+    this.onMouseLeave = this.onMouseLeave.bind(this);
+
+    this.state = {
+      selectedDatum: null,
+      mousedOverDatum: null,
+      mousedOverKey: null,
+    };
+  }
+
+  onClick({ datum }) {
+    this.setState(({ selectedDatum }) => ({
+      selectedDatum: datum === selectedDatum ? null : datum,
+    }));
+  }
+
+  onMouseMove({ datum, key }) {
+    if (this.state.mousedOverDatum !== datum || this.state.mousedOverKey !== key) {
+      this.setState(() => ({ mousedOverDatum: datum, mousedOverKey: key }));
+    }
+  }
+
+  onMouseLeave() {
+    this.setState(() => ({ mousedOverDatum: null, mousedOverKey: null }));
+  }
+
+  render() {
+    const { screenWidth } = this.props;
+    const { mousedOverDatum, mousedOverKey, selectedDatum } = this.state;
+    const width = Math.max(400, Math.min(700, screenWidth / 1.5));
+    const height = 100;
+
+    const intervalData = selectedDatum ? [
+      {
+        x0: selectedDatum.x,
+        x1: new Date(
+          new Date(selectedDatum.x).setFullYear(new Date(selectedDatum.x).getFullYear() + 1),
+        ),
+      },
+    ] : null;
+
+    const crossHairData = mousedOverDatum
+      ? { datum: { ...mousedOverDatum, y: mousedOverDatum[mousedOverKey] } }
+      : null;
+
+    const stackCrossHairData = mousedOverDatum
+      ? { datum: { ...mousedOverDatum, y: getYForKey(mousedOverDatum, mousedOverKey) } }
+      : null;
+
+    return (
+      <div
+        style={{
+          fontFamily: theme.labelStyles.fontFamily,
+          fontSize: 12,
+          color: theme.colors.grays[6],
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        <svg width={0} height={0}>
+          <PatternLines
+            id={PATTERN_ID}
+            height={6}
+            width={6}
+            stroke={theme.colors.darkGray}
+            strokeWidth={1}
+            orientation={['diagonal']}
+          />
+        </svg>
+
+        <XYChart
+          ariaLabel="test"
+          {...stackedChartProps}
+          width={width}
+          height={height * 3}
+          theme={theme}
+          tooltipData={stackCrossHairData}
+        >
+          <StackedBarSeries
+            fillOpacity={0.9}
+            data={stackedData}
+            stackKeys={stackKeys}
+            stackFills={stackFills}
+            stroke={theme.colors.darkGray}
+            strokeWidth={0.5}
+            onMouseMove={this.onMouseMove}
+            onMouseLeave={this.onMouseLeave}
+            onClick={this.onClick}
+          />
+          {selectedDatum &&
+            <StackedBarSeries
+              data={[selectedDatum]}
+              stackKeys={['y']}
+              stackFills={[`url(#${PATTERN_ID})`]}
+              onClick={this.onClick}
+            />}
+          {stackCrossHairData &&
+            <CrossHair
+              fullHeight
+              showHorizontalLine={false}
+              circleFill={stackFills[stackKeys.indexOf(mousedOverKey)]}
+            />}
+          <XAxis tickFormat={formatDate} />
+        </XYChart>
+
+        {stackKeys.map((stackKey, stackIndex) => (
+          <XYChart
+            key={stackKey}
+            ariaLabel={stackKey}
+            {...areaChartProps}
+            width={width}
+            height={height}
+            theme={theme}
+            tooltipData={crossHairData}
+          >
+            <XAxis tickFormat={formatDate} tickValues={tickValues} />
+            <AreaSeries
+              label={stackKey}
+              data={stackedData.map(d => ({ ...d, y: d[stackKey] }))}
+              fill={stackFills[stackIndex]}
+              fillOpacity={0.9}
+              strokeWidth={1}
+              stroke={stackFills[stackIndex]}
+              onMouseMove={({ datum }) => { this.onMouseMove({ datum, key: stackKey }); }}
+              onMouseLeave={this.onMouseLeave}
+            />
+            {intervalData &&
+              <IntervalSeries
+                label={stackKey}
+                fill={`url(#${PATTERN_ID})`}
+                opacity={0.3}
+                data={intervalData}
+              />}
+            {mousedOverDatum &&
+              <CrossHair
+                fullHeight
+                showHorizontalLine={false}
+                showCircle={stackKey === mousedOverKey}
+                circleFill={stackFills[stackIndex]}
+              />}
+          </XYChart>
+        ))}
+      </div>
+    );
+  }
+}
+
+
+export default withScreenSize(LinkedXYCharts);

--- a/packages/demo/examples/01-xy-chart/ScatterWithHistograms.jsx
+++ b/packages/demo/examples/01-xy-chart/ScatterWithHistograms.jsx
@@ -91,7 +91,6 @@ class ScatterWithHistogram extends React.PureComponent {
           {datasets.map((dataset, i) => (
             <PointSeries
               key={i}
-              label={String(i)}
               data={dataset}
               fill={datasetColors[i]}
               opacity={0.7}

--- a/packages/demo/examples/01-xy-chart/StackedAreaExample.jsx
+++ b/packages/demo/examples/01-xy-chart/StackedAreaExample.jsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { timeParse, timeFormat } from 'd3-time-format';
+
+import LegendOrdinal from '@vx/legend/build/legends/Ordinal';
+import scaleOrdinal from '@vx/scale/build/scales/ordinal';
+
+import {
+  CrossHair,
+  StackedAreaSeries,
+  PatternCircles,
+  theme,
+  XAxis,
+} from '@data-ui/xy-chart';
+
+import {
+  stackedData as initialStackedData,
+  groupKeys as stackKeys,
+} from './data';
+
+import ResponsiveXYChart from './ResponsiveXYChart';
+import WithToggle from '../shared/WithToggle';
+
+const PATTERN_ID_1 = 'stackedarea_1';
+const PATTERN_ID_2 = 'stackedarea_2';
+const PATTERN_ID_3 = 'stackedarea_3';
+const PATTERN_COLOR = theme.colors.categories[4];
+
+export const parseDate = timeParse('%Y%m%d');
+export const formatDate = timeFormat('%b %d');
+
+const stackedData = initialStackedData.map(d => ({
+  x: parseDate(d.x),
+  ...stackKeys.reduce((obj, key) => {
+    // multple by a random fraction bc there isn't much variation in temp
+    const value = d[key] * Math.max(0.1, Math.random());
+    return { ...obj, y: obj.y + value, [key]: value };
+  }, { y: 0 }),
+}));
+
+const percentStackedData = stackedData.map(d => ({
+  ...d,
+  y: 1,
+  ...stackKeys.reduce((obj, key) => ({ ...obj, [key]: d[key] / d.y }), {}),
+}));
+
+const patternIds = [PATTERN_ID_1, PATTERN_ID_2, PATTERN_ID_3];
+const stackFills = patternIds.map(id => `url(#${id})`);
+const legendScale = scaleOrdinal({ range: stackFills, domain: stackKeys });
+
+export default function StackedAreaExample() {
+  return (
+    <WithToggle id="lineseries_toggle" label="As percent" initialChecked>
+      {asPercent => (
+        <div
+          style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}
+        >
+          <LegendOrdinal
+            key="legend"
+            direction="row"
+            scale={legendScale}
+            shape={({ fill, width, height }) => (
+              <svg width={width} height={height}>
+                <rect
+                  width={width}
+                  height={height}
+                  fill={fill}
+                />
+              </svg>
+            )}
+            fill={({ datum }) => legendScale(datum)}
+            labelFormat={label => label}
+          />
+
+          <ResponsiveXYChart
+            ariaLabel="Stacked area chart of temperatures"
+            key="chart"
+            xScale={{ type: 'time' }}
+            yScale={{ type: 'linear' }}
+            margin={{ top: 8, left: 24, right: 24 }}
+          >
+            <PatternCircles
+              id={PATTERN_ID_1}
+              width={8}
+              height={8}
+              radius={2}
+              stroke={PATTERN_COLOR}
+              fill={'#fff'}
+            />
+            <PatternCircles
+              id={PATTERN_ID_2}
+              width={2}
+              height={2}
+              radius={2}
+              stroke={PATTERN_COLOR}
+              fill={PATTERN_COLOR}
+            />
+            <PatternCircles
+              id={PATTERN_ID_3}
+              width={4}
+              height={4}
+              radius={2}
+              stroke={PATTERN_COLOR}
+              fill={'#fff'}
+            />
+            <StackedAreaSeries
+              label="City Temperature"
+              data={asPercent ? percentStackedData : stackedData}
+              strokeWidth={2}
+              stackKeys={stackKeys}
+              stackFills={stackFills}
+              fillOpacity={1}
+            />
+            <CrossHair
+              stroke={PATTERN_COLOR}
+              strokeWidth={2}
+              showHorizontalLine={false}
+              showCircle={false}
+              strokeDasharray=""
+            />
+            <CrossHair
+              stroke="#fff"
+              strokeWidth={1}
+              showHorizontalLine={false}
+              showCircle={false}
+              strokeDasharray=""
+            />
+            <XAxis tickFormat={formatDate} />
+          </ResponsiveXYChart>
+        </div>
+      )}
+    </WithToggle>
+  );
+}

--- a/packages/demo/examples/01-xy-chart/StackedAreaExample.jsx
+++ b/packages/demo/examples/01-xy-chart/StackedAreaExample.jsx
@@ -103,7 +103,6 @@ export default function StackedAreaExample() {
               fill={'#fff'}
             />
             <StackedAreaSeries
-              label="City Temperature"
               data={asPercent ? percentStackedData : stackedData}
               strokeWidth={2}
               stackKeys={stackKeys}

--- a/packages/demo/examples/01-xy-chart/data.js
+++ b/packages/demo/examples/01-xy-chart/data.js
@@ -11,7 +11,8 @@ export const categoricalData = letterFrequency.map(d => ({ x: d.letter, y: d.fre
 // stacked data
 export const groupKeys = Object.keys(cityTemperature[0]).filter(attr => attr !== 'date');
 export const stackedData = cityTemperature.slice(0, 12).map(d => ({
-  ...d,
+  // convert all keys to numbers
+  ...(groupKeys.reduce((obj, key) => ({ ...obj, [key]: Number(d[key]) }), {})),
   x: d.date,
   y: groupKeys.reduce((ret, curr) => ret + Number(d[curr]), 0),
 }));

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -96,31 +96,41 @@ export default {
           y: Math.random() > 0.5 ? d.y * 2 : d.y / 2,
         }));
         return (
-          <WithToggle id="lineseries_toggle" label="Show voronoi" initialChecked>
-            {showVoronoi => (
-              <ResponsiveXYChart
-                ariaLabel="Required label"
-                xScale={{ type: 'time' }}
-                yScale={{ type: 'linear' }}
-                useVoronoi
-                showVoronoi={showVoronoi}
-              >
-                <YAxis label="Price ($)" numTicks={4} />
-                <LineSeries
-                  data={timeSeriesData}
-                  label="Apple Stock"
-                  showPoints
-                />
-                <LineSeries
-                  data={data2}
-                  label="Apple Stock 2"
-                  stroke={colors.categories[2]}
-                  strokeDasharray="3 3"
-                  strokeLinecap="butt"
-                />
-                <CrossHair />
-                <XAxis label="Time" numTicks={5} />
-              </ResponsiveXYChart>
+          <WithToggle id="line_use_voronoi_toggle" label="Use voronoi" initialChecked>
+            {useVoronoi => (
+              <WithToggle id="line_show_voronoi_toggle" label="Show voronoi" initialChecked>
+                {showVoronoi => (
+                  <WithToggle id="line_m_events_toggle" label="Disable mouse events" initialChecked>
+                    {disableMouseEvents => (
+                      <ResponsiveXYChart
+                        ariaLabel="Required label"
+                        xScale={{ type: 'time' }}
+                        yScale={{ type: 'linear' }}
+                        useVoronoi={useVoronoi}
+                        showVoronoi={showVoronoi}
+                      >
+                        <YAxis label="Price ($)" numTicks={4} />
+                        <LineSeries
+                          data={timeSeriesData}
+                          label="Apple Stock"
+                          showPoints
+                          disableMouseEvents={disableMouseEvents}
+                        />
+                        <LineSeries
+                          data={data2}
+                          label="Apple Stock 2"
+                          stroke={colors.categories[2]}
+                          strokeDasharray="3 3"
+                          strokeLinecap="butt"
+                          disableMouseEvents={disableMouseEvents}
+                        />
+                        <CrossHair />
+                        <XAxis label="Time" numTicks={5} />
+                      </ResponsiveXYChart>
+                    )}
+                  </WithToggle>
+                )}
+              </WithToggle>
             )}
           </WithToggle>
         );

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -25,8 +25,10 @@ import {
 import readme from '../../node_modules/@data-ui/xy-chart/README.md';
 
 import CirclePackWithCallback from './CirclePackWithCallback';
+import LinkedXYCharts from './LinkedXYCharts';
 import RectPointComponent from './RectPointComponent';
 import ResponsiveXYChart, { dateFormatter } from './ResponsiveXYChart';
+import StackedAreaExample from './StackedAreaExample';
 import ScatterWithHistogram from './ScatterWithHistograms';
 
 import {
@@ -269,6 +271,20 @@ export default {
       components: [PointSeries],
       example: () => (
         <ScatterWithHistogram />
+      ),
+    },
+    {
+      description: 'Linked charts',
+      components: [XYChart, StackedBarSeries, AreaSeries, CrossHair],
+      example: () => (
+        <LinkedXYCharts />
+      ),
+    },
+    {
+      description: 'StackedAreaSeries',
+      components: [XYChart],
+      example: () => (
+        <StackedAreaExample />
       ),
     },
     {

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -81,7 +81,6 @@ export default {
               ...d,
               fill: `url(#${i === 2 ? 'lines' : 'gradient'})`,
             }))}
-            label="Apple Stock"
             fill="url(#aqua_lightaqua_gradient)"
           />
         </ResponsiveXYChart>
@@ -100,7 +99,7 @@ export default {
             {useVoronoi => (
               <WithToggle id="line_show_voronoi_toggle" label="Show voronoi" initialChecked>
                 {showVoronoi => (
-                  <WithToggle id="line_m_events_toggle" label="Disable mouse events" initialChecked>
+                  <WithToggle id="line_m_events_toggle" label="Disable mouse events">
                     {disableMouseEvents => (
                       <ResponsiveXYChart
                         ariaLabel="Required label"
@@ -112,13 +111,11 @@ export default {
                         <YAxis label="Price ($)" numTicks={4} />
                         <LineSeries
                           data={timeSeriesData}
-                          label="Apple Stock"
                           showPoints
                           disableMouseEvents={disableMouseEvents}
                         />
                         <LineSeries
                           data={data2}
-                          label="Apple Stock 2"
                           stroke={colors.categories[2]}
                           strokeDasharray="3 3"
                           strokeLinecap="butt"
@@ -160,13 +157,11 @@ export default {
           />
           <AreaSeries
             data={timeSeriesData}
-            label="Apple Stock"
             fill="url(#area_gradient)"
             strokeWidth={null}
           />
           <AreaSeries
             data={timeSeriesData}
-            label="Apple Stock 2"
             fill="url(#area_pattern)"
             stroke={colors.categories[2]}
           />
@@ -201,7 +196,6 @@ export default {
             />,
             <AreaSeries
               key={`band-${data[0].key}`}
-              label="Temperature range"
               data={data}
               strokeWidth={0.5}
               stroke={colors.categories[i + 1]}
@@ -211,7 +205,6 @@ export default {
               key={`line-${data[0].key}`}
               data={data}
               stroke={colors.categories[i + 1]}
-              label="Temperature avg"
             />,
           ]))}
           <YAxis label="Temperature (°F)" numTicks={4} />
@@ -248,19 +241,16 @@ export default {
             strokeLinecap="butt"
           />
           <AreaSeries
-            label="band"
             data={priceBandData.band}
             fill="url(#confidence-interval-fill)"
             strokeWidth={0}
           />
           <LineSeries
-            label="line"
             data={priceBandData.points.map(d => (d.y >= reference ? d : { ...d, y: reference }))}
             stroke={colors.categories[3]}
             strokeWidth={2}
           />
           <PointSeries
-            label="line"
             data={priceBandData.points.filter(d => d.y < reference)}
             fill="#fff"
             fillOpacity={1}
@@ -316,7 +306,6 @@ export default {
               <XAxis label="X" numTicks={4} />
               <PointSeries
                 data={pointData}
-                label="Random"
                 size={d => d.size}
               />
               <CrossHair fullWidth fullHeight showCircle={false} />
@@ -338,7 +327,6 @@ export default {
           <XAxis label="X" numTicks={4} />
           <PointSeries
             data={pointData}
-            label="Random"
             size={d => d.size}
             pointComponent={RectPointComponent}
           />
@@ -357,7 +345,6 @@ export default {
           <YAxis label="Temperature (°F)" numTicks={4} />
           <StackedBarSeries
             data={stackedData}
-            label="City Temperature"
             stackKeys={groupKeys}
           />
           <XAxis tickFormat={dateFormatter} />
@@ -377,7 +364,6 @@ export default {
           <YAxis label="Temperature (°F)" numTicks={4} />
           <GroupedBarSeries
             data={groupedData}
-            label="City Temperature"
             groupKeys={groupKeys}
           />
           <XAxis tickFormat={dateFormatter} />
@@ -400,7 +386,6 @@ export default {
           />
           <BarSeries
             data={categoricalData}
-            label="Apple Stock"
             fill="url(#aqua_lightaqua_gradient)"
           />
           <XAxis numTicks={categoricalData.length} />
@@ -433,12 +418,10 @@ export default {
           />
           <LineSeries
             data={intervalLineData}
-            label="Line interval"
             showPoints
           />
           <IntervalSeries
             data={intervalData}
-            label="Temperature interval"
             fill="url(#interval_pattern)"
           />
           <XAxis numTicks={0} />
@@ -456,7 +439,6 @@ export default {
         >
           <CirclePackSeries
             data={circlePackData}
-            label="Circle time pack"
             size={d => d.r}
           />
           <HorizontalReferenceLine
@@ -495,12 +477,10 @@ export default {
           />
           <BarSeries
             data={timeSeriesData}
-            label="Apple Stock"
             fill="url(#aqua_lightaqua_gradient)"
           />
           <LineSeries
             data={timeSeriesData}
-            label="Apple Stock"
             stroke={colors.text}
           />
           <XAxis label="Time" numTicks={5} />
@@ -525,7 +505,6 @@ export default {
           />
           <BarSeries
             data={timeSeriesData}
-            label="Apple Stock"
             fill="url(#aqua_lightaqua_gradient)"
           />
           <XAxis label="Time" numTicks={5} orientation="top" />
@@ -549,7 +528,6 @@ export default {
           />
           <BarSeries
             data={timeSeriesData}
-            label="Apple Stock"
             fill="url(#aqua_lightaqua_gradient)"
           />
           <XAxis numTicks={0} />
@@ -569,12 +547,10 @@ export default {
           <YAxis label="Price ($)" numTicks={4} />
           <BarSeries
             data={timeSeriesData.filter((d, i) => i % 2 === 0)}
-            label="Apple Stock"
             fill="#484848"
           />
           <BarSeries
             data={timeSeriesData.filter((d, i) => i % 2 !== 0 && i !== 5)}
-            label="Apple Stock ii"
             fill="#767676"
           />
           <XAxis label="Time" numTicks={5} />

--- a/packages/histogram/README.md
+++ b/packages/histogram/README.md
@@ -225,11 +225,3 @@ export const themeShape = PropTypes.shape({
 npm install
 npm run dev # or 'build'
 ```
-
-## @data-ui packages
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/xy-chart" target="_blank">@data-ui/xy-chart</a> [![Version](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)
-- @data-ui/histogram [![Version](https://img.shields.io/npm/v/@data-ui/histogram.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/histogram.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/radial-chart" target="_blank">@data-ui/radial-chart</a> [![Version](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/data-table" target="_blank">@data-ui/data-table</a> [![Version](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/data-ui-theme" target="_blank">@data-ui/theme</a> [![Version](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/demo" target="_blank">@data-ui/demo</a>

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -19,11 +19,3 @@ Under the covers this will wrap the `<Network />` component in the exported `<Wi
 ### Roadmap
 - more layout algorithms
 - dragging interaction enabled
-
-
-## @data-ui packages
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/xy-chart" target="_blank">@data-ui/xy-chart</a>[![Version](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)
-- @data-ui/radial-chart [![Version](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/data-table" target="_blank">@data-ui/data-table</a> [![Version](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/data-ui-theme" target="_blank">@data-ui/theme</a> [![Version](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/demo" target="_blank">@data-ui/demo</a>

--- a/packages/radial-chart/README.md
+++ b/packages/radial-chart/README.md
@@ -89,11 +89,3 @@ Note that currently this is implemented with `@vx/tooltips`'s `withTooltip` HOC,
 
 ### NOTE ‼️
 Although pie 🍰 and donut 🍩 charts are frequently encountered, they are not the most _effective_ visualization for conveying quantitative information. With that caveat, when used well they can effectively give an overview of population makeup which is an entirely reasonable use of these charts. We don't recommend using >7 slices for user readability.
-
-
-## @data-ui packages
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/xy-chart" target="_blank">@data-ui/xy-chart</a>[![Version](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat)
-- @data-ui/radial-chart [![Version](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/radial-chart.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/data-table" target="_blank">@data-ui/data-table</a> [![Version](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/data-table.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/data-ui-theme" target="_blank">@data-ui/theme</a> [![Version](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)](https://img.shields.io/npm/v/@data-ui/theme.svg?style=flat)
-- <a href="https://github.com/williaster/data-ui/tree/master/packages/demo" target="_blank">@data-ui/demo</a>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -51,7 +51,7 @@
     "@vx/event": "0.0.143",
     "@vx/group": "0.0.143",
     "@vx/shape": "0.0.145",
-    "@vx/tooltip": "0.0.143",
+    "@vx/tooltip": "0.0.147",
     "d3-array": "^1.2.1",
     "prop-types": "^15.5.10"
   },

--- a/packages/shared/src/enhancer/WithTooltip.js
+++ b/packages/shared/src/enhancer/WithTooltip.js
@@ -59,8 +59,8 @@ class WithTooltip extends React.PureComponent {
     }
 
     this.props.showTooltip({
-      tooltipLeft: coords.x + 10,
-      tooltipTop: coords.y + 10,
+      tooltipLeft: coords.x,
+      tooltipTop: coords.y,
       tooltipData: {
         event,
         datum,

--- a/packages/xy-chart/src/chart/Voronoi.jsx
+++ b/packages/xy-chart/src/chart/Voronoi.jsx
@@ -8,6 +8,7 @@ import VoronoiPolygon from '@vx/voronoi/build/components/VoronoiPolygon';
 
 const propTypes = {
   data: PropTypes.array.isRequired,
+  onClick: PropTypes.func,
   onMouseMove: PropTypes.func,
   onMouseLeave: PropTypes.func,
   showVoronoi: PropTypes.bool,
@@ -18,8 +19,9 @@ const propTypes = {
 };
 
 const defaultProps = {
-  onMouseMove: () => {},
-  onMouseLeave: () => {},
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
   showVoronoi: false,
 };
 
@@ -43,7 +45,7 @@ class Voronoi extends React.PureComponent {
   }
 
   render() {
-    const { onMouseLeave, onMouseMove, showVoronoi } = this.props;
+    const { onMouseLeave, onMouseMove, onClick, showVoronoi } = this.props;
     const { voronoi } = this.state;
     return (
       <Group>
@@ -54,10 +56,13 @@ class Voronoi extends React.PureComponent {
             fill="transparent"
             stroke={showVoronoi ? '#ddd' : 'transparent'}
             strokeWidth={1}
-            onMouseMove={() => (event) => {
+            onClick={onClick && (() => (event) => {
+              onClick({ event, datum: polygon.data });
+            })}
+            onMouseMove={onMouseMove && (() => (event) => {
               onMouseMove({ event, datum: polygon.data });
-            }}
-            onMouseLeave={() => onMouseLeave}
+            })}
+            onMouseLeave={onMouseLeave && (() => onMouseLeave)}
           />
         ))}
       </Group>

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -95,7 +95,7 @@ class XYChart extends React.PureComponent {
 
     React.Children.forEach(children, (Child) => { // Child-specific scales or adjustments here
       const name = componentName(Child);
-      if (isBarSeries(name) && xScale.type !== 'band') {
+      if (isBarSeries(name) && xScaleObject.type !== 'band') {
         const dummyBand = getScaleForAccessor({
           allData,
           minAccessor: xString,
@@ -104,7 +104,7 @@ class XYChart extends React.PureComponent {
           rangeRound: [0, innerWidth],
           paddingOuter: 1,
         });
-
+        
         const offset = dummyBand.bandwidth() / 2;
         xScale.range([offset, innerWidth - offset]);
         xScale.barWidth = dummyBand.bandwidth();

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -104,7 +104,7 @@ class XYChart extends React.PureComponent {
           rangeRound: [0, innerWidth],
           paddingOuter: 1,
         });
-        
+
         const offset = dummyBand.bandwidth() / 2;
         xScale.range([offset, innerWidth - offset]);
         xScale.barWidth = dummyBand.bandwidth();

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -75,7 +75,7 @@ class XYChart extends React.PureComponent {
   static collectScalesFromProps(props) {
     const { xScale: xScaleObject, yScale: yScaleObject, children } = props;
     const { innerWidth, innerHeight } = XYChart.getDimmensions(props);
-    const { allData, dataBySeriesType, dataByIndex, data } = collectDataFromChildSeries(children);
+    const { allData } = collectDataFromChildSeries(children);
 
     const xScale = getScaleForAccessor({
       allData,
@@ -97,7 +97,6 @@ class XYChart extends React.PureComponent {
       const name = componentName(Child);
       if (isBarSeries(name) && xScale.type !== 'band') {
         const dummyBand = getScaleForAccessor({
-          // allData: dataBySeriesType[name],
           allData,
           minAccessor: xString,
           maxAccessor: xString,
@@ -117,7 +116,6 @@ class XYChart extends React.PureComponent {
     });
 
     return {
-      dataByIndex,
       xScale,
       yScale,
     };

--- a/packages/xy-chart/src/glyph/GlyphDotComponent.jsx
+++ b/packages/xy-chart/src/glyph/GlyphDotComponent.jsx
@@ -18,6 +18,7 @@ export default function GlyphDotComponent({
   stroke,
   strokeWidth,
   strokeDasharray,
+  onClick,
   onMouseMove,
   onMouseLeave,
   data,
@@ -33,6 +34,9 @@ export default function GlyphDotComponent({
       stroke={stroke}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
+      onClick={onClick && ((event) => {
+        onClick({ event, data, datum, color: fill });
+      })}
       onMouseMove={onMouseMove && ((event) => {
         onMouseMove({ event, data, datum, color: fill });
       })}
@@ -41,5 +45,7 @@ export default function GlyphDotComponent({
   );
 }
 
-GlyphDotComponent.propTypes = pointComponentPropTypes;
+GlyphDotComponent.propTypes = {
+  ...pointComponentPropTypes,
+};
 GlyphDotComponent.defaultProps = defaultPropTypes;

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -9,6 +9,7 @@ export { default as GroupedBarSeries } from './series/GroupedBarSeries';
 export { default as IntervalSeries } from './series/IntervalSeries';
 export { default as LineSeries } from './series/LineSeries';
 export { default as PointSeries, pointComponentPropTypes } from './series/PointSeries';
+export { default as StackedAreaSeries } from './series/StackedAreaSeries';
 export { default as StackedBarSeries } from './series/StackedBarSeries';
 
 export { default as HorizontalReferenceLine } from './annotation/HorizontalReferenceLine';

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -21,11 +21,12 @@ const propTypes = {
   strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   strokeLinecap: PropTypes.oneOf(['butt', 'square', 'round', 'inherit']),
+  onClick: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
   // these will likely be injected by the parent chart
   xScale: PropTypes.func,
   yScale: PropTypes.func,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
 };
 
 const defaultProps = {
@@ -38,8 +39,9 @@ const defaultProps = {
   fillOpacity: 0.3,
   xScale: null,
   yScale: null,
-  onMouseMove: undefined,
-  onMouseLeave: undefined,
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
 };
 
 const x = d => d.x;
@@ -63,6 +65,7 @@ export default class AreaSeries extends React.PureComponent {
       fillOpacity,
       interpolation,
       label,
+      onClick,
       onMouseMove,
       onMouseLeave,
     } = this.props;
@@ -81,6 +84,10 @@ export default class AreaSeries extends React.PureComponent {
     return (
       <Group
         key={label}
+        onClick={onClick && ((event) => {
+          const d = findClosestDatum({ data, getX: x, event, xScale });
+          onClick({ event, data, datum: d, color: fillValue });
+        })}
         onMouseMove={onMouseMove && ((event) => {
           const d = findClosestDatum({ data, getX: x, event, xScale });
           onMouseMove({ event, data, datum: d, color: fillValue });

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -45,10 +45,10 @@ const defaultProps = {
   onMouseLeave: null,
 };
 
-const x = d => d.x;
-const getY = d => d.y;
-const getY0 = d => d.y0;
-const getY1 = d => d.y1;
+const x = d => d && d.x;
+const getY = d => d && d.y;
+const getY0 = d => d && d.y0;
+const getY1 = d => d && d.y1;
 const definedClosed = d => isDefined(getY(d));
 const definedOpen = d => isDefined(getY0(d)) && isDefined(getY1(d));
 const noEventsStyles = { pointerEvents: 'none' };

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -13,10 +13,10 @@ import { areaSeriesDataShape, interpolationShape } from '../utils/propShapes';
 
 const propTypes = {
   data: areaSeriesDataShape.isRequired,
+  disableMouseEvents: PropTypes.bool,
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fillOpacity: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   interpolation: interpolationShape,
-  label: PropTypes.string.isRequired,
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
@@ -30,6 +30,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  disableMouseEvents: false,
   interpolation: 'monotoneX',
   stroke: color.default,
   strokeWidth: 3,
@@ -50,11 +51,13 @@ const getY0 = d => d.y0;
 const getY1 = d => d.y1;
 const definedClosed = d => isDefined(getY(d));
 const definedOpen = d => isDefined(getY0(d)) && isDefined(getY1(d));
+const noEventsStyles = { pointerEvents: 'none' };
 
 export default class AreaSeries extends React.PureComponent {
   render() {
     const {
       data,
+      disableMouseEvents,
       xScale,
       yScale,
       stroke,
@@ -64,7 +67,6 @@ export default class AreaSeries extends React.PureComponent {
       fill,
       fillOpacity,
       interpolation,
-      label,
       onClick,
       onMouseMove,
       onMouseLeave,
@@ -83,16 +85,16 @@ export default class AreaSeries extends React.PureComponent {
     const curve = interpolatorLookup[interpolation] || interpolatorLookup.monotoneX;
     return (
       <Group
-        key={label}
-        onClick={onClick && ((event) => {
+        style={disableMouseEvents ? noEventsStyles : null}
+        onClick={disableMouseEvents ? null : onClick && ((event) => {
           const d = findClosestDatum({ data, getX: x, event, xScale });
           onClick({ event, data, datum: d, color: fillValue });
         })}
-        onMouseMove={onMouseMove && ((event) => {
+        onMouseMove={disableMouseEvents ? null : onMouseMove && ((event) => {
           const d = findClosestDatum({ data, getX: x, event, xScale });
           onMouseMove({ event, data, datum: d, color: fillValue });
         })}
-        onMouseLeave={onMouseLeave}
+        onMouseLeave={disableMouseEvents ? null : onMouseLeave}
       >
         <Area
           data={data}

--- a/packages/xy-chart/src/series/BarSeries.jsx
+++ b/packages/xy-chart/src/series/BarSeries.jsx
@@ -14,27 +14,32 @@ const propTypes = {
 
   // overridden by data props
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  fillOpacity: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+
+  onClick: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
 
   // probably injected by the parent xychart
   barWidth: PropTypes.number,
   xScale: PropTypes.func,
   yScale: PropTypes.func,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
 };
 
 const defaultProps = {
   barWidth: null,
   fill: themeColors.default,
+  fillOpacity: null,
   stackBy: null,
   stroke: '#FFFFFF',
   strokeWidth: 1,
   xScale: null,
   yScale: null,
-  onMouseMove: undefined,
-  onMouseLeave: undefined,
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
 };
 
 const x = d => d.x;
@@ -46,11 +51,13 @@ export default class BarSeries extends React.PureComponent {
       barWidth,
       data,
       fill,
+      fillOpacity,
       stroke,
       strokeWidth,
       label,
       xScale,
       yScale,
+      onClick,
       onMouseMove,
       onMouseLeave,
     } = this.props;
@@ -72,10 +79,14 @@ export default class BarSeries extends React.PureComponent {
               width={barWidth}
               height={barHeight}
               fill={color}
+              fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
               stroke={d.stroke || callOrValue(stroke, d, i)}
               strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              onClick={onClick && (() => (event) => {
+                onClick({ event, data, datum: d, color, index: i });
+              })}
               onMouseMove={onMouseMove && (() => (event) => {
-                onMouseMove({ event, data, datum: d, color });
+                onMouseMove({ event, data, datum: d, color, index: i });
               })}
               onMouseLeave={onMouseLeave && (() => onMouseLeave)}
             />

--- a/packages/xy-chart/src/series/BarSeries.jsx
+++ b/packages/xy-chart/src/series/BarSeries.jsx
@@ -10,8 +10,7 @@ import { callOrValue, isDefined } from '../utils/chartUtils';
 
 const propTypes = {
   data: barSeriesDataShape.isRequired,
-  label: PropTypes.string.isRequired,
-
+  disableMouseEvents: PropTypes.bool,
   // overridden by data props
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fillOpacity: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
@@ -30,6 +29,7 @@ const propTypes = {
 
 const defaultProps = {
   barWidth: null,
+  disableMouseEvents: false,
   fill: themeColors.default,
   fillOpacity: null,
   stackBy: null,
@@ -44,17 +44,18 @@ const defaultProps = {
 
 const x = d => d.x;
 const y = d => d.y;
+const noEventsStyles = { pointerEvents: 'none' };
 
 export default class BarSeries extends React.PureComponent {
   render() {
     const {
       barWidth,
       data,
+      disableMouseEvents,
       fill,
       fillOpacity,
       stroke,
       strokeWidth,
-      label,
       xScale,
       yScale,
       onClick,
@@ -67,13 +68,13 @@ export default class BarSeries extends React.PureComponent {
     const maxHeight = (yScale.range() || [0])[0];
     const offset = xScale.offset || 0;
     return (
-      <Group key={label}>
+      <Group style={disableMouseEvents ? noEventsStyles : null}>
         {data.map((d, i) => {
           const barHeight = maxHeight - yScale(y(d));
           const color = d.fill || callOrValue(fill, d, i);
           return isDefined(d.y) && (
             <Bar
-              key={`bar-${label}-${xScale(x(d))}`}
+              key={`bar-${xScale(x(d))}`}
               x={xScale(x(d)) - offset}
               y={maxHeight - barHeight}
               width={barWidth}
@@ -82,13 +83,13 @@ export default class BarSeries extends React.PureComponent {
               fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
               stroke={d.stroke || callOrValue(stroke, d, i)}
               strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-              onClick={onClick && (() => (event) => {
+              onClick={disableMouseEvents ? null : onClick && (() => (event) => {
                 onClick({ event, data, datum: d, color, index: i });
               })}
-              onMouseMove={onMouseMove && (() => (event) => {
+              onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
                 onMouseMove({ event, data, datum: d, color, index: i });
               })}
-              onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+              onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
             />
           );
         })}

--- a/packages/xy-chart/src/series/GroupedBarSeries.jsx
+++ b/packages/xy-chart/src/series/GroupedBarSeries.jsx
@@ -9,6 +9,7 @@ import { scaleTypeToScale } from '../utils/chartUtils';
 
 const propTypes = {
   data: groupedBarSeriesDataShape.isRequired,
+  disableMouseEvents: PropTypes.bool,
   groupKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
   groupFills: PropTypes.arrayOf(PropTypes.string),
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -24,6 +25,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  disableMouseEvents: false,
   groupKeys: null,
   groupFills: color.categories,
   groupPadding: 0.1,
@@ -37,11 +39,13 @@ const defaultProps = {
 };
 
 const x = d => d.x;
+const noEventsStyles = { pointerEvents: 'none' };
 
 export default class GroupedBarSeries extends React.PureComponent {
   render() {
     const {
       data,
+      disableMouseEvents,
       groupKeys,
       groupFills,
       groupPadding,
@@ -67,6 +71,7 @@ export default class GroupedBarSeries extends React.PureComponent {
     const zScale = scaleTypeToScale.ordinal({ range: groupFills, domain: groupKeys });
     return (
       <BarGroup
+        style={disableMouseEvents ? noEventsStyles : null}
         data={data}
         keys={groupKeys}
         height={maxHeight}
@@ -78,15 +83,15 @@ export default class GroupedBarSeries extends React.PureComponent {
         rx={2}
         stroke={stroke}
         strokeWidth={strokeWidth}
-        onClick={onClick && (d => (event) => {
+        onClick={disableMouseEvents ? null : onClick && (d => (event) => {
           const { key: seriesKey, data: datum } = d;
           onClick({ event, data, datum, seriesKey, color: zScale(seriesKey) });
         })}
-        onMouseMove={onMouseMove && (d => (event) => {
+        onMouseMove={disableMouseEvents ? null : onMouseMove && (d => (event) => {
           const { key, data: datum } = d;
           onMouseMove({ event, data, datum, seriesKey: key, color: zScale(key) });
         })}
-        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+        onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
       />
     );
   }

--- a/packages/xy-chart/src/series/GroupedBarSeries.jsx
+++ b/packages/xy-chart/src/series/GroupedBarSeries.jsx
@@ -14,12 +14,13 @@ const propTypes = {
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   groupPadding: PropTypes.number, // see https://github.com/d3/d3-scale#band-scales
+  onClick: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
 
   // these will likely be injected by the parent xychart
   xScale: PropTypes.func,
   yScale: PropTypes.func,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
 };
 
 const defaultProps = {
@@ -30,8 +31,9 @@ const defaultProps = {
   strokeWidth: 1,
   xScale: null,
   yScale: null,
-  onMouseMove: undefined,
-  onMouseLeave: undefined,
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
 };
 
 const x = d => d.x;
@@ -47,6 +49,7 @@ export default class GroupedBarSeries extends React.PureComponent {
       strokeWidth,
       xScale,
       yScale,
+      onClick,
       onMouseMove,
       onMouseLeave,
     } = this.props;
@@ -75,6 +78,10 @@ export default class GroupedBarSeries extends React.PureComponent {
         rx={2}
         stroke={stroke}
         strokeWidth={strokeWidth}
+        onClick={onClick && (d => (event) => {
+          const { key: seriesKey, data: datum } = d;
+          onClick({ event, data, datum, seriesKey, color: zScale(seriesKey) });
+        })}
         onMouseMove={onMouseMove && (d => (event) => {
           const { key, data: datum } = d;
           onMouseMove({ event, data, datum, seriesKey: key, color: zScale(key) });

--- a/packages/xy-chart/src/series/IntervalSeries.jsx
+++ b/packages/xy-chart/src/series/IntervalSeries.jsx
@@ -14,24 +14,28 @@ const propTypes = {
 
   // overridden by data props
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  fillOpacity: PropTypes.number,
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  onClick: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
 
   // likely be injected by the parent xychart
   xScale: PropTypes.func,
   yScale: PropTypes.func,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
 };
 
 const defaultProps = {
   fill: color.default,
+  fillOpacity: 1,
   stroke: 'none',
   strokeWidth: 1,
   xScale: null,
   yScale: null,
-  onMouseMove: undefined,
-  onMouseLeave: undefined,
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
 };
 
 const x0 = d => d.x0;
@@ -42,11 +46,13 @@ export default class IntervalSeries extends React.PureComponent {
     const {
       data,
       fill,
+      fillOpacity,
       label,
       stroke,
       strokeWidth,
       xScale,
       yScale,
+      onClick,
       onMouseMove,
       onMouseLeave,
     } = this.props;
@@ -67,10 +73,14 @@ export default class IntervalSeries extends React.PureComponent {
               width={barWidth}
               height={barHeight}
               fill={intervalFill}
+              fillOpacity={fillOpacity}
               stroke={d.stroke || callOrValue(stroke, d, i)}
               strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              onClick={onClick && (() => (event) => {
+                onClick({ event, datum: d, index: i, data, color: intervalFill });
+              })}
               onMouseMove={onMouseMove && (() => (event) => {
-                onMouseMove({ event, datum: d, data, color: intervalFill });
+                onMouseMove({ event, datum: d, index: i, data, color: intervalFill });
               })}
               onMouseLeave={onMouseLeave && (() => onMouseLeave)}
             />

--- a/packages/xy-chart/src/series/IntervalSeries.jsx
+++ b/packages/xy-chart/src/series/IntervalSeries.jsx
@@ -10,8 +10,7 @@ import { callOrValue } from '../utils/chartUtils';
 
 const propTypes = {
   data: intervalSeriesDataShape.isRequired,
-  label: PropTypes.string.isRequired,
-
+  disableMouseEvents: PropTypes.bool,
   // overridden by data props
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fillOpacity: PropTypes.number,
@@ -27,6 +26,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  disableMouseEvents: false,
   fill: color.default,
   fillOpacity: 1,
   stroke: 'none',
@@ -40,14 +40,15 @@ const defaultProps = {
 
 const x0 = d => d.x0;
 const x1 = d => d.x1;
+const noEventsStyles = { pointerEvents: 'none' };
 
 export default class IntervalSeries extends React.PureComponent {
   render() {
     const {
       data,
+      disableMouseEvents,
       fill,
       fillOpacity,
-      label,
       stroke,
       strokeWidth,
       xScale,
@@ -60,14 +61,14 @@ export default class IntervalSeries extends React.PureComponent {
 
     const barHeight = (yScale.range() || [0])[0];
     return (
-      <Group key={label}>
+      <Group style={disableMouseEvents ? noEventsStyles : null}>
         {data.map((d, i) => {
           const x = xScale(x0(d));
           const barWidth = xScale(x1(d)) - x;
           const intervalFill = d.fill || callOrValue(fill, d, i);
           return (
             <Bar
-              key={`interval-${label}-${x}`}
+              key={`interval-${x}`}
               x={x}
               y={0}
               width={barWidth}
@@ -76,13 +77,13 @@ export default class IntervalSeries extends React.PureComponent {
               fillOpacity={fillOpacity}
               stroke={d.stroke || callOrValue(stroke, d, i)}
               strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-              onClick={onClick && (() => (event) => {
+              onClick={disableMouseEvents ? null : onClick && (() => (event) => {
                 onClick({ event, datum: d, index: i, data, color: intervalFill });
               })}
-              onMouseMove={onMouseMove && (() => (event) => {
+              onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
                 onMouseMove({ event, datum: d, index: i, data, color: intervalFill });
               })}
-              onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+              onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
             />
           );
         })}

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -12,10 +12,9 @@ import { interpolationShape, lineSeriesDataShape } from '../utils/propShapes';
 
 const propTypes = {
   data: lineSeriesDataShape.isRequired,
+  disableMouseEvents: PropTypes.bool,
   interpolation: interpolationShape,
-  label: PropTypes.string.isRequired,
   showPoints: PropTypes.bool,
-
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
@@ -30,6 +29,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  disableMouseEvents: false,
   interpolation: 'monotoneX',
   showPoints: false,
   stroke: color.default,
@@ -46,13 +46,14 @@ const defaultProps = {
 const x = d => d.x;
 const y = d => d.y;
 const defined = d => isDefined(y(d));
+const noEventsStyles = { pointerEvents: 'none' };
 
 export default class LineSeries extends React.PureComponent {
   render() {
     const {
       data,
+      disableMouseEvents,
       interpolation,
-      label,
       showPoints,
       stroke,
       strokeDasharray,
@@ -69,7 +70,7 @@ export default class LineSeries extends React.PureComponent {
     const curve = interpolatorLookup[interpolation] || interpolatorLookup.monotoneX;
     return (
       <LinePath
-        key={label}
+        style={disableMouseEvents ? noEventsStyles : null}
         data={data}
         xScale={xScale}
         yScale={yScale}
@@ -81,19 +82,19 @@ export default class LineSeries extends React.PureComponent {
         strokeLinecap={strokeLinecap}
         curve={curve}
         defined={defined}
-        onClick={onClick && (() => (event) => {
+        onClick={disableMouseEvents ? null : onClick && (() => (event) => {
           const d = findClosestDatum({ data, getX: x, event, xScale });
           onClick({ event, data, datum: d, color: strokeValue });
         })}
-        onMouseMove={onMouseMove && (() => (event) => {
+        onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
           const d = findClosestDatum({ data, getX: x, event, xScale });
           onMouseMove({ event, data, datum: d, color: strokeValue });
         })}
-        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+        onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
         glyph={showPoints && ((d, i) => (
           isDefined(x(d)) && isDefined(y(d)) &&
             <GlyphDot
-              key={`${label}-${i}-${x(d)}`}
+              key={`${i}-${x(d)}`}
               cx={xScale(x(d))}
               cy={yScale(y(d))}
               r={4}

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -20,12 +20,13 @@ const propTypes = {
   strokeDasharray: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   strokeLinecap: PropTypes.oneOf(['butt', 'square', 'round', 'inherit']),
+  onClick: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
 
   // these will likely be injected by the parent chart
   xScale: PropTypes.func,
   yScale: PropTypes.func,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
 };
 
 const defaultProps = {
@@ -37,8 +38,9 @@ const defaultProps = {
   strokeLinecap: 'round',
   xScale: null,
   yScale: null,
-  onMouseMove: undefined,
-  onMouseLeave: undefined,
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
 };
 
 const x = d => d.x;
@@ -58,6 +60,7 @@ export default class LineSeries extends React.PureComponent {
       strokeLinecap,
       xScale,
       yScale,
+      onClick,
       onMouseMove,
       onMouseLeave,
     } = this.props;
@@ -78,6 +81,10 @@ export default class LineSeries extends React.PureComponent {
         strokeLinecap={strokeLinecap}
         curve={curve}
         defined={defined}
+        onClick={onClick && (() => (event) => {
+          const d = findClosestDatum({ data, getX: x, event, xScale });
+          onClick({ event, data, datum: d, color: strokeValue });
+        })}
         onMouseMove={onMouseMove && (() => (event) => {
           const d = findClosestDatum({ data, getX: x, event, xScale });
           onMouseMove({ event, data, datum: d, color: strokeValue });

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -27,7 +27,7 @@ export const pointComponentPropTypes = {
 
 export const propTypes = {
   data: pointSeriesDataShape.isRequired,
-  label: PropTypes.string.isRequired,
+  disableMouseEvents: PropTypes.bool,
   labelComponent: PropTypes.element,
   pointComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
   onClick: PropTypes.func,
@@ -47,6 +47,7 @@ export const propTypes = {
 };
 
 export const defaultProps = {
+  disableMouseEvents: false,
   labelComponent: <text {...chartTheme.labelStyles} />,
   pointComponent: GlyphDotComponent,
   size: 4,
@@ -62,11 +63,13 @@ export const defaultProps = {
   onMouseLeave: null,
 };
 
+const noEventsStyles = { pointerEvents: 'none' };
+
 export default class PointSeries extends React.PureComponent {
   render() {
     const {
       data,
-      label,
+      disableMouseEvents,
       labelComponent,
       fill,
       fillOpacity,
@@ -84,7 +87,7 @@ export default class PointSeries extends React.PureComponent {
     if (!xScale || !yScale) return null;
     const labels = [];
     return (
-      <Group key={label}>
+      <Group style={disableMouseEvents ? noEventsStyles : null}>
         {data.map((d, i) => {
           const xVal = d.x;
           const yVal = d.y;
@@ -92,7 +95,7 @@ export default class PointSeries extends React.PureComponent {
           const x = xScale(xVal);
           const y = yScale(yVal);
           const computedFill = d.fill || callOrValue(fill, d, i);
-          const key = `${label}-${d.x}-${i}`;
+          const key = `${d.x}-${i}`;
           if (defined && d.label) {
             labels.push({ x, y, label: d.label, key: `${key}-label` });
           }
@@ -111,9 +114,9 @@ export default class PointSeries extends React.PureComponent {
             stroke: computedStroke,
             strokeWidth: computedStrokeWidth,
             strokeDasharray: computedStrokeDasharray,
-            onClick,
-            onMouseMove,
-            onMouseLeave,
+            onClick: disableMouseEvents ? null : onClick,
+            onMouseMove: disableMouseEvents ? null : onMouseMove,
+            onMouseLeave: disableMouseEvents ? null : onMouseLeave,
             data,
             datum: d,
           };

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -18,6 +18,7 @@ export const pointComponentPropTypes = {
   stroke: PropTypes.string.isRequired,
   strokeWidth: PropTypes.number.isRequired,
   strokeDasharray: PropTypes.string,
+  onClick: PropTypes.func,
   onMouseMove: PropTypes.func,
   onMouseLeave: PropTypes.func,
   data: pointSeriesDataShape.isRequired,
@@ -29,6 +30,9 @@ export const propTypes = {
   label: PropTypes.string.isRequired,
   labelComponent: PropTypes.element,
   pointComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.element]),
+  onClick: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
   // attributes on data points will override these
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   fillOpacity: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
@@ -40,8 +44,6 @@ export const propTypes = {
   // likely be injected by the parent chart
   xScale: PropTypes.func,
   yScale: PropTypes.func,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
 };
 
 export const defaultProps = {
@@ -55,8 +57,9 @@ export const defaultProps = {
   strokeWidth: 1,
   xScale: null,
   yScale: null,
-  onMouseMove: undefined,
-  onMouseLeave: undefined,
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
 };
 
 export default class PointSeries extends React.PureComponent {
@@ -73,6 +76,7 @@ export default class PointSeries extends React.PureComponent {
       strokeDasharray,
       xScale,
       yScale,
+      onClick,
       onMouseMove,
       onMouseLeave,
       pointComponent,
@@ -107,13 +111,13 @@ export default class PointSeries extends React.PureComponent {
             stroke: computedStroke,
             strokeWidth: computedStrokeWidth,
             strokeDasharray: computedStrokeDasharray,
+            onClick,
             onMouseMove,
             onMouseLeave,
             data,
             datum: d,
           };
-          return defined &&
-            React.createElement(pointComponent, props);
+          return defined && React.createElement(pointComponent, props);
         })}
         {/* Put labels on top */}
         {labels.map(d => React.cloneElement(labelComponent, d, d.label))}

--- a/packages/xy-chart/src/series/StackedAreaSeries.jsx
+++ b/packages/xy-chart/src/series/StackedAreaSeries.jsx
@@ -42,9 +42,9 @@ const defaultProps = {
   onMouseLeave: null,
 };
 
-const x = d => d.x;
-const y0 = d => d[0];
-const y1 = d => d[1];
+const x = d => d && d.x;
+const y0 = d => d && d[0];
+const y1 = d => d && d[1];
 const defined = d => isDefined(d[0]) && isDefined(d[1]);
 const noEventsStyles = { pointerEvents: 'none' };
 

--- a/packages/xy-chart/src/series/StackedAreaSeries.jsx
+++ b/packages/xy-chart/src/series/StackedAreaSeries.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Group from '@vx/group/build/Group';
+import Stack from '@vx/shape/build/shapes/Stack';
+import color from '@data-ui/theme/build/color';
+
+import interpolatorLookup from '../utils/interpolatorLookup';
+import { callOrValue, isDefined } from '../utils/chartUtils';
+import findClosestDatum from '../utils/findClosestDatum';
+import { lineSeriesDataShape, interpolationShape } from '../utils/propShapes';
+
+const propTypes = {
+  data: lineSeriesDataShape.isRequired,
+  fillOpacity: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  interpolation: interpolationShape,
+  label: PropTypes.string.isRequired,
+  stackKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+  stackFills: PropTypes.arrayOf(PropTypes.string),
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  onClick: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  // these will likely be injected by the parent chart
+  xScale: PropTypes.func,
+  yScale: PropTypes.func,
+};
+
+const defaultProps = {
+  interpolation: 'monotoneX',
+  fill: color.default,
+  fillOpacity: 0.3,
+  stackFills: color.categories,
+  stroke: '#fff',
+  strokeWidth: 1,
+  xScale: null,
+  yScale: null,
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
+};
+
+const x = d => d.x;
+const y0 = d => d[0];
+const y1 = d => d[1];
+const defined = d => isDefined(d[0]) && isDefined(d[1]);
+
+export default class StackedAreaSeries extends React.PureComponent {
+  render() {
+    const {
+      data,
+      xScale,
+      yScale,
+      stackKeys,
+      stackFills,
+      fillOpacity,
+      stroke,
+      strokeWidth,
+      interpolation,
+      label,
+      onClick,
+      onMouseMove,
+      onMouseLeave,
+    } = this.props;
+    if (!xScale || !yScale) return null;
+    return (
+      <Group key={label}>
+        <Stack
+          data={data}
+          x={d => xScale(x(d.data))}
+          y0={d => yScale(y0(d))}
+          y1={d => yScale(y1(d))}
+          keys={stackKeys}
+          fill={({ index }) => stackFills[index]}
+          fillOpacity={({ index, datum }) => callOrValue(fillOpacity, { datum, index })}
+          stroke={({ datum, index }) => callOrValue(stroke, { datum, index })}
+          strokeWidth={({ datum, index }) => callOrValue(strokeWidth, { datum, index })}
+          curve={interpolatorLookup[interpolation] || interpolatorLookup.monotoneX}
+          defined={defined}
+          onClick={onClick && (({ series, index }) => (event) => {
+            const datum = findClosestDatum({ data: series, getX: d => x(d.data), event, xScale });
+            onClick({
+              event,
+              data,
+              seriesKey: series.key,
+              datum: datum && datum.data,
+              color: stackFills[index],
+            });
+          })}
+          onMouseMove={onMouseMove && (({ series, index }) => (event) => {
+            const datum = findClosestDatum({ data: series, getX: d => x(d.data), event, xScale });
+            onMouseMove({
+              event,
+              data,
+              seriesKey: series.key,
+              datum: datum && datum.data,
+              color: stackFills[index],
+            });
+          })}
+          onMouseLeave={() => onMouseLeave}
+        />
+      </Group>
+    );
+  }
+}
+
+StackedAreaSeries.propTypes = propTypes;
+StackedAreaSeries.defaultProps = defaultProps;
+StackedAreaSeries.displayName = 'StackedAreaSeries';

--- a/packages/xy-chart/src/series/StackedBarSeries.jsx
+++ b/packages/xy-chart/src/series/StackedBarSeries.jsx
@@ -13,12 +13,13 @@ const propTypes = {
   stackFills: PropTypes.arrayOf(PropTypes.string),
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  onClick: PropTypes.func,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
 
   // these will likely be injected by the parent xychart
   xScale: PropTypes.func,
   yScale: PropTypes.func,
-  onMouseMove: PropTypes.func,
-  onMouseLeave: PropTypes.func,
 };
 
 const defaultProps = {
@@ -27,8 +28,9 @@ const defaultProps = {
   strokeWidth: 1,
   xScale: null,
   yScale: null,
-  onMouseMove: undefined,
-  onMouseLeave: undefined,
+  onClick: null,
+  onMouseMove: null,
+  onMouseLeave: null,
 };
 
 const x = d => d.x;
@@ -43,6 +45,7 @@ export default class StackedBarSeries extends React.PureComponent {
       strokeWidth,
       xScale,
       yScale,
+      onClick,
       onMouseMove,
       onMouseLeave,
     } = this.props;
@@ -63,6 +66,10 @@ export default class StackedBarSeries extends React.PureComponent {
         zScale={zScale}
         stroke={stroke}
         strokeWidth={strokeWidth}
+        onClick={onMouseMove && (d => (event) => {
+          const { data: datum, key: seriesKey } = d;
+          onClick({ event, data, datum, seriesKey, color: zScale(seriesKey) });
+        })}
         onMouseMove={onMouseMove && (d => (event) => {
           const { data: datum, key } = d;
           onMouseMove({ event, data, datum, seriesKey: key, color: zScale(key) });

--- a/packages/xy-chart/src/series/StackedBarSeries.jsx
+++ b/packages/xy-chart/src/series/StackedBarSeries.jsx
@@ -9,6 +9,7 @@ import { scaleTypeToScale } from '../utils/chartUtils';
 
 const propTypes = {
   data: stackedBarSeriesDataShape.isRequired,
+  disableMouseEvents: PropTypes.bool,
   stackKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
   stackFills: PropTypes.arrayOf(PropTypes.string),
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -23,6 +24,7 @@ const propTypes = {
 };
 
 const defaultProps = {
+  disableMouseEvents: false,
   stackFills: color.categories,
   stroke: '#FFFFFF',
   strokeWidth: 1,
@@ -34,11 +36,13 @@ const defaultProps = {
 };
 
 const x = d => d.x;
+const noEventsStyles = { pointerEvents: 'none' };
 
 export default class StackedBarSeries extends React.PureComponent {
   render() {
     const {
       data,
+      disableMouseEvents,
       stackKeys,
       stackFills,
       stroke,
@@ -57,6 +61,7 @@ export default class StackedBarSeries extends React.PureComponent {
     const zScale = scaleTypeToScale.ordinal({ range: stackFills, domain: stackKeys });
     return (
       <BarStack
+        style={disableMouseEvents ? noEventsStyles : null}
         data={data}
         keys={stackKeys}
         height={maxHeight}
@@ -66,15 +71,15 @@ export default class StackedBarSeries extends React.PureComponent {
         zScale={zScale}
         stroke={stroke}
         strokeWidth={strokeWidth}
-        onClick={onMouseMove && (d => (event) => {
+        onClick={disableMouseEvents ? null : onMouseMove && (d => (event) => {
           const { data: datum, key: seriesKey } = d;
           onClick({ event, data, datum, seriesKey, color: zScale(seriesKey) });
         })}
-        onMouseMove={onMouseMove && (d => (event) => {
+        onMouseMove={disableMouseEvents ? null : onMouseMove && (d => (event) => {
           const { data: datum, key } = d;
           onMouseMove({ event, data, datum, seriesKey: key, color: zScale(key) });
         })}
-        onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+        onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
       />
     );
   }

--- a/packages/xy-chart/src/utils/chartUtils.js
+++ b/packages/xy-chart/src/utils/chartUtils.js
@@ -1,5 +1,5 @@
 import { Children } from 'react';
-import { scaleLinear, scaleTime, scaleBand, scaleOrdinal } from '@vx/scale';
+import { scaleLinear, scaleTime, scaleUtc, scaleBand, scaleOrdinal } from '@vx/scale';
 import { extent } from 'd3-array';
 
 export function callOrValue(maybeFn, ...args) {
@@ -55,6 +55,7 @@ export function isStackedSeries(name) {
 
 export const scaleTypeToScale = {
   time: scaleTime,
+  timeUtc: scaleUtc,
   linear: scaleLinear,
   band: scaleBand,
   ordinal: scaleOrdinal,
@@ -92,7 +93,7 @@ export function getScaleForAccessor({
   if (type === 'band' || type === 'ordinal') {
     domain = allData.map(minAccessor);
   }
-  if (type === 'linear' || type === 'time') {
+  if (type === 'linear' || type === 'time' || type === 'timeUtc') {
     const [min, max] = extent([
       ...extent(allData, minAccessor),
       ...extent(allData, maxAccessor),

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -4,6 +4,7 @@ import interpolatorLookup from './interpolatorLookup';
 export const scaleShape = PropTypes.shape({
   type: PropTypes.oneOf([
     'time',
+    'timeUtc',
     'linear',
     'band',
   ]).isRequired,

--- a/packages/xy-chart/test/AreaSeries.test.js
+++ b/packages/xy-chart/test/AreaSeries.test.js
@@ -60,23 +60,39 @@ describe('<AreaSeries />', () => {
     expect(areaSeriesNoLinePath.find(LinePath).length).toBe(0);
   });
 
-  test('it should call onMouseMove({ datum, data, event, color }) on trigger', () => {
+  test('it should call onMouseMove({ datum, data, event, color }), onMouseLeave(), and onClick({ datum, data, event, color }) on trigger', () => {
     const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
-      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         <AreaSeries label="l" data={data} fill="hot-pink" />
       </XYChart>,
     );
 
-    // event listener is on area's parent, but .parent().simulate() call throws in enzyme 3
-    const area = wrapper.find(Area);
-    area.simulate('mousemove');
+    const area = wrapper.find(AreaSeries);
 
+    area.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
+    expect(args.data).toBe(data);
+    expect(args.datum).toBeNull(); // @TODO depends on mocking out findClosestDatum
+    expect(args.event).toBeDefined();
+    expect(args.color).toBe('hot-pink');
+
+    area.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    area.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
     expect(args.data).toBe(data);
     expect(args.datum).toBeNull(); // @TODO depends on mocking out findClosestDatum
     expect(args.event).toBeDefined();

--- a/packages/xy-chart/test/AreaSeries.test.js
+++ b/packages/xy-chart/test/AreaSeries.test.js
@@ -26,14 +26,14 @@ describe('<AreaSeries />', () => {
   });
 
   test('it should not render without x- and y-scales', () => {
-    expect(shallow(<AreaSeries label="" data={[]} />).type()).toBeNull();
+    expect(shallow(<AreaSeries data={[]} />).type()).toBeNull();
   });
 
   test('it should render an Area for each AreaSeries', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <AreaSeries label="l" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
-        <AreaSeries label="l2" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <AreaSeries data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <AreaSeries data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
       </XYChart>,
     );
     expect(wrapper.find(AreaSeries).length).toBe(2);
@@ -44,7 +44,7 @@ describe('<AreaSeries />', () => {
     const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
     const wrapperWithLine = shallow(
       <XYChart {...mockProps} >
-        <AreaSeries label="l" data={data} strokeWidth={3} />
+        <AreaSeries data={data} strokeWidth={3} />
       </XYChart>,
     );
     const areaSeriesWithLinePath = wrapperWithLine.find(AreaSeries).dive();
@@ -52,7 +52,7 @@ describe('<AreaSeries />', () => {
 
     const wrapperNoLine = shallow(
       <XYChart {...mockProps} >
-        <AreaSeries label="l" data={data} strokeWidth={0} />
+        <AreaSeries data={data} strokeWidth={0} />
       </XYChart>,
     );
 
@@ -73,7 +73,7 @@ describe('<AreaSeries />', () => {
         onMouseLeave={onMouseLeave}
         onClick={onClick}
       >
-        <AreaSeries label="l" data={data} fill="hot-pink" />
+        <AreaSeries data={data} fill="hot-pink" />
       </XYChart>,
     );
 
@@ -97,5 +97,34 @@ describe('<AreaSeries />', () => {
     expect(args.datum).toBeNull(); // @TODO depends on mocking out findClosestDatum
     expect(args.event).toBeDefined();
     expect(args.color).toBe('hot-pink');
+  });
+
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <AreaSeries disableMouseEvents data={data} fill="hot-pink" />
+      </XYChart>,
+    );
+
+    const area = wrapper.find(AreaSeries);
+
+    area.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    area.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    area.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/xy-chart/test/BarSeries.test.js
+++ b/packages/xy-chart/test/BarSeries.test.js
@@ -24,13 +24,13 @@ describe('<BarSeries />', () => {
   });
 
   test('it should not render without x- and y-scales', () => {
-    expect(shallow(<BarSeries label="" data={[]} />).type()).toBeNull();
+    expect(shallow(<BarSeries data={[]} />).type()).toBeNull();
   });
 
   test('it should render one bar per datum', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <BarSeries label="l" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <BarSeries data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
       </XYChart>,
     );
     const barSeries = wrapper.find(BarSeries).dive();
@@ -38,7 +38,7 @@ describe('<BarSeries />', () => {
 
     const noDataWrapper = shallow(
       <XYChart {...mockProps} >
-        <BarSeries label="l" data={[]} />
+        <BarSeries data={[]} />
       </XYChart>,
     );
     const noDataBarSeries = noDataWrapper.find(BarSeries).dive();
@@ -49,7 +49,6 @@ describe('<BarSeries />', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
         <BarSeries
-          label="l"
           data={mockData.map((d, i) => ({
             x: d.date,
             y: i === 0 ? null : d.num,
@@ -64,7 +63,7 @@ describe('<BarSeries />', () => {
   test('it should work with time or band scales', () => {
     const timeWrapper = shallow(
       <XYChart {...mockProps} xScale={{ type: 'time' }}>
-        <BarSeries label="l" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <BarSeries data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
       </XYChart>,
     );
     expect(timeWrapper.find(BarSeries).length).toBe(1);
@@ -72,7 +71,7 @@ describe('<BarSeries />', () => {
 
     const bandWrapper = shallow(
       <XYChart {...mockProps} xScale={{ type: 'band' }}>
-        <BarSeries label="l" data={mockData.map(d => ({ ...d, x: d.cat, y: d.num }))} />
+        <BarSeries data={mockData.map(d => ({ ...d, x: d.cat, y: d.num }))} />
       </XYChart>,
     );
     expect(bandWrapper.find(BarSeries).length).toBe(1);
@@ -92,7 +91,7 @@ describe('<BarSeries />', () => {
         onMouseLeave={onMouseLeave}
         onClick={onClick}
       >
-        <BarSeries fill="banana" label="l" data={data} />
+        <BarSeries fill="banana" data={data} />
       </XYChart>,
     );
 
@@ -116,5 +115,34 @@ describe('<BarSeries />', () => {
     expect(args.datum).toBe(data[0]);
     expect(args.event).toBeDefined();
     expect(args.color).toBe('banana');
+  });
+
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <BarSeries data={data} disableMouseEvents />
+      </XYChart>,
+    );
+
+    const bar = wrapper.find(Bar).first();
+
+    bar.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    bar.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/xy-chart/test/BarSeries.test.js
+++ b/packages/xy-chart/test/BarSeries.test.js
@@ -79,22 +79,28 @@ describe('<BarSeries />', () => {
     expect(bandWrapper.find(BarSeries).dive().find(Bar).length).toBe(mockData.length);
   });
 
-  test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {
+  test('it should call onMouseMove({ datum, data, event, color }), onMouseLeave(), and onClick({ datum, data, event, color }) on trigger', () => {
     const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
-      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         <BarSeries fill="banana" label="l" data={data} />
       </XYChart>,
     );
 
     const bar = wrapper.find(Bar).first();
-    bar.simulate('mousemove');
 
+    bar.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(data);
     expect(args.datum).toBe(data[0]);
     expect(args.event).toBeDefined();
@@ -102,5 +108,13 @@ describe('<BarSeries />', () => {
 
     bar.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toBe(data);
+    expect(args.datum).toBe(data[0]);
+    expect(args.event).toBeDefined();
+    expect(args.color).toBe('banana');
   });
 });

--- a/packages/xy-chart/test/CirclePackSeries.test.js
+++ b/packages/xy-chart/test/CirclePackSeries.test.js
@@ -47,12 +47,18 @@ describe('<CirclePackSeries />', () => {
     expect(data[0].y).toEqual(expect.any(Number));
   });
 
-  test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {
+  test('it should call onMouseMove({ datum, data, event, color }), onMouseLeave(), and onClick({ datum, data, event, color }) on trigger', () => {
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
-      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         <CirclePackSeries label="" data={mockData} fill="army-green" />
       </XYChart>,
     );
@@ -61,7 +67,7 @@ describe('<CirclePackSeries />', () => {
     point.simulate('mousemove');
 
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toMatchObject(mockData);
     expect(args.datum).toMatchObject(mockData[0]);
     expect(args.event).toBeDefined();
@@ -69,6 +75,14 @@ describe('<CirclePackSeries />', () => {
 
     point.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    point.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toMatchObject(mockData);
+    expect(args.datum).toMatchObject(mockData[0]);
+    expect(args.event).toBeDefined();
+    expect(args.color).toBe('army-green');
   });
 
   test('it should invoke layoutCallback if passed with y-range and -domain arguments', () => {

--- a/packages/xy-chart/test/CirclePackSeries.test.js
+++ b/packages/xy-chart/test/CirclePackSeries.test.js
@@ -26,7 +26,7 @@ describe('<CirclePackSeries />', () => {
   test('it should render a PointSeries', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <CirclePackSeries label="" data={mockData} />
+        <CirclePackSeries data={mockData} />
       </XYChart>,
     );
     const circleSeries = wrapper.find(CirclePackSeries);
@@ -37,7 +37,7 @@ describe('<CirclePackSeries />', () => {
   test('data passed to PointSeries should include computed y values', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <CirclePackSeries label="" data={mockData} />
+        <CirclePackSeries data={mockData} />
       </XYChart>,
     );
     const circleSeries = wrapper.find(CirclePackSeries);
@@ -59,7 +59,7 @@ describe('<CirclePackSeries />', () => {
         onMouseLeave={onMouseLeave}
         onClick={onClick}
       >
-        <CirclePackSeries label="" data={mockData} fill="army-green" />
+        <CirclePackSeries data={mockData} fill="army-green" />
       </XYChart>,
     );
 
@@ -85,13 +85,41 @@ describe('<CirclePackSeries />', () => {
     expect(args.color).toBe('army-green');
   });
 
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <CirclePackSeries data={mockData} disableMouseEvents />
+      </XYChart>,
+    );
+
+    const point = wrapper.find('circle').first();
+
+    point.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    point.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    point.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
   test('it should invoke layoutCallback if passed with y-range and -domain arguments', () => {
     jest.useFakeTimers();
     const layoutCallback = jest.fn();
 
     mount(
       <XYChart {...mockProps} >
-        <CirclePackSeries label="" data={mockData} layoutCallback={layoutCallback} />
+        <CirclePackSeries data={mockData} layoutCallback={layoutCallback} />
       </XYChart>,
     );
 

--- a/packages/xy-chart/test/GroupedBarSeries.test.js
+++ b/packages/xy-chart/test/GroupedBarSeries.test.js
@@ -71,14 +71,20 @@ describe('<GroupedBarSeries />', () => {
     });
   });
 
-  test('it should call onMouseMove({ datum, data, event, seriesKey, color }) and onMouseLeave() on trigger', () => {
+  test('it should call onMouseMove({ datum, data, event, seriesKey, color }), onMouseLeave(), and onClick({ datum, data, event, seriesKey, color }) on trigger', () => {
     const fills = ['magenta', 'maplesyrup', 'banana'];
     const stackKeys = ['a', 'b', 'c'];
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
-      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         <GroupedBarSeries
           groupKeys={['a', 'b', 'c']}
           groupFills={fills}
@@ -88,10 +94,10 @@ describe('<GroupedBarSeries />', () => {
     );
 
     const bar = wrapper.find(Bar).first();
-    bar.simulate('mousemove');
 
+    bar.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(mockData);
     expect(args.datum).toBe(mockData[0]);
     expect(args.event).toBeDefined();
@@ -100,5 +106,14 @@ describe('<GroupedBarSeries />', () => {
 
     bar.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toBe(mockData);
+    expect(args.datum).toBe(mockData[0]);
+    expect(args.event).toBeDefined();
+    expect(stackKeys.includes(args.seriesKey)).toBe(true);
+    expect(fills.includes(args.color)).toBe(true);
   });
 });

--- a/packages/xy-chart/test/GroupedBarSeries.test.js
+++ b/packages/xy-chart/test/GroupedBarSeries.test.js
@@ -86,7 +86,7 @@ describe('<GroupedBarSeries />', () => {
         onClick={onClick}
       >
         <GroupedBarSeries
-          groupKeys={['a', 'b', 'c']}
+          groupKeys={stackKeys}
           groupFills={fills}
           data={mockData}
         />
@@ -115,5 +115,39 @@ describe('<GroupedBarSeries />', () => {
     expect(args.event).toBeDefined();
     expect(stackKeys.includes(args.seriesKey)).toBe(true);
     expect(fills.includes(args.color)).toBe(true);
+  });
+
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const fills = ['magenta', 'maplesyrup', 'banana'];
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <GroupedBarSeries
+          groupKeys={['a', 'b', 'c']}
+          groupFills={fills}
+          data={mockData}
+          disableMouseEvents
+        />
+      </XYChart>,
+    );
+
+    const bar = wrapper.find(Bar).first();
+
+    bar.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    bar.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/xy-chart/test/IntervalSeries.test.js
+++ b/packages/xy-chart/test/IntervalSeries.test.js
@@ -38,21 +38,27 @@ describe('<PointSeries />', () => {
     expect(wrapper.find(IntervalSeries).dive().find(Bar).length).toBe(mockData.length);
   });
 
-  test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {
+  test('it should call onMouseMove({ datum, data, event, color }), onMouseLeave(), and onClick({ datum, data, event, color }) on trigger', () => {
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
-      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         <IntervalSeries label="" data={mockData} fill="purple" />
       </XYChart>,
     );
 
     const bar = wrapper.find(Bar).first();
-    bar.simulate('mousemove');
 
+    bar.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(mockData);
     expect(args.datum).toBe(mockData[0]);
     expect(args.event).toBeDefined();
@@ -60,5 +66,13 @@ describe('<PointSeries />', () => {
 
     bar.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toBe(mockData);
+    expect(args.datum).toBe(mockData[0]);
+    expect(args.event).toBeDefined();
+    expect(args.color).toBe('purple');
   });
 });

--- a/packages/xy-chart/test/IntervalSeries.test.js
+++ b/packages/xy-chart/test/IntervalSeries.test.js
@@ -25,13 +25,13 @@ describe('<PointSeries />', () => {
   });
 
   test('it should not render without x- and y-scales', () => {
-    expect(shallow(<IntervalSeries label="" data={[]} />).type()).toBeNull();
+    expect(shallow(<IntervalSeries data={[]} />).type()).toBeNull();
   });
 
   test('it should render a Bar for each datum', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <IntervalSeries label="" data={mockData} />
+        <IntervalSeries data={mockData} />
       </XYChart>,
     );
     expect(wrapper.find(IntervalSeries).length).toBe(1);
@@ -50,7 +50,7 @@ describe('<PointSeries />', () => {
         onMouseLeave={onMouseLeave}
         onClick={onClick}
       >
-        <IntervalSeries label="" data={mockData} fill="purple" />
+        <IntervalSeries data={mockData} fill="purple" />
       </XYChart>,
     );
 
@@ -74,5 +74,33 @@ describe('<PointSeries />', () => {
     expect(args.datum).toBe(mockData[0]);
     expect(args.event).toBeDefined();
     expect(args.color).toBe('purple');
+  });
+
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <IntervalSeries data={mockData} fill="purple" disableMouseEvents />
+      </XYChart>,
+    );
+
+    const bar = wrapper.find(Bar).first();
+
+    bar.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    bar.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/xy-chart/test/LineSeries.test.js
+++ b/packages/xy-chart/test/LineSeries.test.js
@@ -26,14 +26,14 @@ describe('<LineSeries />', () => {
   });
 
   test('it should not render without x- and y-scales', () => {
-    expect(shallow(<LineSeries label="" data={[]} />).type()).toBeNull();
+    expect(shallow(<LineSeries data={[]} />).type()).toBeNull();
   });
 
   test('it should render a LinePath for each LineSeries', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <LineSeries label="l" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
-        <LineSeries label="l2" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <LineSeries data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <LineSeries data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
       </XYChart>,
     );
     expect(wrapper.find(LineSeries).length).toBe(2);
@@ -44,7 +44,7 @@ describe('<LineSeries />', () => {
     const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
     const wrapperWithPoints = shallow(
       <XYChart {...mockProps} >
-        <LineSeries label="l" data={data} showPoints />
+        <LineSeries data={data} showPoints />
       </XYChart>,
     );
     const lineSeriesWithPoints = wrapperWithPoints.find(LineSeries).dive();
@@ -53,7 +53,7 @@ describe('<LineSeries />', () => {
 
     const wrapperNoPoints = shallow(
       <XYChart {...mockProps} >
-        <LineSeries label="l" data={data} showPoints={false} />
+        <LineSeries data={data} showPoints={false} />
       </XYChart>,
     );
     const lineSeriesNoPoints = wrapperNoPoints.find(LineSeries).dive();
@@ -65,7 +65,6 @@ describe('<LineSeries />', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
         <LineSeries
-          label="l"
           data={mockData.map((d, i) => ({ // test null x AND y's
             x: i === 0 ? null : d.date,
             y: i === 1 ? null : d.num,
@@ -92,7 +91,7 @@ describe('<LineSeries />', () => {
         onMouseLeave={onMouseLeave}
         onClick={onClick}
       >
-        <LineSeries label="l" data={data} stroke="gray-or-grey?" />
+        <LineSeries data={data} stroke="gray-or-grey?" />
       </XYChart>,
     );
 
@@ -116,5 +115,34 @@ describe('<LineSeries />', () => {
     expect(args.datum).toBeNull(); // @TODO depends on mocking out findClosestDatum
     expect(args.event).toBeDefined();
     expect(args.color).toBe('gray-or-grey?');
+  });
+
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <LineSeries data={data} disableMouseEvents />
+      </XYChart>,
+    );
+
+    const line = wrapper.find('path');
+
+    line.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    line.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    line.simulate('click');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/xy-chart/test/LineSeries.test.js
+++ b/packages/xy-chart/test/LineSeries.test.js
@@ -79,22 +79,28 @@ describe('<LineSeries />', () => {
     expect(path.find(GlyphDot).length).toBe(mockData.length - 2);
   });
 
-  test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {
+  test('it should call onMouseMove({ datum, data, event, color }), onMouseLeave(), and onClick({ datum, data, event, color }) on trigger', () => {
     const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
-      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         <LineSeries label="l" data={data} stroke="gray-or-grey?" />
       </XYChart>,
     );
 
     const line = wrapper.find('path');
-    line.simulate('mousemove');
 
+    line.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(data);
     expect(args.datum).toBeNull(); // @TODO depends on mocking out findClosestDatum
     expect(args.event).toBeDefined();
@@ -102,5 +108,13 @@ describe('<LineSeries />', () => {
 
     line.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    line.simulate('click');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+    args = onMouseMove.mock.calls[0][0];
+    expect(args.data).toBe(data);
+    expect(args.datum).toBeNull(); // @TODO depends on mocking out findClosestDatum
+    expect(args.event).toBeDefined();
+    expect(args.color).toBe('gray-or-grey?');
   });
 });

--- a/packages/xy-chart/test/PointSeries.test.js
+++ b/packages/xy-chart/test/PointSeries.test.js
@@ -25,13 +25,13 @@ describe('<PointSeries />', () => {
   });
 
   test('it should not render without x- and y-scales', () => {
-    expect(shallow(<PointSeries label="" data={[]} />).type()).toBeNull();
+    expect(shallow(<PointSeries data={[]} />).type()).toBeNull();
   });
 
   test('it should render a GlyphDotComponent for each datum', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <PointSeries label="" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <PointSeries data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
       </XYChart>,
     );
     expect(wrapper.find(PointSeries).length).toBe(1);
@@ -42,7 +42,6 @@ describe('<PointSeries />', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
         <PointSeries
-          label=""
           data={mockData.map((d, i) => ({ // test null x AND y's
             x: i === 0 ? null : d.date,
             y: i === 1 ? null : d.num,
@@ -58,7 +57,7 @@ describe('<PointSeries />', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
         <PointSeries
-          label="l" data={mockData.map((d, i) => ({
+          data={mockData.map((d, i) => ({
             x: d.date,
             y: d.num,
             label: i === 0 ? 'LABEL' : null,
@@ -85,7 +84,7 @@ describe('<PointSeries />', () => {
         onMouseLeave={onMouseLeave}
         onClick={onClick}
       >
-        <PointSeries label="" data={data} fill="army-green" />
+        <PointSeries data={data} fill="army-green" />
       </XYChart>,
     );
 
@@ -109,5 +108,34 @@ describe('<PointSeries />', () => {
     expect(args.datum).toBe(data[0]);
     expect(args.event).toBeDefined();
     expect(args.color).toBe('army-green');
+  });
+
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <PointSeries data={data} disableMouseEvents />
+      </XYChart>,
+    );
+
+    const point = wrapper.find('circle').first();
+
+    point.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    point.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    point.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/xy-chart/test/PointSeries.test.js
+++ b/packages/xy-chart/test/PointSeries.test.js
@@ -72,22 +72,28 @@ describe('<PointSeries />', () => {
     expect(label.text()).toBe('LABEL');
   });
 
-  test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {
+  test('it should call onMouseMove({ datum, data, event, color }), onMouseLeave(), and onClick({ datum, data, event, color }) on trigger', () => {
     const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
-      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         <PointSeries label="" data={data} fill="army-green" />
       </XYChart>,
     );
 
     const point = wrapper.find('circle').first();
-    point.simulate('mousemove');
 
+    point.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(data);
     expect(args.datum).toBe(data[0]);
     expect(args.event).toBeDefined();
@@ -95,5 +101,13 @@ describe('<PointSeries />', () => {
 
     point.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    point.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toBe(data);
+    expect(args.datum).toBe(data[0]);
+    expect(args.event).toBeDefined();
+    expect(args.color).toBe('army-green');
   });
 });

--- a/packages/xy-chart/test/StackedAreaSeries.test.js
+++ b/packages/xy-chart/test/StackedAreaSeries.test.js
@@ -29,14 +29,14 @@ describe('<StackedAreaSeries />', () => {
 
   test('it should not render without x- and y-scales', () => {
     expect(
-      shallow(<StackedAreaSeries label="" data={[]} stackKeys={[]} />).type(),
+      shallow(<StackedAreaSeries data={[]} stackKeys={[]} />).type(),
     ).toBeNull();
   });
 
   test('it should render a <Stack />', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <StackedAreaSeries label="" data={mockData} stackKeys={mockStackKeys} />
+        <StackedAreaSeries data={mockData} stackKeys={mockStackKeys} />
       </XYChart>,
     );
 
@@ -48,7 +48,7 @@ describe('<StackedAreaSeries />', () => {
   test('it should render an path for each stackKey', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <StackedAreaSeries label="" data={mockData} stackKeys={mockStackKeys} />
+        <StackedAreaSeries data={mockData} stackKeys={mockStackKeys} />
       </XYChart>,
     );
 
@@ -71,7 +71,6 @@ describe('<StackedAreaSeries />', () => {
         onClick={onClick}
       >
         <StackedAreaSeries
-          label=""
           data={mockData}
           stackKeys={mockStackKeys}
           stackFills={mockStackFills}
@@ -103,5 +102,40 @@ describe('<StackedAreaSeries />', () => {
     expect(args.event).toBeDefined();
     expect(mockStackFills.indexOf(args.color)).toBeGreaterThan(-1);
     expect(mockStackKeys.indexOf(args.seriesKey)).toBeGreaterThan(-1);
+  });
+
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <StackedAreaSeries
+          data={mockData}
+          stackKeys={mockStackKeys}
+          stackFills={mockStackFills}
+          disableMouseEvents
+        />
+      </XYChart>,
+    );
+
+    const series = wrapper.find(StackedAreaSeries);
+    const stack = series.find(Stack);
+    const path = stack.find('path').first();
+
+    path.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    path.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    path.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/xy-chart/test/StackedAreaSeries.test.js
+++ b/packages/xy-chart/test/StackedAreaSeries.test.js
@@ -1,0 +1,107 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import Stack from '@vx/shape/build/shapes/Stack';
+
+import { XYChart, StackedAreaSeries } from '../src/';
+
+describe('<StackedAreaSeries />', () => {
+  const mockProps = {
+    xScale: { type: 'time' },
+    yScale: { type: 'linear' },
+    width: 100,
+    height: 100,
+    margin: { top: 10, right: 10, bottom: 10, left: 10 },
+    ariaLabel: 'label',
+  };
+
+  const mockData = [
+    { x: new Date('2017-01-05'), y: 5, a: 1, b: 2, c: 3 },
+    { x: new Date('2018-01-05'), y: 15, a: 10, b: 2, c: 3 },
+    { x: new Date('2019-01-05'), y: 5, a: 4, b: 2, c: 0 },
+  ];
+
+  const mockStackKeys = ['a', 'b', 'c'];
+  const mockStackFills = ['#fill1', '#fill2', '#fill3'];
+
+  test('it should be defined', () => {
+    expect(StackedAreaSeries).toBeDefined();
+  });
+
+  test('it should not render without x- and y-scales', () => {
+    expect(
+      shallow(<StackedAreaSeries label="" data={[]} stackKeys={[]} />).type(),
+    ).toBeNull();
+  });
+
+  test('it should render a <Stack />', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <StackedAreaSeries label="" data={mockData} stackKeys={mockStackKeys} />
+      </XYChart>,
+    );
+
+    const series = wrapper.find(StackedAreaSeries).dive();
+
+    expect(series.find(Stack).length).toBe(1);
+  });
+
+  test('it should render an path for each stackKey', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <StackedAreaSeries label="" data={mockData} stackKeys={mockStackKeys} />
+      </XYChart>,
+    );
+
+    const series = wrapper.find(StackedAreaSeries).dive();
+    const stack = series.find(Stack).dive();
+
+    expect(stack.find('path').length).toBe(mockStackKeys.length);
+  });
+
+  test('it should call onMouseMove({ datum, data, event, color, seriesKey }), onMouseLeave(), and onClick({ datum, data, event, color, seriesKey }) on trigger', () => {
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <StackedAreaSeries
+          label=""
+          data={mockData}
+          stackKeys={mockStackKeys}
+          stackFills={mockStackFills}
+        />
+      </XYChart>,
+    );
+
+    const series = wrapper.find(StackedAreaSeries);
+    const stack = series.find(Stack);
+    const path = stack.find('path').first();
+
+    path.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+    let args = onMouseMove.mock.calls[0][0];
+    expect(args.data).toBe(mockData);
+    expect(args.datum).toBeNull(); // @TODO depends on mocking out findClosestDatum
+    expect(args.event).toBeDefined();
+    expect(mockStackFills.indexOf(args.color)).toBeGreaterThan(-1);
+    expect(mockStackKeys.indexOf(args.seriesKey)).toBeGreaterThan(-1);
+
+    path.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    path.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toBe(mockData);
+    expect(args.datum).toBeNull(); // @TODO depends on mocking out findClosestDatum
+    expect(args.event).toBeDefined();
+    expect(mockStackFills.indexOf(args.color)).toBeGreaterThan(-1);
+    expect(mockStackKeys.indexOf(args.seriesKey)).toBeGreaterThan(-1);
+  });
+});

--- a/packages/xy-chart/test/StackedBarSeries.test.js
+++ b/packages/xy-chart/test/StackedBarSeries.test.js
@@ -71,14 +71,20 @@ describe('<GroupedBarSeries />', () => {
     });
   });
 
-  test('it should call onMouseMove({ datum, data, event, seriesKey, color }) and onMouseLeave() on trigger', () => {
+  test('it should call onMouseMove({ datum, data, event, seriesKey, color }), onMouseLeave(), and onClick({ datum, data, event, seriesKey, color }) on trigger', () => {
     const fills = ['magenta', 'maplesyrup', 'banana'];
     const stackKeys = ['a', 'b', 'c'];
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
-      <XYChart {...mockProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
         <StackedBarSeries
           stackKeys={stackKeys}
           stackFills={fills}
@@ -88,10 +94,10 @@ describe('<GroupedBarSeries />', () => {
     );
 
     const bar = wrapper.find(Bar).first();
-    bar.simulate('mousemove');
 
+    bar.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toEqual(mockData);
     expect(args.datum).toBe(mockData[0]);
     expect(args.event).toBeDefined();
@@ -100,5 +106,14 @@ describe('<GroupedBarSeries />', () => {
 
     bar.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toEqual(mockData);
+    expect(args.datum).toBe(mockData[0]);
+    expect(args.event).toBeDefined();
+    expect(stackKeys.includes(args.seriesKey)).toBe(true);
+    expect(fills.includes(args.color)).toBe(true);
   });
 });

--- a/packages/xy-chart/test/StackedBarSeries.test.js
+++ b/packages/xy-chart/test/StackedBarSeries.test.js
@@ -116,4 +116,39 @@ describe('<GroupedBarSeries />', () => {
     expect(stackKeys.includes(args.seriesKey)).toBe(true);
     expect(fills.includes(args.color)).toBe(true);
   });
+
+  test('it should not trigger onMouseMove, onMouseLeave, or onClick if disableMouseEvents is true', () => {
+    const fills = ['magenta', 'maplesyrup', 'banana'];
+    const stackKeys = ['a', 'b', 'c'];
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    const wrapper = mount(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <StackedBarSeries
+          stackKeys={stackKeys}
+          stackFills={fills}
+          data={mockData}
+          disableMouseEvents
+        />
+      </XYChart>,
+    );
+
+    const bar = wrapper.find(Bar).first();
+
+    bar.simulate('mousemove');
+    expect(onMouseMove).toHaveBeenCalledTimes(0);
+
+    bar.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(0);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(0);
+  });
 });

--- a/packages/xy-chart/test/Voronoi.test.js
+++ b/packages/xy-chart/test/Voronoi.test.js
@@ -47,6 +47,17 @@ describe('<Voronoi />', () => {
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 
+  test('it should pass the relevant datum to onClick on trigger', () => {
+    const onClick = jest.fn();
+    const wrapper = mount(<Voronoi {...props} onClick={onClick} />);
+    const polygon = wrapper.find(VoronoiPolygon).first();
+    polygon.simulate('click');
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    const datum = onClick.mock.calls[0][0].datum;
+    expect(props.data.includes(datum)).toBe(true);
+  });
+
   test('it should update its voronoi if the data update', () => {
     const wrapper = shallow(<Voronoi {...props} />);
     const voronoi0 = wrapper.state('voronoi');


### PR DESCRIPTION
🏆 Enhancements
- [xy-chart] adds `<StackedAreaSeries />` and example
- [xy-chart] adds `onClick` support to all series and voronoi
- [xy-chart] removes previously-required `label` prop from series
- [demo] adds `<LinkedXYCharts />` example with custom click handling and mouse overs
- [demo] adds `disableMouseEvents` prop to all series
- removes enumeration of `@data-ui` packages in `readme`s

🐛 Bug Fix
- fixes a bug for bar offsets

🏠 Internal
- [shared] bumps `@vx/tooltip` to `0.0.147` for [smarter tooltips](https://github.com/hshoff/vx/blob/master/CHANGELOG.md#v00147)

<img width="400" alt="screen shot 2017-11-14 at 1 23 28 am" src="https://user-images.githubusercontent.com/4496521/32772433-b235be36-c8da-11e7-91e7-d96860af388d.png">

<img width="400" src="https://user-images.githubusercontent.com/4496521/32772465-caefea1e-c8da-11e7-97d2-bc245aac8fd7.gif" />
