### PR TITLE
added stats charts in xy-chart

### DIFF
--- a/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
+++ b/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
@@ -93,7 +93,6 @@ export function SimpleBoxPlotSeriesExample() {
       <YAxis numTicks={4} />
       <BoxPlotSeries
         data={boxPlotData}
-        label="Test"
         fill="url(#aqua_lightaqua_gradient)"
         stroke="#22b8cf"
         strokeWidth={1.5}
@@ -140,7 +139,6 @@ export function SingleBoxPlotSeriesExample() {
       />
       <BoxPlotSeries
         data={boxPlotData}
-        label="Test"
         fill="url(#aqua_lightaqua_gradient)"
         stroke="#22b8cf"
         strokeWidth={1.5}
@@ -192,7 +190,6 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
       <YAxis numTicks={4} />
       <ViolinPlotSeries
         data={violinData}
-        label="Test"
         fill="url(#vViolinLines)"
         stroke="#22b8cf"
         strokeWidth={0.5}
@@ -200,7 +197,6 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
       />
       <BoxPlotSeries
         data={boxPlotData}
-        label="Test"
         fill={colors.categories[0]}
         stroke={colors.categories[0]}
         widthRatio={0.5}
@@ -248,14 +244,12 @@ export function BoxPlotViolinPlotSeriesExample() {
       <YAxis numTicks={4} />
       <ViolinPlotSeries
         data={violinData}
-        label="Test"
         fill="url(#hViolinLines)"
         stroke="#22b8cf"
         strokeWidth={0.5}
       />
       <BoxPlotSeries
         data={boxPlotData}
-        label="Test"
         fill={colors.categories[0]}
         stroke={colors.categories[0]}
         widthRatio={0.5}

--- a/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
+++ b/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
@@ -17,6 +17,21 @@ import { statsData } from './data';
 
 const { colors } = theme;
 
+function renderViolinPlotTooltip({ datum, color }) {
+  const { x, y, binData } = datum;
+  const label = x || y;
+  return (
+    <div>
+      <div>
+        <strong style={{ color }}>{label}</strong>
+      </div>
+      <div>
+        <strong style={{ color }}>Bin Number </strong>
+        {binData.length}
+      </div>
+    </div>
+  );
+}
 function renderBoxPlotTooltip({ datum, color }) {
   const {
     x,
@@ -194,6 +209,7 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
         stroke="#22b8cf"
         strokeWidth={0.5}
         horizontal
+        disableMouseEvents
       />
       <BoxPlotSeries
         data={boxPlotData}
@@ -209,7 +225,7 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
   );
 }
 
-export function BoxPlotViolinPlotSeriesExample() {
+export function ViolinPlotSeriesExample() {
   const boxPlotData = statsData.map(s => s.boxPlot);
   const violinData = statsData.map(s => ({ x: s.boxPlot.x, binData: s.binData }));
   const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
@@ -229,7 +245,7 @@ export function BoxPlotViolinPlotSeriesExample() {
       yScale={{ type: 'linear',
         domain: yDomain,
       }}
-      renderTooltip={renderBoxPlotTooltip}
+      renderTooltip={renderViolinPlotTooltip}
       showYGrid
     >
       <PatternLines
@@ -247,14 +263,6 @@ export function BoxPlotViolinPlotSeriesExample() {
         fill="url(#hViolinLines)"
         stroke="#22b8cf"
         strokeWidth={0.5}
-      />
-      <BoxPlotSeries
-        data={boxPlotData}
-        fill={colors.categories[0]}
-        stroke={colors.categories[0]}
-        widthRatio={0.5}
-        fillOpacity={0.2}
-        strokeWidth={1}
       />
       <XAxis />
     </ResponsiveXYChart>

--- a/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
+++ b/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
@@ -1,0 +1,268 @@
+/* eslint react/prop-types: 0 */
+import React from 'react';
+
+import {
+  XAxis,
+  YAxis,
+  BoxPlotSeries,
+  ViolinPlotSeries,
+  PatternLines,
+  LinearGradient,
+  theme,
+} from '@data-ui/xy-chart';
+
+import ResponsiveXYChart from './ResponsiveXYChart';
+
+import { statsData } from './data';
+
+const { colors } = theme;
+
+function renderBoxPlotTooltip({ datum, color }) {
+  const {
+    x,
+    y,
+    min,
+    max,
+    median,
+    firstQuartile,
+    thirdQuartile,
+    outliers,
+  } = datum;
+
+  const label = x || y;
+  return (
+    <div>
+      <div>
+        <strong style={{ color }}>{label}</strong>
+      </div>
+      <div>
+        <strong style={{ color }}>Min </strong>
+        {min && min.toFixed ? min.toFixed(2) : min}
+      </div>
+      <div>
+        <strong style={{ color }}>Max </strong>
+        {max && max.toFixed ? max.toFixed(2) : max}
+      </div>
+      <div>
+        <strong style={{ color }}>Median </strong>
+        {median && median.toFixed ? median.toFixed(2) : median}
+      </div>
+      <div>
+        <strong style={{ color }}>First Quartile </strong>
+        {firstQuartile && firstQuartile.toFixed ? firstQuartile.toFixed(2) : firstQuartile}
+      </div>
+      <div>
+        <strong style={{ color }}>Third Quartile </strong>
+        {thirdQuartile && thirdQuartile.toFixed ? thirdQuartile.toFixed(2) : thirdQuartile}
+      </div>
+      <div>
+        <strong style={{ color }}>Outliers Number </strong>
+        {outliers.length}
+      </div>
+    </div>
+  );
+}
+
+export function SimpleBoxPlotSeriesExample() {
+  const boxPlotData = statsData.map(s => s.boxPlot);
+  const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+  const minYValue = Math.min(...values);
+  const maxYValue = Math.max(...values);
+  const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
+    maxYValue + (0.1 * Math.abs(minYValue))];
+  return (
+    <ResponsiveXYChart
+      theme={{}}
+      ariaLabel="Required label"
+      xScale={{
+        type: 'band',
+        paddingInner: 0.15,
+        paddingOuter: 0.3,
+      }}
+      yScale={{ type: 'linear',
+        domain: yDomain,
+      }}
+      renderTooltip={renderBoxPlotTooltip}
+      showYGrid
+    >
+      <LinearGradient
+        id="aqua_lightaqua_gradient"
+        from="#99e9f2"
+        to="#c5f6fa"
+      />
+      <YAxis numTicks={4} />
+      <BoxPlotSeries
+        data={boxPlotData}
+        label="Test"
+        fill="url(#aqua_lightaqua_gradient)"
+        stroke="#22b8cf"
+        strokeWidth={1.5}
+      />
+      <XAxis />
+    </ResponsiveXYChart>
+  );
+}
+
+export function SingleBoxPlotSeriesExample() {
+  const singleStats = [statsData[0]];
+  const boxPlotData = singleStats.map((s) => {
+    const { boxPlot } = s;
+    const { x, ...rest } = boxPlot;
+    return {
+      y: x,
+      ...rest,
+    };
+  });
+  const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+  const minXValue = Math.min(...values);
+  const maxXValue = Math.max(...values);
+  const xDomain = [minXValue - (0.1 * Math.abs(minXValue)),
+    maxXValue + (0.1 * Math.abs(maxXValue))];
+  return (
+    <ResponsiveXYChart
+      theme={{}}
+      ariaLabel="Required label"
+      yScale={{
+        type: 'band',
+        paddingInner: 0.15,
+        paddingOuter: 0.3,
+      }}
+      xScale={{ type: 'linear',
+        domain: xDomain,
+      }}
+      renderTooltip={renderBoxPlotTooltip}
+      showYGrid
+    >
+      <LinearGradient
+        id="aqua_lightaqua_gradient"
+        from="#99e9f2"
+        to="#c5f6fa"
+      />
+      <BoxPlotSeries
+        data={boxPlotData}
+        label="Test"
+        fill="url(#aqua_lightaqua_gradient)"
+        stroke="#22b8cf"
+        strokeWidth={1.5}
+        horizontal
+      />
+      <XAxis />
+    </ResponsiveXYChart>
+  );
+}
+
+export function HorizontalBoxPlotViolinPlotSeriesExample() {
+  const boxPlotData = statsData.map((s) => {
+    const { boxPlot } = s;
+    const { x, ...rest } = boxPlot;
+    return {
+      y: x,
+      ...rest,
+    };
+  });
+  const violinData = statsData.map(s => ({ y: s.boxPlot.x, binData: s.binData }));
+  const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+  const minXValue = Math.min(...values);
+  const maxXValue = Math.max(...values);
+  const xDomain = [minXValue - (0.1 * Math.abs(minXValue)),
+    maxXValue + (0.1 * Math.abs(maxXValue))];
+  return (
+    <ResponsiveXYChart
+      theme={{}}
+      ariaLabel="Required label"
+      yScale={{
+        type: 'band',
+        paddingInner: 0.15,
+        paddingOuter: 0.3,
+      }}
+      xScale={{ type: 'linear',
+        domain: xDomain,
+      }}
+      renderTooltip={renderBoxPlotTooltip}
+      showYGrid
+    >
+      <PatternLines
+        id="vViolinLines"
+        height={3}
+        width={3}
+        stroke="#ced4da"
+        strokeWidth={1}
+        fill="rgba(0,0,0,0.3)"
+      />
+      <YAxis numTicks={4} />
+      <ViolinPlotSeries
+        data={violinData}
+        label="Test"
+        fill="url(#vViolinLines)"
+        stroke="#22b8cf"
+        strokeWidth={0.5}
+        horizontal
+      />
+      <BoxPlotSeries
+        data={boxPlotData}
+        label="Test"
+        fill={colors.categories[0]}
+        stroke={colors.categories[0]}
+        widthRatio={0.5}
+        fillOpacity={0.2}
+        strokeWidth={1}
+        horizontal
+      />
+      <XAxis />
+    </ResponsiveXYChart>
+  );
+}
+
+export function BoxPlotViolinPlotSeriesExample() {
+  const boxPlotData = statsData.map(s => s.boxPlot);
+  const violinData = statsData.map(s => ({ x: s.boxPlot.x, binData: s.binData }));
+  const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+  const minYValue = Math.min(...values);
+  const maxYValue = Math.max(...values);
+  const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
+    maxYValue + (0.1 * Math.abs(minYValue))];
+  return (
+    <ResponsiveXYChart
+      theme={{}}
+      ariaLabel="Required label"
+      xScale={{
+        type: 'band',
+        paddingInner: 0.15,
+        paddingOuter: 0.3,
+      }}
+      yScale={{ type: 'linear',
+        domain: yDomain,
+      }}
+      renderTooltip={renderBoxPlotTooltip}
+      showYGrid
+    >
+      <PatternLines
+        id="hViolinLines"
+        height={3}
+        width={3}
+        stroke="#ced4da"
+        strokeWidth={1}
+        fill="rgba(0,0,0,0.3)"
+        orientation={['horizontal']}
+      />
+      <YAxis numTicks={4} />
+      <ViolinPlotSeries
+        data={violinData}
+        label="Test"
+        fill="url(#hViolinLines)"
+        stroke="#22b8cf"
+        strokeWidth={0.5}
+      />
+      <BoxPlotSeries
+        data={boxPlotData}
+        label="Test"
+        fill={colors.categories[0]}
+        stroke={colors.categories[0]}
+        widthRatio={0.5}
+        fillOpacity={0.2}
+        strokeWidth={1}
+      />
+      <XAxis />
+    </ResponsiveXYChart>
+  );
+}

--- a/packages/demo/examples/01-xy-chart/data.js
+++ b/packages/demo/examples/01-xy-chart/data.js
@@ -1,4 +1,4 @@
-import { cityTemperature, appleStock, genRandomNormalPoints, letterFrequency } from '@vx/mock-data';
+import { cityTemperature, appleStock, genRandomNormalPoints, letterFrequency, genStats } from '@vx/mock-data';
 import { theme } from '@data-ui/xy-chart';
 
 export const timeSeriesData = appleStock.filter((d, i) => i % 120 === 0).map(d => ({
@@ -123,3 +123,5 @@ export const circlePackData = Array(400).fill(null).map((_, i) => ({
   fillOpacity: Math.max(0.4, Math.random()),
   fill: theme.colors.categories[i % 2 === 0 ? 1 : 3],
 }));
+
+export const statsData = genStats(5);

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -15,6 +15,8 @@ import {
   LineSeries,
   PointSeries,
   StackedBarSeries,
+  BoxPlotSeries,
+  ViolinPlotSeries,
 
   HorizontalReferenceLine,
   PatternLines,
@@ -43,6 +45,7 @@ import {
   intervalData,
   temperatureBands,
   priceBandData,
+  statsData,
 } from './data';
 
 import WithToggle from '../shared/WithToggle';
@@ -487,6 +490,214 @@ export default {
           <CrossHair />
         </ResponsiveXYChart>
       ),
+    },
+    {
+      description: 'Box Plot Example',
+      example: () => {
+        const boxPlotData = statsData.map(s => s.boxPlot);
+        const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+        const minYValue = Math.min(...values);
+        const maxYValue = Math.max(...values);
+        const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
+          maxYValue + (0.1 * Math.abs(minYValue))];
+        return (
+          <ResponsiveXYChart
+            theme={{}}
+            ariaLabel="Required label"
+            xScale={{
+              type: 'band',
+              paddingInner: 0.15,
+              paddingOuter: 0.3,
+            }}
+            yScale={{ type: 'linear',
+              domain: yDomain,
+            }}
+            showYGrid
+          >
+            <LinearGradient
+              id="aqua_lightaqua_gradient"
+              from="#99e9f2"
+              to="#c5f6fa"
+            />
+            <YAxis numTicks={4} />
+            <BoxPlotSeries
+              data={boxPlotData}
+              label="Test"
+              fill="url(#aqua_lightaqua_gradient)"
+              stroke="#22b8cf"
+              strokeWidth={1.5}
+            />
+            <XAxis />
+          </ResponsiveXYChart>
+        );
+      },
+    },
+    {
+      description: 'Single Horizontal Box Plot Example',
+      example: () => {
+        const singleStats = [statsData[0]];
+        const boxPlotData = singleStats.map((s) => {
+          const { boxPlot } = s;
+          const { x, ...rest } = boxPlot;
+          return {
+            y: x,
+            ...rest,
+          };
+        });
+        const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+        const minXValue = Math.min(...values);
+        const maxXValue = Math.max(...values);
+        const xDomain = [minXValue - (0.1 * Math.abs(minXValue)),
+          maxXValue + (0.1 * Math.abs(maxXValue))];
+        return (
+          <ResponsiveXYChart
+            theme={{}}
+            ariaLabel="Required label"
+            yScale={{
+              type: 'band',
+              paddingInner: 0.15,
+              paddingOuter: 0.3,
+            }}
+            xScale={{ type: 'linear',
+              domain: xDomain,
+            }}
+            showYGrid
+          >
+            <LinearGradient
+              id="aqua_lightaqua_gradient"
+              from="#99e9f2"
+              to="#c5f6fa"
+            />
+            <BoxPlotSeries
+              data={boxPlotData}
+              label="Test"
+              fill="url(#aqua_lightaqua_gradient)"
+              stroke="#22b8cf"
+              strokeWidth={1.5}
+              horizontal
+            />
+            <XAxis />
+          </ResponsiveXYChart>
+        );
+      },
+    },
+    {
+      description: 'Horizontal BoxPlot With ViolinPlot Example',
+      example: () => {
+        const boxPlotData = statsData.map((s) => {
+          const { boxPlot } = s;
+          const { x, ...rest } = boxPlot;
+          return {
+            y: x,
+            ...rest,
+          };
+        });
+        const violinData = statsData.map(s => ({ y: s.boxPlot.x, binData: s.binData }));
+        const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+        const minXValue = Math.min(...values);
+        const maxXValue = Math.max(...values);
+        const xDomain = [minXValue - (0.1 * Math.abs(minXValue)),
+          maxXValue + (0.1 * Math.abs(maxXValue))];
+        return (
+          <ResponsiveXYChart
+            theme={{}}
+            ariaLabel="Required label"
+            yScale={{
+              type: 'band',
+              paddingInner: 0.15,
+              paddingOuter: 0.3,
+            }}
+            xScale={{ type: 'linear',
+              domain: xDomain,
+            }}
+            showYGrid
+          >
+            <PatternLines
+              id="vViolinLines"
+              height={3}
+              width={3}
+              stroke="#ced4da"
+              strokeWidth={1}
+              fill="rgba(0,0,0,0.3)"
+            />
+            <YAxis numTicks={4} />
+            <ViolinPlotSeries
+              data={violinData}
+              label="Test"
+              fill="url(#vViolinLines)"
+              stroke="#22b8cf"
+              strokeWidth={0.5}
+              horizontal
+            />
+            <BoxPlotSeries
+              data={boxPlotData}
+              label="Test"
+              fill={colors.categories[0]}
+              stroke={colors.categories[0]}
+              widthRatio={0.5}
+              fillOpacity={0.2}
+              strokeWidth={1}
+              horizontal
+            />
+            <XAxis />
+          </ResponsiveXYChart>
+        );
+      },
+    },
+    {
+      description: 'BoxPlot With ViolinPlot Example',
+      example: () => {
+        const boxPlotData = statsData.map(s => s.boxPlot);
+        const violinData = statsData.map(s => ({ x: s.boxPlot.x, binData: s.binData }));
+        const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+        const minYValue = Math.min(...values);
+        const maxYValue = Math.max(...values);
+        const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
+          maxYValue + (0.1 * Math.abs(minYValue))];
+        return (
+          <ResponsiveXYChart
+            theme={{}}
+            ariaLabel="Required label"
+            xScale={{
+              type: 'band',
+              paddingInner: 0.15,
+              paddingOuter: 0.3,
+            }}
+            yScale={{ type: 'linear',
+              domain: yDomain,
+            }}
+            showYGrid
+          >
+            <PatternLines
+              id='hViolinLines'
+              height={3}
+              width={3}
+              stroke='#ced4da'
+              strokeWidth={1}
+              fill='rgba(0,0,0,0.3)'
+              orientation={['horizontal']}
+            />
+            <YAxis numTicks={4} />
+            <ViolinPlotSeries
+              data={violinData}
+              label="Test"
+              fill="url(#hViolinLines)"
+              stroke="#22b8cf"
+              strokeWidth={0.5}
+            />
+            <BoxPlotSeries
+              data={boxPlotData}
+              label="Test"
+              fill={colors.categories[0]}
+              stroke={colors.categories[0]}
+              widthRatio={0.5}
+              fillOpacity={0.2}
+              strokeWidth={1}
+            />
+            <XAxis />
+          </ResponsiveXYChart>
+        );
+      },
     },
     {
       description: 'XAxis, YAxis -- orientation',

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -493,6 +493,7 @@ export default {
     },
     {
       description: 'Box Plot Example',
+      components: [BoxPlotSeries],
       example: () => {
         const boxPlotData = statsData.map(s => s.boxPlot);
         const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
@@ -534,6 +535,7 @@ export default {
     },
     {
       description: 'Single Horizontal Box Plot Example',
+      components: [BoxPlotSeries],
       example: () => {
         const singleStats = [statsData[0]];
         const boxPlotData = singleStats.map((s) => {
@@ -583,6 +585,7 @@ export default {
     },
     {
       description: 'Horizontal BoxPlot With ViolinPlot Example',
+      components: [BoxPlotSeries, ViolinPlotSeries],
       example: () => {
         const boxPlotData = statsData.map((s) => {
           const { boxPlot } = s;
@@ -646,6 +649,7 @@ export default {
     },
     {
       description: 'BoxPlot With ViolinPlot Example',
+      components: [BoxPlotSeries, ViolinPlotSeries],
       example: () => {
         const boxPlotData = statsData.map(s => s.boxPlot);
         const violinData = statsData.map(s => ({ x: s.boxPlot.x, binData: s.binData }));

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -32,6 +32,12 @@ import RectPointComponent from './RectPointComponent';
 import ResponsiveXYChart, { dateFormatter } from './ResponsiveXYChart';
 import StackedAreaExample from './StackedAreaExample';
 import ScatterWithHistogram from './ScatterWithHistograms';
+import {
+  SimpleBoxPlotSeriesExample,
+  SingleBoxPlotSeriesExample,
+  HorizontalBoxPlotViolinPlotSeriesExample,
+  BoxPlotViolinPlotSeriesExample,
+} from './StatsSeriesExample';
 
 import {
   circlePackData,
@@ -45,7 +51,6 @@ import {
   intervalData,
   temperatureBands,
   priceBandData,
-  statsData,
 } from './data';
 
 import WithToggle from '../shared/WithToggle';
@@ -494,214 +499,30 @@ export default {
     {
       description: 'Box Plot Example',
       components: [BoxPlotSeries],
-      example: () => {
-        const boxPlotData = statsData.map(s => s.boxPlot);
-        const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-        const minYValue = Math.min(...values);
-        const maxYValue = Math.max(...values);
-        const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
-          maxYValue + (0.1 * Math.abs(minYValue))];
-        return (
-          <ResponsiveXYChart
-            theme={{}}
-            ariaLabel="Required label"
-            xScale={{
-              type: 'band',
-              paddingInner: 0.15,
-              paddingOuter: 0.3,
-            }}
-            yScale={{ type: 'linear',
-              domain: yDomain,
-            }}
-            showYGrid
-          >
-            <LinearGradient
-              id="aqua_lightaqua_gradient"
-              from="#99e9f2"
-              to="#c5f6fa"
-            />
-            <YAxis numTicks={4} />
-            <BoxPlotSeries
-              data={boxPlotData}
-              label="Test"
-              fill="url(#aqua_lightaqua_gradient)"
-              stroke="#22b8cf"
-              strokeWidth={1.5}
-            />
-            <XAxis />
-          </ResponsiveXYChart>
-        );
-      },
+      example: () => (
+        <SimpleBoxPlotSeriesExample />
+      ),
     },
     {
       description: 'Single Horizontal Box Plot Example',
       components: [BoxPlotSeries],
-      example: () => {
-        const singleStats = [statsData[0]];
-        const boxPlotData = singleStats.map((s) => {
-          const { boxPlot } = s;
-          const { x, ...rest } = boxPlot;
-          return {
-            y: x,
-            ...rest,
-          };
-        });
-        const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-        const minXValue = Math.min(...values);
-        const maxXValue = Math.max(...values);
-        const xDomain = [minXValue - (0.1 * Math.abs(minXValue)),
-          maxXValue + (0.1 * Math.abs(maxXValue))];
-        return (
-          <ResponsiveXYChart
-            theme={{}}
-            ariaLabel="Required label"
-            yScale={{
-              type: 'band',
-              paddingInner: 0.15,
-              paddingOuter: 0.3,
-            }}
-            xScale={{ type: 'linear',
-              domain: xDomain,
-            }}
-            showYGrid
-          >
-            <LinearGradient
-              id="aqua_lightaqua_gradient"
-              from="#99e9f2"
-              to="#c5f6fa"
-            />
-            <BoxPlotSeries
-              data={boxPlotData}
-              label="Test"
-              fill="url(#aqua_lightaqua_gradient)"
-              stroke="#22b8cf"
-              strokeWidth={1.5}
-              horizontal
-            />
-            <XAxis />
-          </ResponsiveXYChart>
-        );
-      },
+      example: () => (
+        <SingleBoxPlotSeriesExample />
+      ),
     },
     {
       description: 'Horizontal BoxPlot With ViolinPlot Example',
       components: [BoxPlotSeries, ViolinPlotSeries],
-      example: () => {
-        const boxPlotData = statsData.map((s) => {
-          const { boxPlot } = s;
-          const { x, ...rest } = boxPlot;
-          return {
-            y: x,
-            ...rest,
-          };
-        });
-        const violinData = statsData.map(s => ({ y: s.boxPlot.x, binData: s.binData }));
-        const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-        const minXValue = Math.min(...values);
-        const maxXValue = Math.max(...values);
-        const xDomain = [minXValue - (0.1 * Math.abs(minXValue)),
-          maxXValue + (0.1 * Math.abs(maxXValue))];
-        return (
-          <ResponsiveXYChart
-            theme={{}}
-            ariaLabel="Required label"
-            yScale={{
-              type: 'band',
-              paddingInner: 0.15,
-              paddingOuter: 0.3,
-            }}
-            xScale={{ type: 'linear',
-              domain: xDomain,
-            }}
-            showYGrid
-          >
-            <PatternLines
-              id="vViolinLines"
-              height={3}
-              width={3}
-              stroke="#ced4da"
-              strokeWidth={1}
-              fill="rgba(0,0,0,0.3)"
-            />
-            <YAxis numTicks={4} />
-            <ViolinPlotSeries
-              data={violinData}
-              label="Test"
-              fill="url(#vViolinLines)"
-              stroke="#22b8cf"
-              strokeWidth={0.5}
-              horizontal
-            />
-            <BoxPlotSeries
-              data={boxPlotData}
-              label="Test"
-              fill={colors.categories[0]}
-              stroke={colors.categories[0]}
-              widthRatio={0.5}
-              fillOpacity={0.2}
-              strokeWidth={1}
-              horizontal
-            />
-            <XAxis />
-          </ResponsiveXYChart>
-        );
-      },
+      example: () => (
+        <HorizontalBoxPlotViolinPlotSeriesExample />
+      ),
     },
     {
       description: 'BoxPlot With ViolinPlot Example',
       components: [BoxPlotSeries, ViolinPlotSeries],
-      example: () => {
-        const boxPlotData = statsData.map(s => s.boxPlot);
-        const violinData = statsData.map(s => ({ x: s.boxPlot.x, binData: s.binData }));
-        const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-        const minYValue = Math.min(...values);
-        const maxYValue = Math.max(...values);
-        const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
-          maxYValue + (0.1 * Math.abs(minYValue))];
-        return (
-          <ResponsiveXYChart
-            theme={{}}
-            ariaLabel="Required label"
-            xScale={{
-              type: 'band',
-              paddingInner: 0.15,
-              paddingOuter: 0.3,
-            }}
-            yScale={{ type: 'linear',
-              domain: yDomain,
-            }}
-            showYGrid
-          >
-            <PatternLines
-              id="hViolinLines"
-              height={3}
-              width={3}
-              stroke="#ced4da"
-              strokeWidth={1}
-              fill="rgba(0,0,0,0.3)"
-              orientation={['horizontal']}
-            />
-            <YAxis numTicks={4} />
-            <ViolinPlotSeries
-              data={violinData}
-              label="Test"
-              fill="url(#hViolinLines)"
-              stroke="#22b8cf"
-              strokeWidth={0.5}
-            />
-            <BoxPlotSeries
-              data={boxPlotData}
-              label="Test"
-              fill={colors.categories[0]}
-              stroke={colors.categories[0]}
-              widthRatio={0.5}
-              fillOpacity={0.2}
-              strokeWidth={1}
-            />
-            <XAxis />
-          </ResponsiveXYChart>
-        );
-      },
+      example: () => (
+        <BoxPlotViolinPlotSeriesExample />
+      ),
     },
     {
       description: 'XAxis, YAxis -- orientation',

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -669,12 +669,12 @@ export default {
             showYGrid
           >
             <PatternLines
-              id='hViolinLines'
+              id="hViolinLines"
               height={3}
               width={3}
-              stroke='#ced4da'
+              stroke="#ced4da"
               strokeWidth={1}
-              fill='rgba(0,0,0,0.3)'
+              fill="rgba(0,0,0,0.3)"
               orientation={['horizontal']}
             />
             <YAxis numTicks={4} />

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -36,7 +36,7 @@ import {
   SimpleBoxPlotSeriesExample,
   SingleBoxPlotSeriesExample,
   HorizontalBoxPlotViolinPlotSeriesExample,
-  BoxPlotViolinPlotSeriesExample,
+  ViolinPlotSeriesExample,
 } from './StatsSeriesExample';
 
 import {
@@ -518,10 +518,10 @@ export default {
       ),
     },
     {
-      description: 'BoxPlot With ViolinPlot Example',
-      components: [BoxPlotSeries, ViolinPlotSeries],
+      description: 'ViolinPlot Example',
+      components: [ViolinPlotSeries],
       example: () => (
-        <BoxPlotViolinPlotSeriesExample />
+        <ViolinPlotSeriesExample />
       ),
     },
     {

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -32,7 +32,7 @@
     "@storybook/addon-options": "^3.1.6",
     "@storybook/react": "3.2.12",
     "@vx/legend": "0.0.140",
-    "@vx/mock-data": "0.0.136",
+    "@vx/mock-data": "0.0.147",
     "@vx/responsive": "0.0.140",
     "@vx/scale": "0.0.140",
     "aphrodite": "^1.2.0",

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -171,6 +171,9 @@ Series | supported x scale type | supported y scale types | data shape | voronoi
 `<GroupedBarSeries/>` | band | linear | `{ x, y }` (colors controlled with groupFills & groupKeys) | no
 `<CirclePackSeries/>` | time, linear | y is computed | `{ x [, size] }` | no
 `<IntervalSeries/>` | time, linear | linear | `{ x0, x1 [, fill, stroke] }` | no
+`<BoxPlotSeries/>` | linear, band | band, linear | `{ x (or y), min, max, median, firstQuartile, thirdQuartile, outliers [, fill, stroke] }` | no
+`<ViolinPlotSeries/>` | linear, band | band, linear | `{ x (or y), binData [, fill, stroke] }` | no
+
 
 \* The y boundaries of the `<AreaSeries/>` may be specified by either
  - defined `y0` and `y1` values or

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -35,6 +35,7 @@
     "@vx/responsive": "0.0.140",
     "@vx/scale": "0.0.140",
     "@vx/shape": "0.0.145",
+    "@vx/stats": "0.0.147",
     "@vx/tooltip": "0.0.140",
     "@vx/voronoi": "0.0.140",
     "d3-array": "^1.2.0",

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -13,6 +13,7 @@ export { default as StackedAreaSeries } from './series/StackedAreaSeries';
 export { default as StackedBarSeries } from './series/StackedBarSeries';
 export { default as BoxPlotSeries } from './series/BoxPlotSeries';
 export { default as ViolinPlotSeries } from './series/ViolinPlotSeries';
+export { computeStats } from '@vx/stats';
 
 export { default as HorizontalReferenceLine } from './annotation/HorizontalReferenceLine';
 export { default as CrossHair } from './chart/CrossHair';

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -11,6 +11,8 @@ export { default as LineSeries } from './series/LineSeries';
 export { default as PointSeries, pointComponentPropTypes } from './series/PointSeries';
 export { default as StackedAreaSeries } from './series/StackedAreaSeries';
 export { default as StackedBarSeries } from './series/StackedBarSeries';
+export { default as BoxPlotSeries } from './series/BoxPlotSeries';
+export { default as ViolinPlotSeries } from './series/ViolinPlotSeries';
 
 export { default as HorizontalReferenceLine } from './annotation/HorizontalReferenceLine';
 export { default as CrossHair } from './chart/CrossHair';

--- a/packages/xy-chart/src/series/BoxPlotSeries.jsx
+++ b/packages/xy-chart/src/series/BoxPlotSeries.jsx
@@ -28,7 +28,7 @@ const propTypes = {
 
 const defaultProps = {
   boxWidth: null,
-  stroke: '#000000',
+  stroke: themeColors.darkGray,
   strokeWidth: 2,
   fill: themeColors.default,
   fillOpacity: 1,
@@ -68,12 +68,12 @@ export default function BoxPlotSeries({
   const offsetValue = horizontal ? y : x;
   const valueScale = horizontal ? xScale : yScale;
   const boxWidth = offsetScale.bandwidth();
-  const actualyWidth = Math.min(MAX_BOX_WIDTH, boxWidth);
-  const offset = (offsetScale.offset || 0) - ((boxWidth - actualyWidth) / 2);
+  const actualWidth = Math.min(MAX_BOX_WIDTH, boxWidth);
+  const offset = (offsetScale.offset || 0) - ((boxWidth - actualWidth) / 2);
   const offsetPropName = horizontal ? 'top' : 'left';
   const offsetProp = d => ({
     [offsetPropName]: (offsetScale(offsetValue(d)) - offset) +
-     (((1 - widthRatio) / 2) * actualyWidth),
+     (((1 - widthRatio) / 2) * actualWidth),
   });
   return (
     <Group>
@@ -87,7 +87,7 @@ export default function BoxPlotSeries({
             firstQuartile={firstQuartile(d)}
             thirdQuartile={thirdQuartile(d)}
             median={median(d)}
-            boxWidth={actualyWidth * widthRatio}
+            boxWidth={actualWidth * widthRatio}
             outliers={outliers(d)}
             fill={d.fill || callOrValue(fill, d, i)}
             stroke={d.stroke || callOrValue(stroke, d, i)}
@@ -101,7 +101,6 @@ export default function BoxPlotSeries({
               }),
               onMouseLeave: onMouseLeave && (() => onMouseLeave),
             }}
-
           />
         )
       ))}

--- a/packages/xy-chart/src/series/BoxPlotSeries.jsx
+++ b/packages/xy-chart/src/series/BoxPlotSeries.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Group } from '@vx/group';
+import { BoxPlot } from '@vx/stats';
+import themeColors from '@data-ui/theme/build/color';
+
+import { callOrValue, isDefined } from '../utils/chartUtils';
+
+import { boxPlotSeriesDataShape } from '../utils/propShapes';
+
+const propTypes = {
+  data: boxPlotSeriesDataShape.isRequired,
+  label: PropTypes.string.isRequired,
+
+  // attributes on data points will override these
+  fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  fillOpacity: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+
+  // likely be injected by the parent chart
+  xScale: PropTypes.func,
+  yScale: PropTypes.func,
+  horizontal: PropTypes.bool,
+  widthRatio: PropTypes.number,
+};
+
+const defaultProps = {
+  boxWidth: null,
+  stroke: '#000000',
+  strokeWidth: 2,
+  fill: themeColors.default,
+  fillOpacity: 1,
+  xScale: null,
+  yScale: null,
+  horizontal: false,
+  widthRatio: 1,
+};
+
+const MAX_BOX_WIDTH = 50;
+const x = d => d.x;
+const y = d => d.y;
+const min = d => d.min;
+const max = d => d.max;
+const median = d => d.median;
+const firstQuartile = d => d.firstQuartile;
+const thirdQuartile = d => d.thirdQuartile;
+const outliers = d => d.outliers || [];
+
+export default function BoxPlotSeries({
+  data,
+  label,
+  fill,
+  stroke,
+  strokeWidth,
+  xScale,
+  yScale,
+  horizontal,
+  widthRatio,
+  fillOpacity,
+}) {
+  if (!xScale || !yScale) return null;
+  const offsetScale = horizontal ? yScale : xScale;
+  const offsetValue = horizontal ? y : x;
+  const valueScale = horizontal ? xScale : yScale;
+  const boxWidth = offsetScale.bandwidth();
+  const actualyWidth = Math.min(MAX_BOX_WIDTH, boxWidth);
+  const offset = (offsetScale.offset || 0) - ((boxWidth - actualyWidth) / 2);
+  const offsetPropName = horizontal ? 'top' : 'left';
+  const offsetProp = d => ({
+    [offsetPropName]: (offsetScale(offsetValue(d)) - offset) +
+     (((1 - widthRatio) / 2) * actualyWidth),
+  });
+  return (
+    <Group key={label}>
+      {data.map((d, i) => (
+        isDefined(min(d)) && (
+          <BoxPlot
+            key={offsetValue(d)}
+            min={min(d)}
+            max={max(d)}
+            {...offsetProp(d)}
+            firstQuartile={firstQuartile(d)}
+            thirdQuartile={thirdQuartile(d)}
+            median={median(d)}
+            boxWidth={actualyWidth * widthRatio}
+            outliers={outliers(d)}
+            fill={d.fill || callOrValue(fill, d, i)}
+            stroke={d.stroke || callOrValue(stroke, d, i)}
+            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+            fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
+            valueScale={valueScale}
+            horizontal={horizontal}
+          />
+        )
+      ))
+    }
+    </Group>
+  );
+}
+
+BoxPlotSeries.propTypes = propTypes;
+BoxPlotSeries.defaultProps = defaultProps;
+BoxPlotSeries.displayName = 'BoxPlotSeries';

--- a/packages/xy-chart/src/series/BoxPlotSeries.jsx
+++ b/packages/xy-chart/src/series/BoxPlotSeries.jsx
@@ -12,6 +12,7 @@ const propTypes = {
   data: boxPlotSeriesDataShape.isRequired,
 
   // attributes on data points will override these
+  disableMouseEvents: PropTypes.bool,
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
@@ -22,6 +23,7 @@ const propTypes = {
   yScale: PropTypes.func,
   horizontal: PropTypes.bool,
   widthRatio: PropTypes.number,
+  onClick: PropTypes.func,
   onMouseMove: PropTypes.func,
   onMouseLeave: PropTypes.func,
 };
@@ -36,8 +38,10 @@ const defaultProps = {
   yScale: null,
   horizontal: false,
   widthRatio: 1,
+  disableMouseEvents: false,
   onMouseMove: undefined,
   onMouseLeave: undefined,
+  onClick: undefined,
 };
 
 const MAX_BOX_WIDTH = 50;
@@ -62,6 +66,8 @@ export default function BoxPlotSeries({
   fillOpacity,
   onMouseMove,
   onMouseLeave,
+  disableMouseEvents,
+  onClick,
 }) {
   if (!xScale || !yScale) return null;
   const offsetScale = horizontal ? yScale : xScale;
@@ -96,10 +102,13 @@ export default function BoxPlotSeries({
             valueScale={valueScale}
             horizontal={horizontal}
             boxProps={{
-              onMouseMove: onMouseMove && (() => (event) => {
+              onMouseMove: disableMouseEvents ? null : onMouseMove && (() => (event) => {
                 onMouseMove({ event, data, datum: d });
               }),
-              onMouseLeave: onMouseLeave && (() => onMouseLeave),
+              onMouseLeave: disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave),
+              onClick: disableMouseEvents ? null : onClick && (() => (event) => {
+                onClick({ event, data, datum: d, index: i });
+              }),
             }}
           />
         )

--- a/packages/xy-chart/src/series/BoxPlotSeries.jsx
+++ b/packages/xy-chart/src/series/BoxPlotSeries.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Group } from '@vx/group';
-import { BoxPlot } from '@vx/stats';
+import Group from '@vx/group/build/Group';
+import BoxPlot from '@vx/stats/build/boxplot/BoxPlot';
 import themeColors from '@data-ui/theme/build/color';
 
 import { callOrValue, isDefined } from '../utils/chartUtils';
@@ -10,7 +10,6 @@ import { boxPlotSeriesDataShape } from '../utils/propShapes';
 
 const propTypes = {
   data: boxPlotSeriesDataShape.isRequired,
-  label: PropTypes.string.isRequired,
 
   // attributes on data points will override these
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -53,7 +52,6 @@ const outliers = d => d.outliers || [];
 
 export default function BoxPlotSeries({
   data,
-  label,
   fill,
   stroke,
   strokeWidth,
@@ -78,7 +76,7 @@ export default function BoxPlotSeries({
      (((1 - widthRatio) / 2) * actualyWidth),
   });
   return (
-    <Group key={label}>
+    <Group>
       {data.map((d, i) => (
         isDefined(min(d)) && (
           <BoxPlot

--- a/packages/xy-chart/src/series/BoxPlotSeries.jsx
+++ b/packages/xy-chart/src/series/BoxPlotSeries.jsx
@@ -93,8 +93,7 @@ export default function BoxPlotSeries({
             horizontal={horizontal}
           />
         )
-      ))
-    }
+      ))}
     </Group>
   );
 }

--- a/packages/xy-chart/src/series/BoxPlotSeries.jsx
+++ b/packages/xy-chart/src/series/BoxPlotSeries.jsx
@@ -23,6 +23,8 @@ const propTypes = {
   yScale: PropTypes.func,
   horizontal: PropTypes.bool,
   widthRatio: PropTypes.number,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
 };
 
 const defaultProps = {
@@ -35,6 +37,8 @@ const defaultProps = {
   yScale: null,
   horizontal: false,
   widthRatio: 1,
+  onMouseMove: undefined,
+  onMouseLeave: undefined,
 };
 
 const MAX_BOX_WIDTH = 50;
@@ -58,6 +62,8 @@ export default function BoxPlotSeries({
   horizontal,
   widthRatio,
   fillOpacity,
+  onMouseMove,
+  onMouseLeave,
 }) {
   if (!xScale || !yScale) return null;
   const offsetScale = horizontal ? yScale : xScale;
@@ -91,6 +97,13 @@ export default function BoxPlotSeries({
             fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
             valueScale={valueScale}
             horizontal={horizontal}
+            boxProps={{
+              onMouseMove: onMouseMove && (() => (event) => {
+                onMouseMove({ event, data, datum: d });
+              }),
+              onMouseLeave: onMouseLeave && (() => onMouseLeave),
+            }}
+
           />
         )
       ))}

--- a/packages/xy-chart/src/series/ViolinPlotSeries.jsx
+++ b/packages/xy-chart/src/series/ViolinPlotSeries.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Group } from '@vx/group';
+import { ViolinPlot } from '@vx/stats';
+import themeColors from '@data-ui/theme/build/color';
+
+import { callOrValue } from '../utils/chartUtils';
+
+const propTypes = {
+  data: PropTypes.object.isRequired,
+  label: PropTypes.string.isRequired,
+
+  // attributes on data points will override these
+  fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+
+  // likely be injected by the parent chart
+  xScale: PropTypes.func,
+  yScale: PropTypes.func,
+  horizontal: PropTypes.bool,
+  widthRatio: PropTypes.number,
+};
+
+const defaultProps = {
+  boxWidth: null,
+  stroke: '#000000',
+  strokeWidth: 2,
+  fill: themeColors.default,
+  xScale: null,
+  yScale: null,
+  horizontal: false,
+  widthRatio: 1,
+};
+
+const MAX_BOX_WIDTH = 50;
+const x = d => d.x;
+const y = d => d.y;
+
+export default function ViolinPlotSeries({
+  data,
+  label,
+  fill,
+  stroke,
+  strokeWidth,
+  xScale,
+  yScale,
+  horizontal,
+  widthRatio,
+}) {
+  if (!xScale || !yScale) return null;
+  const offsetScale = horizontal ? yScale : xScale;
+  const offsetValue = horizontal ? y : x;
+  const valueScale = horizontal ? xScale : yScale;
+  const boxWidth = offsetScale.bandwidth();
+  const actualyWidth = Math.min(MAX_BOX_WIDTH, boxWidth);
+  const offset = (offsetScale.offset || 0) - ((boxWidth - actualyWidth) / 2);
+  const offsetPropName = horizontal ? 'top' : 'left';
+  const offsetProp = d => ({
+    [offsetPropName]: (offsetScale(offsetValue(d)) - offset) +
+     (((1 - widthRatio) / 2) * actualyWidth),
+  });
+  return (
+    <Group key={label}>
+      {data.map((d, i) => (
+        <ViolinPlot
+          key={d.x}
+          {...offsetProp(d)}
+          binData={d.binData}
+          width={actualyWidth * widthRatio}
+          fill={d.fill || callOrValue(fill, d, i)}
+          stroke={d.stroke || callOrValue(stroke, d, i)}
+          strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+          valueScale={valueScale}
+          horizontal={horizontal}
+        />
+      ))
+    }
+    </Group>
+  );
+}
+
+ViolinPlotSeries.propTypes = propTypes;
+ViolinPlotSeries.defaultProps = defaultProps;
+ViolinPlotSeries.displayName = 'ViolinPlotSeries';

--- a/packages/xy-chart/src/series/ViolinPlotSeries.jsx
+++ b/packages/xy-chart/src/series/ViolinPlotSeries.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Group } from '@vx/group';
-import { ViolinPlot } from '@vx/stats';
+import Group from '@vx/group/build/Group';
+import ViolinPlot from '@vx/stats/build/violinplot/ViolinPlot';
 import themeColors from '@data-ui/theme/build/color';
 
 import { callOrValue } from '../utils/chartUtils';
@@ -11,7 +11,6 @@ import { violinPlotSeriesDataShape } from '../utils/propShapes';
 
 const propTypes = {
   data: violinPlotSeriesDataShape.isRequired,
-  label: PropTypes.string.isRequired,
 
   // attributes on data points will override these
   fill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -42,7 +41,6 @@ const y = d => d.y;
 
 export default function ViolinPlotSeries({
   data,
-  label,
   fill,
   stroke,
   strokeWidth,
@@ -64,7 +62,7 @@ export default function ViolinPlotSeries({
      (((1 - widthRatio) / 2) * actualyWidth),
   });
   return (
-    <Group key={label}>
+    <Group>
       {data.map((d, i) => (
         <ViolinPlot
           key={offsetValue(d)}

--- a/packages/xy-chart/src/series/ViolinPlotSeries.jsx
+++ b/packages/xy-chart/src/series/ViolinPlotSeries.jsx
@@ -6,8 +6,11 @@ import themeColors from '@data-ui/theme/build/color';
 
 import { callOrValue } from '../utils/chartUtils';
 
+import { violinPlotSeriesDataShape } from '../utils/propShapes';
+
+
 const propTypes = {
-  data: PropTypes.object.isRequired,
+  data: violinPlotSeriesDataShape.isRequired,
   label: PropTypes.string.isRequired,
 
   // attributes on data points will override these
@@ -64,7 +67,7 @@ export default function ViolinPlotSeries({
     <Group key={label}>
       {data.map((d, i) => (
         <ViolinPlot
-          key={d.x}
+          key={offsetValue(d)}
           {...offsetProp(d)}
           binData={d.binData}
           width={actualyWidth * widthRatio}

--- a/packages/xy-chart/src/series/ViolinPlotSeries.jsx
+++ b/packages/xy-chart/src/series/ViolinPlotSeries.jsx
@@ -26,7 +26,7 @@ const propTypes = {
 
 const defaultProps = {
   boxWidth: null,
-  stroke: '#000000',
+  stroke: themeColors.darkGray,
   strokeWidth: 2,
   fill: themeColors.default,
   xScale: null,
@@ -54,12 +54,12 @@ export default function ViolinPlotSeries({
   const offsetValue = horizontal ? y : x;
   const valueScale = horizontal ? xScale : yScale;
   const boxWidth = offsetScale.bandwidth();
-  const actualyWidth = Math.min(MAX_BOX_WIDTH, boxWidth);
-  const offset = (offsetScale.offset || 0) - ((boxWidth - actualyWidth) / 2);
+  const actualWidth = Math.min(MAX_BOX_WIDTH, boxWidth);
+  const offset = (offsetScale.offset || 0) - ((boxWidth - actualWidth) / 2);
   const offsetPropName = horizontal ? 'top' : 'left';
   const offsetProp = d => ({
     [offsetPropName]: (offsetScale(offsetValue(d)) - offset) +
-     (((1 - widthRatio) / 2) * actualyWidth),
+     (((1 - widthRatio) / 2) * actualWidth),
   });
   return (
     <Group>
@@ -68,7 +68,7 @@ export default function ViolinPlotSeries({
           key={offsetValue(d)}
           {...offsetProp(d)}
           binData={d.binData}
-          width={actualyWidth * widthRatio}
+          width={actualWidth * widthRatio}
           fill={d.fill || callOrValue(fill, d, i)}
           stroke={d.stroke || callOrValue(stroke, d, i)}
           strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}

--- a/packages/xy-chart/src/series/ViolinPlotSeries.jsx
+++ b/packages/xy-chart/src/series/ViolinPlotSeries.jsx
@@ -22,6 +22,10 @@ const propTypes = {
   yScale: PropTypes.func,
   horizontal: PropTypes.bool,
   widthRatio: PropTypes.number,
+  disableMouseEvents: PropTypes.bool,
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onClick: PropTypes.func,
 };
 
 const defaultProps = {
@@ -33,6 +37,10 @@ const defaultProps = {
   yScale: null,
   horizontal: false,
   widthRatio: 1,
+  disableMouseEvents: false,
+  onMouseMove: undefined,
+  onMouseLeave: undefined,
+  onClick: undefined,
 };
 
 const MAX_BOX_WIDTH = 50;
@@ -48,6 +56,10 @@ export default function ViolinPlotSeries({
   yScale,
   horizontal,
   widthRatio,
+  disableMouseEvents,
+  onMouseMove,
+  onMouseLeave,
+  onClick,
 }) {
   if (!xScale || !yScale) return null;
   const offsetScale = horizontal ? yScale : xScale;
@@ -74,6 +86,13 @@ export default function ViolinPlotSeries({
           strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
           valueScale={valueScale}
           horizontal={horizontal}
+          onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
+            onMouseMove({ event, data, datum: d });
+          })}
+          onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
+          onClick={disableMouseEvents ? null : onClick && (() => (event) => {
+            onClick({ event, data, datum: d, index: i });
+          })}
         />
       ))
     }

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -35,6 +35,19 @@ export const boxPlotSeriesDataShape = PropTypes.arrayOf(
   }),
 );
 
+export const violinPlotSeriesDataShape = PropTypes.arrayOf(
+  PropTypes.shape({
+    x: PropTypes.oneOfType([ // data with null x/y are not rendered
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date),
+      PropTypes.object, // eg a moment() instance
+    ]),
+    binData: PropTypes.array.isRequired,
+  }),
+);
+
+
 export const lineSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
     x: PropTypes.oneOfType([ // data with null x/y are not rendered

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -18,6 +18,23 @@ export const scaleShape = PropTypes.shape({
   domain: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
 });
 
+export const boxPlotSeriesDataShape = PropTypes.arrayOf(
+  PropTypes.shape({
+    x: PropTypes.oneOfType([ // data with null x/y are not rendered
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.instanceOf(Date),
+      PropTypes.object, // eg a moment() instance
+    ]),
+    median: PropTypes.number.isRequired,
+    min: PropTypes.number.isRequired,
+    max: PropTypes.number.isRequired,
+    firstQuartile: PropTypes.number.isRequired,
+    thirdQuartile: PropTypes.number.isRequired,
+    outliers: PropTypes.array.isRequired,
+  }),
+);
+
 export const lineSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
     x: PropTypes.oneOfType([ // data with null x/y are not rendered

--- a/packages/xy-chart/test/BoxPlotSeries.test.js
+++ b/packages/xy-chart/test/BoxPlotSeries.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { BoxPlot } from '@vx/stats';
+
+import { XYChart, BoxPlotSeries, computeStats } from '../src/';
+
+describe('<BoxPlotSeries />', () => {
+  const mockProps = {
+    xScale: { type: 'band', paddingInner: 0.15, paddingOuter: 0.3 },
+    yScale: { type: 'linear', includeZero: false },
+    width: 100,
+    height: 100,
+    margin: { top: 10, right: 10, bottom: 10, left: 10 },
+    ariaLabel: 'label',
+  };
+
+  const mockData = [1, 2, 3, 4, 5, 5, 5, 5, 5, 6, 9, 5, 1];
+  const mockStats = computeStats(mockData);
+
+
+  test('it should be defined', () => {
+    expect(BoxPlotSeries).toBeDefined();
+  });
+
+  test('it should not render without x- and y-scales', () => {
+    expect(shallow(<BoxPlotSeries label="" data={[]} />).type()).toBeNull();
+  });
+
+  test('it should render only one boxplot', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <BoxPlotSeries label="l2" data={[{ x: 'label1', ...mockStats.boxPlot }]} />
+      </XYChart>,
+    );
+    expect(wrapper.find(BoxPlotSeries).length).toBe(1);
+    expect(wrapper.find(BoxPlotSeries).first().dive().find(BoxPlot).length).toBe(1);
+  });
+});

--- a/packages/xy-chart/test/ViolinPlotSeries.test.js
+++ b/packages/xy-chart/test/ViolinPlotSeries.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ViolinPlot } from '@vx/stats';
+
+import { XYChart, ViolinPlotSeries, computeStats } from '../src/';
+
+describe('<ViolinPlotSeries />', () => {
+  const mockProps = {
+    xScale: { type: 'band', paddingInner: 0.15, paddingOuter: 0.3 },
+    yScale: { type: 'linear', includeZero: false },
+    width: 100,
+    height: 100,
+    margin: { top: 10, right: 10, bottom: 10, left: 10 },
+    ariaLabel: 'label',
+  };
+
+  const mockData = [1, 2, 3, 4, 5, 5, 5, 5, 5, 6, 9, 5, 1];
+  const mockStats = computeStats(mockData);
+
+
+  test('it should be defined', () => {
+    expect(ViolinPlotSeries).toBeDefined();
+  });
+
+  test('it should not render without x- and y-scales', () => {
+    expect(shallow(<ViolinPlotSeries label="" data={[]} />).type()).toBeNull();
+  });
+
+  test('it should render only one boxplot', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <ViolinPlotSeries label="l2" data={[{ x: 'label1', binData: mockStats.binData }]} />
+      </XYChart>,
+    );
+    expect(wrapper.find(ViolinPlotSeries).length).toBe(1);
+    expect(wrapper.find(ViolinPlotSeries).first().dive().find(ViolinPlot).length).toBe(1);
+  });
+});


### PR DESCRIPTION
This PR
- adds `<ViolinPlotSeries/>` and example
- adds `<BoxPlotSeries/>` and example
- bumps @vx-mock-data to 0.0.147 for stats data generation

TODO
- [x] update README
- [x] test renderTooltips to series
- [x] add testing files for two new series

![boxplot](https://user-images.githubusercontent.com/2024960/32791788-a41677f0-c916-11e7-8378-a1d37fdebb7d.gif)
