### PR TITLE
[shared] Expose tooltip props

### DIFF
--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -21,6 +21,7 @@ import {
   HorizontalReferenceLine,
   PatternLines,
   LinearGradient,
+  WithTooltip,
   theme,
 } from '@data-ui/xy-chart';
 
@@ -66,32 +67,44 @@ export default {
       description: 'BarSeries -- no axes',
       components: [XYChart, BarSeries, LinearGradient, PatternLines],
       example: () => (
-        <ResponsiveXYChart
-          ariaLabel="Required label"
-          xScale={{ type: 'time' }}
-          yScale={{ type: 'linear' }}
+        <WithTooltip
+          renderTooltip={({ datum }) => datum.y}
+          tooltipProps={{
+            offsetTop: 0,
+            style: {
+              backgroundColor: 'pink',
+              opacity: 0.9,
+            },
+          }}
         >
-          <LinearGradient
-            id="gradient"
-            from={colors.default}
-            to={colors.dark}
-          />
-          <PatternLines
-            id="lines"
-            height={8}
-            width={8}
-            stroke={colors.categories[2]}
-            strokeWidth={1}
-            orientation={['horizontal', 'vertical']}
-          />
-          <BarSeries
-            data={timeSeriesData.map((d, i) => ({
-              ...d,
-              fill: `url(#${i === 2 ? 'lines' : 'gradient'})`,
-            }))}
-            fill="url(#aqua_lightaqua_gradient)"
-          />
-        </ResponsiveXYChart>
+          <ResponsiveXYChart
+            ariaLabel="Required label"
+            xScale={{ type: 'time' }}
+            yScale={{ type: 'linear' }}
+            renderTooltip={null}
+          >
+            <LinearGradient
+              id="gradient"
+              from={colors.default}
+              to={colors.dark}
+            />
+            <PatternLines
+              id="lines"
+              height={8}
+              width={8}
+              stroke={colors.categories[2]}
+              strokeWidth={1}
+              orientation={['horizontal', 'vertical']}
+            />
+            <BarSeries
+              data={timeSeriesData.map((d, i) => ({
+                ...d,
+                fill: `url(#${i === 2 ? 'lines' : 'gradient'})`,
+              }))}
+              fill="url(#aqua_lightaqua_gradient)"
+            />
+          </ResponsiveXYChart>
+        </WithTooltip>
       ),
     },
     {

--- a/packages/histogram/README.md
+++ b/packages/histogram/README.md
@@ -172,6 +172,7 @@ className | PropTypes.string | - | Class name to add to the `<div>` container wr
 renderTooltip | PropTypes.func.isRequired | - | Renders the _contents_ of the tooltip, signature of `({ event, data, datum, color }) => node`. If this function returns a `falsy` value, a tooltip will not be rendered.
 styles | PropTypes.object | {} | Styles to add to the `<div>` container wrapper
 TooltipComponent | PropTypes.func or PropTypes.object | `@vx`'s `TooltipWithBounds` | Component (not instance) to use as the tooltip container component. It is passed `top` and `left` numbers for positioning
+tooltipProps | PropTypes.object | - | Props that are passed to `TooltipComponent`
 tooltipTimeout | PropTypes.number | 200 | Timeout in ms for the tooltip to hide upon calling `onMouseLeave`
 
 ### Theme

--- a/packages/histogram/package.json
+++ b/packages/histogram/package.json
@@ -58,7 +58,7 @@
     "@vx/gradient": "0.0.140",
     "@vx/group": "0.0.140",
     "@vx/pattern": "0.0.140",
-    "@vx/responsive": "0.0.140",
+    "@vx/responsive": "0.0.147",
     "@vx/scale": "0.0.140",
     "@vx/shape": "0.0.140",
     "@vx/tooltip": "0.0.140",

--- a/packages/histogram/src/index.js
+++ b/packages/histogram/src/index.js
@@ -9,4 +9,4 @@ export { default as WithTooltip, withTooltipPropTypes } from '@data-ui/shared/bu
 
 export { LinearGradient } from '@vx/gradient';
 export { PatternLines } from '@vx/pattern';
-export { withScreenSize, withParentSize } from '@vx/responsive';
+export { withScreenSize, withParentSize, ParentSize } from '@vx/responsive';

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -52,7 +52,7 @@
     "@vx/event": "0.0.141",
     "@vx/glyph": "0.0.140",
     "@vx/group": "0.0.140",
-    "@vx/responsive": "0.0.140",
+    "@vx/responsive": "0.0.147",
     "@vx/shape": "0.0.142",
     "@vx/tooltip": "0.0.141",
     "airbnb-prop-types": "^2.8.0",

--- a/packages/network/src/index.js
+++ b/packages/network/src/index.js
@@ -1,4 +1,4 @@
-export { withScreenSize, withParentSize } from '@vx/responsive';
+export { withScreenSize, withParentSize, ParentSize } from '@vx/responsive';
 export { nodeShape, linkShape } from './utils/propShapes';
 export { default as Node } from './chart/Node';
 export { default as Nodes } from './chart/Nodes';

--- a/packages/radial-chart/README.md
+++ b/packages/radial-chart/README.md
@@ -79,6 +79,7 @@ className | PropTypes.string | - | Class name to add to the `<div>` container wr
 renderTooltip | PropTypes.func.isRequired | - | Renders the _contents_ of the tooltip, signature of `({ event, data, datum, fraction }) => node`. If this function returns a `falsy` value, a tooltip will not be rendered.
 styles | PropTypes.object | {} | Styles to add to the `<div>` container wrapper
 TooltipComponent | PropTypes.func or PropTypes.object | `@vx`'s `TooltipWithBounds` | Component (not instance) to use as the tooltip container component. It is passed `top` and `left` numbers for positioning
+tooltipProps | PropTypes.object | - | Props that are passed to `TooltipComponent`
 tooltipTimeout | PropTypes.number | 200 | Timeout in ms for the tooltip to hide upon calling `onMouseLeave`
 
 Note that currently this is implemented with `@vx/tooltips`'s `withTooltip` HOC, which adds an _additional_ div wrapper.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -51,7 +51,7 @@
     "@vx/event": "0.0.143",
     "@vx/group": "0.0.143",
     "@vx/shape": "0.0.145",
-    "@vx/tooltip": "0.0.147",
+    "@vx/tooltip": "0.0.148",
     "d3-array": "^1.2.1",
     "prop-types": "^15.5.10"
   },

--- a/packages/shared/src/enhancer/WithTooltip.js
+++ b/packages/shared/src/enhancer/WithTooltip.js
@@ -21,6 +21,7 @@ const propTypes = {
   renderTooltip: PropTypes.func,
   styles: PropTypes.object,
   TooltipComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  tooltipProps: PropTypes.object,
 };
 
 const defaultProps = {
@@ -37,6 +38,7 @@ const defaultProps = {
   renderTooltip: null,
   styles: { display: 'inline-block', position: 'relative' },
   TooltipComponent: TooltipWithBounds,
+  tooltipProps: null,
   tooltipTimeout: 200,
 };
 
@@ -46,6 +48,12 @@ class WithTooltip extends React.PureComponent {
     this.handleMouseMove = this.handleMouseMove.bind(this);
     this.handleMouseLeave = this.handleMouseLeave.bind(this);
     this.tooltipTimeout = null;
+  }
+
+  componentWillUnmount() {
+    if (this.tooltipTimeout) {
+      clearTimeout(this.tooltipTimeout);
+    }
   }
 
   handleMouseMove({ event, datum, ...rest }) {
@@ -83,6 +91,7 @@ class WithTooltip extends React.PureComponent {
       tooltipOpen,
       tooltipLeft,
       tooltipTop,
+      tooltipProps,
       renderTooltip,
       styles,
       TooltipComponent,
@@ -112,6 +121,7 @@ class WithTooltip extends React.PureComponent {
             key={Math.random()}
             top={tooltipTop}
             left={tooltipLeft}
+            {...tooltipProps}
           >
             {tooltipContent}
           </TooltipComponent>}

--- a/packages/shared/test/enhancer/WithTooltip.test.js
+++ b/packages/shared/test/enhancer/WithTooltip.test.js
@@ -148,6 +148,8 @@ describe('<WithTooltip />', () => {
   });
 
   test('it should render the passed TooltipComponent and pass it left and top props', () => {
+    expect.assertions(3);
+
     function Tooltip({ left, top }) { // eslint-disable-line
       expect(left).toEqual(expect.any(Number));
       expect(top).toEqual(expect.any(Number));
@@ -188,5 +190,38 @@ describe('<WithTooltip />', () => {
     const container = wrapper.find(`.${className}`);
     expect(container.length).toBe(1);
     expect(container.prop('style')).toMatchObject(styles);
+  });
+
+  test('it should pass tooltipProps to TooltipComponent', () => {
+    const tooltipProps = {
+      fill: 'pink',
+      minWidth: 200,
+    };
+
+    const propsToCheck = Object.keys(tooltipProps);
+
+    function Tooltip(props) { // eslint-disable-line
+      propsToCheck.forEach((prop) => {
+        expect(props[prop]).toBe(tooltipProps[prop]);
+      });
+      return <div />;
+    }
+
+    let mouseMove;
+    const wrapper = mount(
+      <WithTooltip
+        renderTooltip={() => 'test'}
+        TooltipComponent={Tooltip}
+        tooltipProps={tooltipProps}
+      >
+        {({ onMouseMove }) => {
+          mouseMove = onMouseMove;
+        }}
+      </WithTooltip>,
+    );
+
+    mouseMove({});
+    wrapper.update();
+    expect.assertions(propsToCheck.length);
   });
 });

--- a/packages/sparkline/README.md
+++ b/packages/sparkline/README.md
@@ -165,6 +165,7 @@ className | PropTypes.string | - | Class name to add to the `<div>` container wr
 renderTooltip | PropTypes.func.isRequired | - | Renders the _contents_ of the tooltip, signature of `({ event, data, datum, color }) => node`. If this function returns a `falsy` value, a tooltip will not be rendered.
 styles | PropTypes.object | {} | Styles to add to the `<div>` container wrapper
 TooltipComponent | PropTypes.func or PropTypes.object | `@vx`'s `TooltipWithBounds` | Component (not instance) to use as the tooltip container component. It is passed `top` and `left` numbers for positioning
+tooltipProps | PropTypes.object | - | Props that are passed to `TooltipComponent`
 tooltipTimeout | PropTypes.number | 200 | Timeout in ms for the tooltip to hide upon calling `onMouseLeave`
 
 

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -215,6 +215,7 @@ className | PropTypes.string | - | Class name to add to the `<div>` container wr
 renderTooltip | PropTypes.func.isRequired | - | Renders the _contents_ of the tooltip, signature of `({ event, data, datum, color }) => node`. If this function returns a `falsy` value, a tooltip will not be rendered.
 styles | PropTypes.object | {} | Styles to add to the `<div>` container wrapper
 TooltipComponent | PropTypes.func or PropTypes.object | `@vx`'s `TooltipWithBounds` | Component (not instance) to use as the tooltip container component. It is passed `top` and `left` numbers for positioning
+tooltipProps | PropTypes.object | - | Props that are passed to `TooltipComponent`
 tooltipTimeout | PropTypes.number | 200 | Timeout in ms for the tooltip to hide upon calling `onMouseLeave`
 
 

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -32,7 +32,7 @@
     "@vx/group": "0.0.140",
     "@vx/pattern": "0.0.140",
     "@vx/point": "0.0.136",
-    "@vx/responsive": "0.0.140",
+    "@vx/responsive": "0.0.147",
     "@vx/scale": "0.0.140",
     "@vx/shape": "0.0.145",
     "@vx/stats": "0.0.147",

--- a/packages/xy-chart/src/index.js
+++ b/packages/xy-chart/src/index.js
@@ -21,7 +21,7 @@ export { default as WithTooltip, withTooltipPropTypes } from '@data-ui/shared/bu
 
 export { LinearGradient } from '@vx/gradient';
 export { PatternLines, PatternCircles, PatternWaves, PatternHexagons } from '@vx/pattern';
-export { withScreenSize, withParentSize } from '@vx/responsive';
+export { withScreenSize, withParentSize, ParentSize } from '@vx/responsive';
 
 export { default as withTheme } from './enhancer/withTheme';
 export { chartTheme as theme } from '@data-ui/theme';


### PR DESCRIPTION
🏆  Enhancements
- Allows additional customization Adds `tooltipProps` to the `<WithTooltip />`which will be passed to its `TooltipComponent` (and adds example in demo)
![image](https://user-images.githubusercontent.com/4496521/33091626-7eeefede-ceac-11e7-8c16-6e4055611e5f.png)

- Exposes `@vx/responsive`'s [new observer-based `<ParentSize />` HOC](https://github.com/hshoff/vx/pull/198)

🐛  Bug fix
- bumps `@vx/tooltip` to 0.0.148 for [bounds bug fix](https://github.com/hshoff/vx/pull/204) 

TODO
- [x] update readmes to include `tooltipProps`
- [x] add tests for new functionality
