### PR TITLE
[boxplot] add support for boxplot container events

### DIFF
--- a/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
+++ b/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
@@ -6,7 +6,6 @@ import {
   YAxis,
   BoxPlotSeries,
   ViolinPlotSeries,
-  PatternCircles,
   PatternLines,
   LinearGradient,
   theme,
@@ -28,7 +27,7 @@ function renderViolinPlotTooltip({ datum, color }) {
         <strong style={{ color }}>{label}</strong>
       </div>
       <div>
-        <strong style={{ color }}>Bin count</strong>
+        <strong style={{ color }}>Bin count </strong>
         {binData.length}
       </div>
     </div>
@@ -112,33 +111,36 @@ function MouseEventTargetStyles({ containerEvents, color = colors.categories[7] 
   );
 }
 
-export function SimpleBoxPlotSeriesExample() {
-  const verticalBoxPlotData = statsData.map(s => s.boxPlot);
-  const horizontalBoxPlotData = statsData.map((s) => {
-    const { boxPlot } = s;
-    const { x, ...rest } = boxPlot;
-    return {
-      y: x,
-      ...rest,
-    };
-  });
-  const values = verticalBoxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-  const minValue = Math.min(...values);
-  const maxValue = Math.max(...values);
-  const valueDomain = [
-    minValue - (0.1 * Math.abs(minValue)),
-    maxValue + (0.1 * Math.abs(minValue)),
-  ];
-  const bandScaleConfig = {
-    type: 'band',
-    paddingInner: 0.15,
-    paddingOuter: 0.3,
+// Boxplot example
+const verticalBoxPlotData = statsData.map(s => s.boxPlot);
+const horizontalBoxPlotData = statsData.map((s) => {
+  const { boxPlot } = s;
+  const { x, ...rest } = boxPlot;
+  return {
+    y: x,
+    ...rest,
   };
-  const valueScaleConfig = {
-    type: 'linear',
-    domain: valueDomain,
-  };
+});
+const boxPlotValues = verticalBoxPlotData.reduce((r, e) => (
+  r.push(e.min, e.max, ...e.outliers) && r
+), []);
+const minBoxPlotValue = Math.min(...boxPlotValues);
+const maxBoxPlotValue = Math.max(...boxPlotValues);
+const valueDomain = [
+  minBoxPlotValue - (0.1 * Math.abs(minBoxPlotValue)),
+  maxBoxPlotValue + (0.1 * Math.abs(maxBoxPlotValue)),
+];
+const boxPlotBandScaleConfig = {
+  type: 'band',
+  paddingInner: 0.15,
+  paddingOuter: 0.3,
+};
+const boxPlotValueScaleConfig = {
+  type: 'linear',
+  domain: valueDomain,
+};
 
+export function BoxPlotSeriesExample() {
   return (
     <WithToggle id="toggle_boxplot_horizontal" label="Horizontal" initialChecked>
       {horizontal => (
@@ -146,11 +148,13 @@ export function SimpleBoxPlotSeriesExample() {
           {containerEvents => (
             <WithToggle id="toggle_boxplot_show_container" label="Show mouse targets">
               {showTargets => ([
-                showTargets && <MouseEventTargetStyles containerEvents={containerEvents} />,
+                showTargets &&
+                  <MouseEventTargetStyles key="mouse_styles" containerEvents={containerEvents} />,
                 <ResponsiveXYChart
+                  key="boxplot_chart"
                   ariaLabel="Boxplot example"
-                  xScale={horizontal ? valueScaleConfig : bandScaleConfig}
-                  yScale={horizontal ? bandScaleConfig : valueScaleConfig}
+                  xScale={horizontal ? boxPlotValueScaleConfig : boxPlotBandScaleConfig}
+                  yScale={horizontal ? boxPlotBandScaleConfig : boxPlotValueScaleConfig}
                   renderTooltip={renderBoxPlotTooltip}
                   margin={{ right: 80, left: 16, top: 16 }}
                   showYGrid
@@ -165,7 +169,7 @@ export function SimpleBoxPlotSeriesExample() {
                     id="boxplot_lines"
                     height={4}
                     width={4}
-                    stroke={colors.categories[4]}
+                    stroke={colors.categories[5]}
                     strokeWidth={1}
                     orientation={['diagonal']}
                   />
@@ -188,23 +192,24 @@ export function SimpleBoxPlotSeriesExample() {
   );
 }
 
-export function HorizontalBoxPlotViolinPlotSeriesExample() {
-  const boxPlotData = statsData.map((s) => {
-    const { boxPlot } = s;
-    const { x, ...rest } = boxPlot;
-    return {
-      y: x,
-      ...rest,
-    };
-  });
-  const violinData = statsData.map(s => ({ y: s.boxPlot.x, binData: s.binData }));
-  const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-  const minXValue = Math.min(...values);
-  const maxXValue = Math.max(...values);
-  const xDomain = [
-    minXValue - (0.1 * Math.abs(minXValue)),
-    maxXValue + (0.1 * Math.abs(maxXValue)),
-  ];
+// Violin + boxplot
+const boxPlotData = statsData.map((s) => {
+  const { boxPlot } = s;
+  const { x, ...rest } = boxPlot;
+  return {
+    y: x,
+    ...rest,
+  };
+});
+const violinData = statsData.map(s => ({ y: s.boxPlot.x, binData: s.binData }));
+const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+const minXValue = Math.min(...values);
+const maxXValue = Math.max(...values);
+const xDomain = [
+  minXValue - (0.1 * Math.abs(minXValue)),
+  maxXValue + (0.1 * Math.abs(maxXValue)),
+];
+export function BoxPlotViolinPlotSeriesExample() {
   return (
     <WithToggle id="boxplot_violin_box_toggle" label="Show boxplot" initialChecked>
       {showBoxplot => (
@@ -221,8 +226,8 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
                 type: 'linear',
                 domain: xDomain,
               }}
-              margin={{ right: 70, left: 16 }}
-              renderTooltip={renderBoxPlotTooltip}
+              margin={{ right: 70, left: 16, top: 16 }}
+              renderTooltip={showBoxplot ? renderBoxPlotTooltip : renderViolinPlotTooltip}
               showYGrid
             >
               <PatternLines
@@ -242,7 +247,7 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
                   stroke="#22b8cf"
                   strokeWidth={1}
                   horizontal
-                  disableMouseEvents
+                  disableMouseEvents={showBoxplot}
                 />}
               {showBoxplot &&
                 <BoxPlotSeries
@@ -253,7 +258,6 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
                   fillOpacity={0.2}
                   strokeWidth={1}
                   horizontal
-                  containerEvents={false}
                 />}
               <XAxis />
             </ResponsiveXYChart>
@@ -261,48 +265,5 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
         </WithToggle>
       )}
     </WithToggle>
-  );
-}
-
-export function ViolinPlotSeriesExample() {
-  const boxPlotData = statsData.map(s => s.boxPlot);
-  const violinData = statsData.map(s => ({ x: s.boxPlot.x, binData: s.binData }));
-  const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-  const minYValue = Math.min(...values);
-  const maxYValue = Math.max(...values);
-  const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
-    maxYValue + (0.1 * Math.abs(minYValue))];
-  return (
-    <ResponsiveXYChart
-      ariaLabel="Violin plot"
-      xScale={{
-        type: 'band',
-        paddingInner: 0.15,
-        paddingOuter: 0.3,
-      }}
-      yScale={{
-        type: 'linear',
-        domain: yDomain,
-      }}
-      renderTooltip={renderViolinPlotTooltip}
-      showYGrid
-    >
-      <PatternCircles
-        id="violin_plot_circles"
-        height={3}
-        width={3}
-        radius={2}
-        stroke={colors.categories[3]}
-        fill="#fff"
-      />
-      <YAxis numTicks={4} />
-      <ViolinPlotSeries
-        data={violinData}
-        fill="url(#violin_plot_circles)"
-        stroke={colors.categories[3]}
-        strokeWidth={1}
-      />
-      <XAxis />
-    </ResponsiveXYChart>
   );
 }

--- a/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
+++ b/packages/demo/examples/01-xy-chart/StatsSeriesExample.jsx
@@ -6,12 +6,14 @@ import {
   YAxis,
   BoxPlotSeries,
   ViolinPlotSeries,
+  PatternCircles,
   PatternLines,
   LinearGradient,
   theme,
 } from '@data-ui/xy-chart';
 
 import ResponsiveXYChart from './ResponsiveXYChart';
+import WithToggle from '../shared/WithToggle';
 
 import { statsData } from './data';
 
@@ -26,12 +28,13 @@ function renderViolinPlotTooltip({ datum, color }) {
         <strong style={{ color }}>{label}</strong>
       </div>
       <div>
-        <strong style={{ color }}>Bin Number </strong>
+        <strong style={{ color }}>Bin count</strong>
         {binData.length}
       </div>
     </div>
   );
 }
+
 function renderBoxPlotTooltip({ datum, color }) {
   const {
     x,
@@ -50,76 +53,68 @@ function renderBoxPlotTooltip({ datum, color }) {
       <div>
         <strong style={{ color }}>{label}</strong>
       </div>
-      <div>
-        <strong style={{ color }}>Min </strong>
-        {min && min.toFixed ? min.toFixed(2) : min}
-      </div>
-      <div>
-        <strong style={{ color }}>Max </strong>
-        {max && max.toFixed ? max.toFixed(2) : max}
-      </div>
-      <div>
-        <strong style={{ color }}>Median </strong>
-        {median && median.toFixed ? median.toFixed(2) : median}
-      </div>
-      <div>
-        <strong style={{ color }}>First Quartile </strong>
-        {firstQuartile && firstQuartile.toFixed ? firstQuartile.toFixed(2) : firstQuartile}
-      </div>
-      <div>
-        <strong style={{ color }}>Third Quartile </strong>
-        {thirdQuartile && thirdQuartile.toFixed ? thirdQuartile.toFixed(2) : thirdQuartile}
-      </div>
-      <div>
-        <strong style={{ color }}>Outliers Number </strong>
-        {outliers.length}
-      </div>
+      {min &&
+        <div>
+          <strong style={{ color }}>Min </strong>
+          {min && min.toFixed ? min.toFixed(2) : min}
+        </div>}
+      {max &&
+        <div>
+          <strong style={{ color }}>Max </strong>
+          {max && max.toFixed ? max.toFixed(2) : max}
+        </div>}
+      {median &&
+        <div>
+          <strong style={{ color }}>Median </strong>
+          {median && median.toFixed ? median.toFixed(2) : median}
+        </div>}
+      {firstQuartile &&
+        <div>
+          <strong style={{ color }}>First quartile </strong>
+          {firstQuartile && firstQuartile.toFixed ? firstQuartile.toFixed(2) : firstQuartile}
+        </div>}
+      {thirdQuartile &&
+        <div>
+          <strong style={{ color }}>Third quartile </strong>
+          {thirdQuartile && thirdQuartile.toFixed ? thirdQuartile.toFixed(2) : thirdQuartile}
+        </div>}
+      {outliers && outliers.length > 0 &&
+        <div>
+          <strong style={{ color }}># Outliers </strong>
+          {outliers.length}
+        </div>}
     </div>
   );
 }
 
-export function SimpleBoxPlotSeriesExample() {
-  const boxPlotData = statsData.map(s => s.boxPlot);
-  const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-  const minYValue = Math.min(...values);
-  const maxYValue = Math.max(...values);
-  const yDomain = [minYValue - (0.1 * Math.abs(minYValue)),
-    maxYValue + (0.1 * Math.abs(minYValue))];
+function MouseEventTargetStyles({ containerEvents, color = colors.categories[7] }) {
   return (
-    <ResponsiveXYChart
-      theme={{}}
-      ariaLabel="Required label"
-      xScale={{
-        type: 'band',
-        paddingInner: 0.15,
-        paddingOuter: 0.3,
-      }}
-      yScale={{ type: 'linear',
-        domain: yDomain,
-      }}
-      renderTooltip={renderBoxPlotTooltip}
-      showYGrid
-    >
-      <LinearGradient
-        id="aqua_lightaqua_gradient"
-        from="#99e9f2"
-        to="#c5f6fa"
-      />
-      <YAxis numTicks={4} />
-      <BoxPlotSeries
-        data={boxPlotData}
-        fill="url(#aqua_lightaqua_gradient)"
-        stroke="#22b8cf"
-        strokeWidth={1.5}
-      />
-      <XAxis />
-    </ResponsiveXYChart>
+    <style type="text/css">{`
+      .vx-boxplot rect:not(:last-child),
+      .vx-boxplot circle {
+        stroke: ${containerEvents ? undefined : color};
+        fill: ${color};
+        fill-opacity: ${containerEvents ? 0 : 0.5};
+      }
+
+      .vx-boxplot .vx-boxplot-min,
+      .vx-boxplot .vx-boxplot-median,
+      .vx-boxplot .vx-boxplot-max {
+        stroke: ${containerEvents ? undefined : color};
+        stroke-width: ${containerEvents ? undefined : 3};
+      }
+
+      .vx-boxplot rect:last-child {
+        fill: ${color};
+        fill-opacity: ${containerEvents ? 0.5 : 0};
+      }
+    `}</style>
   );
 }
 
-export function SingleBoxPlotSeriesExample() {
-  const singleStats = [statsData[0]];
-  const boxPlotData = singleStats.map((s) => {
+export function SimpleBoxPlotSeriesExample() {
+  const verticalBoxPlotData = statsData.map(s => s.boxPlot);
+  const horizontalBoxPlotData = statsData.map((s) => {
     const { boxPlot } = s;
     const { x, ...rest } = boxPlot;
     return {
@@ -127,40 +122,69 @@ export function SingleBoxPlotSeriesExample() {
       ...rest,
     };
   });
-  const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
-  const minXValue = Math.min(...values);
-  const maxXValue = Math.max(...values);
-  const xDomain = [minXValue - (0.1 * Math.abs(minXValue)),
-    maxXValue + (0.1 * Math.abs(maxXValue))];
+  const values = verticalBoxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+  const valueDomain = [
+    minValue - (0.1 * Math.abs(minValue)),
+    maxValue + (0.1 * Math.abs(minValue)),
+  ];
+  const bandScaleConfig = {
+    type: 'band',
+    paddingInner: 0.15,
+    paddingOuter: 0.3,
+  };
+  const valueScaleConfig = {
+    type: 'linear',
+    domain: valueDomain,
+  };
+
   return (
-    <ResponsiveXYChart
-      theme={{}}
-      ariaLabel="Required label"
-      yScale={{
-        type: 'band',
-        paddingInner: 0.15,
-        paddingOuter: 0.3,
-      }}
-      xScale={{ type: 'linear',
-        domain: xDomain,
-      }}
-      renderTooltip={renderBoxPlotTooltip}
-      showYGrid
-    >
-      <LinearGradient
-        id="aqua_lightaqua_gradient"
-        from="#99e9f2"
-        to="#c5f6fa"
-      />
-      <BoxPlotSeries
-        data={boxPlotData}
-        fill="url(#aqua_lightaqua_gradient)"
-        stroke="#22b8cf"
-        strokeWidth={1.5}
-        horizontal
-      />
-      <XAxis />
-    </ResponsiveXYChart>
+    <WithToggle id="toggle_boxplot_horizontal" label="Horizontal" initialChecked>
+      {horizontal => (
+        <WithToggle id="toggle_boxplot_container_e" label="Container mouse events" initialChecked>
+          {containerEvents => (
+            <WithToggle id="toggle_boxplot_show_container" label="Show mouse targets">
+              {showTargets => ([
+                showTargets && <MouseEventTargetStyles containerEvents={containerEvents} />,
+                <ResponsiveXYChart
+                  ariaLabel="Boxplot example"
+                  xScale={horizontal ? valueScaleConfig : bandScaleConfig}
+                  yScale={horizontal ? bandScaleConfig : valueScaleConfig}
+                  renderTooltip={renderBoxPlotTooltip}
+                  margin={{ right: 80, left: 16, top: 16 }}
+                  showYGrid
+                >
+                  <LinearGradient
+                    id="simple_box_plot_series_gradient"
+                    from="rgb(77,173,247)"
+                    to="rgba(77,173,247,0.4)"
+                  />
+                  <YAxis numTicks={4} />
+                  <PatternLines
+                    id="boxplot_lines"
+                    height={4}
+                    width={4}
+                    stroke={colors.categories[4]}
+                    strokeWidth={1}
+                    orientation={['diagonal']}
+                  />
+                  <BoxPlotSeries
+                    data={horizontal ? horizontalBoxPlotData : verticalBoxPlotData}
+                    fill="url(#boxplot_lines)"
+                    stroke={colors.categories[3]}
+                    strokeWidth={2}
+                    horizontal={horizontal}
+                    containerEvents={containerEvents}
+                  />
+                  <XAxis numTicks={4} />
+                </ResponsiveXYChart>,
+              ])}
+            </WithToggle>
+          )}
+        </WithToggle>
+      )}
+    </WithToggle>
   );
 }
 
@@ -177,51 +201,66 @@ export function HorizontalBoxPlotViolinPlotSeriesExample() {
   const values = boxPlotData.reduce((r, e) => r.push(e.min, e.max, ...e.outliers) && r, []);
   const minXValue = Math.min(...values);
   const maxXValue = Math.max(...values);
-  const xDomain = [minXValue - (0.1 * Math.abs(minXValue)),
-    maxXValue + (0.1 * Math.abs(maxXValue))];
+  const xDomain = [
+    minXValue - (0.1 * Math.abs(minXValue)),
+    maxXValue + (0.1 * Math.abs(maxXValue)),
+  ];
   return (
-    <ResponsiveXYChart
-      theme={{}}
-      ariaLabel="Required label"
-      yScale={{
-        type: 'band',
-        paddingInner: 0.15,
-        paddingOuter: 0.3,
-      }}
-      xScale={{ type: 'linear',
-        domain: xDomain,
-      }}
-      renderTooltip={renderBoxPlotTooltip}
-      showYGrid
-    >
-      <PatternLines
-        id="vViolinLines"
-        height={3}
-        width={3}
-        stroke="#ced4da"
-        strokeWidth={1}
-        fill="rgba(0,0,0,0.3)"
-      />
-      <YAxis numTicks={4} />
-      <ViolinPlotSeries
-        data={violinData}
-        fill="url(#vViolinLines)"
-        stroke="#22b8cf"
-        strokeWidth={0.5}
-        horizontal
-        disableMouseEvents
-      />
-      <BoxPlotSeries
-        data={boxPlotData}
-        fill={colors.categories[0]}
-        stroke={colors.categories[0]}
-        widthRatio={0.5}
-        fillOpacity={0.2}
-        strokeWidth={1}
-        horizontal
-      />
-      <XAxis />
-    </ResponsiveXYChart>
+    <WithToggle id="boxplot_violin_box_toggle" label="Show boxplot" initialChecked>
+      {showBoxplot => (
+        <WithToggle id="boxplot_violin_violin_toggle" label="Show violin" initialChecked>
+          {showViolin => (
+            <ResponsiveXYChart
+              ariaLabel="Horizontal box plot + violin"
+              yScale={{
+                type: 'band',
+                paddingInner: 0.15,
+                paddingOuter: 0.3,
+              }}
+              xScale={{
+                type: 'linear',
+                domain: xDomain,
+              }}
+              margin={{ right: 70, left: 16 }}
+              renderTooltip={renderBoxPlotTooltip}
+              showYGrid
+            >
+              <PatternLines
+                id="horiz_box_violin_lines"
+                height={4}
+                width={4}
+                stroke="#fff"
+                strokeWidth={1}
+                background="rgba(0,0,100,0.2)"
+                orientation={['diagonal']}
+              />
+              <YAxis numTicks={4} />
+              {showViolin &&
+                <ViolinPlotSeries
+                  data={violinData}
+                  fill="url(#horiz_box_violin_lines)"
+                  stroke="#22b8cf"
+                  strokeWidth={1}
+                  horizontal
+                  disableMouseEvents
+                />}
+              {showBoxplot &&
+                <BoxPlotSeries
+                  data={boxPlotData}
+                  fill={colors.categories[7]}
+                  stroke={colors.categories[7]}
+                  widthRatio={0.5}
+                  fillOpacity={0.2}
+                  strokeWidth={1}
+                  horizontal
+                  containerEvents={false}
+                />}
+              <XAxis />
+            </ResponsiveXYChart>
+          )}
+        </WithToggle>
+      )}
+    </WithToggle>
   );
 }
 
@@ -235,34 +274,33 @@ export function ViolinPlotSeriesExample() {
     maxYValue + (0.1 * Math.abs(minYValue))];
   return (
     <ResponsiveXYChart
-      theme={{}}
-      ariaLabel="Required label"
+      ariaLabel="Violin plot"
       xScale={{
         type: 'band',
         paddingInner: 0.15,
         paddingOuter: 0.3,
       }}
-      yScale={{ type: 'linear',
+      yScale={{
+        type: 'linear',
         domain: yDomain,
       }}
       renderTooltip={renderViolinPlotTooltip}
       showYGrid
     >
-      <PatternLines
-        id="hViolinLines"
+      <PatternCircles
+        id="violin_plot_circles"
         height={3}
         width={3}
-        stroke="#ced4da"
-        strokeWidth={1}
-        fill="rgba(0,0,0,0.3)"
-        orientation={['horizontal']}
+        radius={2}
+        stroke={colors.categories[3]}
+        fill="#fff"
       />
       <YAxis numTicks={4} />
       <ViolinPlotSeries
         data={violinData}
-        fill="url(#hViolinLines)"
-        stroke="#22b8cf"
-        strokeWidth={0.5}
+        fill="url(#violin_plot_circles)"
+        stroke={colors.categories[3]}
+        strokeWidth={1}
       />
       <XAxis />
     </ResponsiveXYChart>

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -33,9 +33,8 @@ import ResponsiveXYChart, { dateFormatter } from './ResponsiveXYChart';
 import StackedAreaExample from './StackedAreaExample';
 import ScatterWithHistogram from './ScatterWithHistograms';
 import {
-  SimpleBoxPlotSeriesExample,
-  HorizontalBoxPlotViolinPlotSeriesExample,
-  ViolinPlotSeriesExample,
+  BoxPlotSeriesExample,
+  BoxPlotViolinPlotSeriesExample,
 } from './StatsSeriesExample';
 
 import {
@@ -468,6 +467,20 @@ export default {
       example: () => <CirclePackWithCallback />,
     },
     {
+      description: 'Box Plot Example',
+      components: [BoxPlotSeries],
+      example: () => (
+        <BoxPlotSeriesExample />
+      ),
+    },
+    {
+      description: 'Horizontal BoxPlot With ViolinPlot Example',
+      components: [BoxPlotSeries, ViolinPlotSeries],
+      example: () => (
+        <BoxPlotViolinPlotSeriesExample />
+      ),
+    },
+    {
       description: 'Mixed series',
       components: [BarSeries, LineSeries, XAxis, YAxis, CrossHair],
       example: () => (
@@ -493,27 +506,6 @@ export default {
           <XAxis label="Time" numTicks={5} />
           <CrossHair />
         </ResponsiveXYChart>
-      ),
-    },
-    {
-      description: 'Box Plot Example',
-      components: [BoxPlotSeries],
-      example: () => (
-        <SimpleBoxPlotSeriesExample />
-      ),
-    },
-    {
-      description: 'Horizontal BoxPlot With ViolinPlot Example',
-      components: [BoxPlotSeries, ViolinPlotSeries],
-      example: () => (
-        <HorizontalBoxPlotViolinPlotSeriesExample />
-      ),
-    },
-    {
-      description: 'ViolinPlot Example',
-      components: [ViolinPlotSeries],
-      example: () => (
-        <ViolinPlotSeriesExample />
       ),
     },
     {

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -34,7 +34,6 @@ import StackedAreaExample from './StackedAreaExample';
 import ScatterWithHistogram from './ScatterWithHistograms';
 import {
   SimpleBoxPlotSeriesExample,
-  SingleBoxPlotSeriesExample,
   HorizontalBoxPlotViolinPlotSeriesExample,
   ViolinPlotSeriesExample,
 } from './StatsSeriesExample';
@@ -501,13 +500,6 @@ export default {
       components: [BoxPlotSeries],
       example: () => (
         <SimpleBoxPlotSeriesExample />
-      ),
-    },
-    {
-      description: 'Single Horizontal Box Plot Example',
-      components: [BoxPlotSeries],
-      example: () => (
-        <SingleBoxPlotSeriesExample />
       ),
     },
     {

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -35,7 +35,7 @@
     "@vx/responsive": "0.0.140",
     "@vx/scale": "0.0.140",
     "@vx/shape": "0.0.145",
-    "@vx/stats": "0.0.147",
+    "@vx/stats": "0.0.148",
     "@vx/tooltip": "0.0.140",
     "@vx/voronoi": "0.0.140",
     "d3-array": "^1.2.0",

--- a/packages/xy-chart/src/series/ViolinPlotSeries.jsx
+++ b/packages/xy-chart/src/series/ViolinPlotSeries.jsx
@@ -87,7 +87,7 @@ export default function ViolinPlotSeries({
           valueScale={valueScale}
           horizontal={horizontal}
           onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
-            onMouseMove({ event, data, datum: d });
+            onMouseMove({ event, data, datum: d, index: i });
           })}
           onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
           onClick={disableMouseEvents ? null : onClick && (() => (event) => {

--- a/packages/xy-chart/test/BoxPlotSeries.test.js
+++ b/packages/xy-chart/test/BoxPlotSeries.test.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { BoxPlot } from '@vx/stats';
+import BoxPlot from '@vx/stats/build/boxplot/BoxPlot';
 
 import { XYChart, BoxPlotSeries, computeStats } from '../src/';
 
 describe('<BoxPlotSeries />', () => {
+  const mockData = [1, 2, 3, 4, 5, 5, 5, 5, 5, 6, 9, 5, 1];
+  const mockStats = computeStats(mockData);
   const mockProps = {
     xScale: { type: 'band', paddingInner: 0.15, paddingOuter: 0.3 },
     yScale: { type: 'linear', includeZero: false },
@@ -13,26 +15,133 @@ describe('<BoxPlotSeries />', () => {
     margin: { top: 10, right: 10, bottom: 10, left: 10 },
     ariaLabel: 'label',
   };
-
-  const mockData = [1, 2, 3, 4, 5, 5, 5, 5, 5, 6, 9, 5, 1];
-  const mockStats = computeStats(mockData);
-
+  const boxplotProps = {
+    data: [{ x: 'label1', ...mockStats.boxPlot }],
+  };
 
   test('it should be defined', () => {
     expect(BoxPlotSeries).toBeDefined();
   });
 
   test('it should not render without x- and y-scales', () => {
-    expect(shallow(<BoxPlotSeries label="" data={[]} />).type()).toBeNull();
+    expect(shallow(<BoxPlotSeries data={[]} />).type()).toBeNull();
   });
 
-  test('it should render only one boxplot', () => {
+  test('it should render one boxplot per datum', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <BoxPlotSeries label="l2" data={[{ x: 'label1', ...mockStats.boxPlot }]} />
+        <BoxPlotSeries {...boxplotProps} />
       </XYChart>,
     );
     expect(wrapper.find(BoxPlotSeries).length).toBe(1);
     expect(wrapper.find(BoxPlotSeries).first().dive().find(BoxPlot).length).toBe(1);
+  });
+
+  test('it should pass containerProps, outlierProps, boxProps, minProps, maxProps, and medianProps to BoxPlot', () => {
+    const extraBoxplotProps = {
+      containerProps: {
+        fill: 'pink',
+      },
+      outlierProps: {
+        stroke: 'violet',
+      },
+      boxProps: {
+        pointerEvents: 'none',
+      },
+      minProps: {
+        strokeWidth: 0.5,
+      },
+      maxProps: {
+        strokeWidth: 4.5,
+      },
+      medianProps: {
+        strokeWidth: 5.5,
+      },
+    };
+    const wrapper = shallow(
+      <XYChart {...mockProps} >
+        <BoxPlotSeries
+          {...boxplotProps}
+          {...extraBoxplotProps}
+        />
+      </XYChart>,
+    );
+
+    const boxplot = wrapper.find(BoxPlotSeries).first().dive().find(BoxPlot);
+
+    const propsToCheck = Object.keys(extraBoxplotProps);
+    const assertions = propsToCheck.length;
+
+    expect.assertions(assertions);
+    propsToCheck.forEach((prop) => {
+      expect(boxplot.prop(prop)).toMatchObject(extraBoxplotProps[prop]);
+    });
+  });
+
+  test('it should call onMouseMove({ datum, data, event, index }), onMouseLeave(), and onClick({ datum, data, event, index }) on trigger when disableMouseEvents is falsy', () => {
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    let wrapper = shallow(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <BoxPlotSeries {...boxplotProps} />
+      </XYChart>,
+    );
+
+    let boxplot = wrapper.find(BoxPlotSeries).dive()
+      .find(BoxPlot).dive()
+      .find('rect')
+      .last();
+
+    boxplot.simulate('mousemove', {});
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+    let args = onMouseMove.mock.calls[0][0];
+    expect(args.data).toBe(boxplotProps.data);
+    expect(args.datum).toBe(boxplotProps.data[0]);
+    expect(args.event).toBeDefined();
+    expect(args.index).toBe(0);
+
+    boxplot.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    boxplot.simulate('click', {});
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toBe(boxplotProps.data);
+    expect(args.datum).toBe(boxplotProps.data[0]);
+    expect(args.event).toBeDefined();
+    expect(args.index).toBe(0);
+
+    // disable mouse events
+    wrapper = shallow(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <BoxPlotSeries {...boxplotProps} disableMouseEvents />
+      </XYChart>,
+    );
+
+    boxplot = wrapper.find(BoxPlotSeries).dive()
+      .find(BoxPlot).dive()
+      .find('rect')
+      .last();
+
+    boxplot.simulate('mousemove', {});
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+
+    boxplot.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    boxplot.simulate('click', {});
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xy-chart/test/ViolinPlotSeries.test.js
+++ b/packages/xy-chart/test/ViolinPlotSeries.test.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { ViolinPlot } from '@vx/stats';
+import ViolinPlot from '@vx/stats/build/violinplot/ViolinPlot';
 
 import { XYChart, ViolinPlotSeries, computeStats } from '../src/';
 
 describe('<ViolinPlotSeries />', () => {
+  const mockData = [1, 2, 3, 4, 5, 5, 5, 5, 5, 6, 9, 5, 1];
+  const mockStats = computeStats(mockData);
   const mockProps = {
     xScale: { type: 'band', paddingInner: 0.15, paddingOuter: 0.3 },
     yScale: { type: 'linear', includeZero: false },
@@ -13,26 +15,92 @@ describe('<ViolinPlotSeries />', () => {
     margin: { top: 10, right: 10, bottom: 10, left: 10 },
     ariaLabel: 'label',
   };
-
-  const mockData = [1, 2, 3, 4, 5, 5, 5, 5, 5, 6, 9, 5, 1];
-  const mockStats = computeStats(mockData);
-
+  const violinProps = {
+    data: [{ x: 'label1', binData: mockStats.binData }],
+  };
 
   test('it should be defined', () => {
     expect(ViolinPlotSeries).toBeDefined();
   });
 
   test('it should not render without x- and y-scales', () => {
-    expect(shallow(<ViolinPlotSeries label="" data={[]} />).type()).toBeNull();
+    expect(shallow(<ViolinPlotSeries data={[]} />).type()).toBeNull();
   });
 
-  test('it should render only one boxplot', () => {
+  test('it should render one violin per datum', () => {
     const wrapper = shallow(
       <XYChart {...mockProps} >
-        <ViolinPlotSeries label="l2" data={[{ x: 'label1', binData: mockStats.binData }]} />
+        <ViolinPlotSeries {...violinProps} />
       </XYChart>,
     );
     expect(wrapper.find(ViolinPlotSeries).length).toBe(1);
     expect(wrapper.find(ViolinPlotSeries).first().dive().find(ViolinPlot).length).toBe(1);
+  });
+
+  test('it should call onMouseMove({ datum, data, event, index }), onMouseLeave(), and onClick({ datum, data, event, index }) on trigger when disableMouseEvents is falsy', () => {
+    const onMouseMove = jest.fn();
+    const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
+
+    let wrapper = shallow(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <ViolinPlotSeries {...violinProps} />
+      </XYChart>,
+    );
+
+    let violin = wrapper.find(ViolinPlotSeries).dive()
+      .find(ViolinPlot).dive()
+      .find('path')
+      .first();
+
+    violin.simulate('mousemove', {});
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+    let args = onMouseMove.mock.calls[0][0];
+    expect(args.data).toBe(violinProps.data);
+    expect(args.datum).toBe(violinProps.data[0]);
+    expect(args.event).toBeDefined();
+    expect(args.index).toBe(0);
+
+    violin.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    violin.simulate('click', {});
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toBe(violinProps.data);
+    expect(args.datum).toBe(violinProps.data[0]);
+    expect(args.event).toBeDefined();
+    expect(args.index).toBe(0);
+
+    // disable mouse events
+    wrapper = shallow(
+      <XYChart
+        {...mockProps}
+        onMouseMove={onMouseMove}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        <ViolinPlotSeries {...violinProps} disableMouseEvents />
+      </XYChart>,
+    );
+
+    violin = wrapper.find(ViolinPlotSeries).dive()
+      .find(ViolinPlot).dive()
+      .find('path')
+      .first();
+
+    violin.simulate('mousemove', {});
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+
+    violin.simulate('mouseleave');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    violin.simulate('click', {});
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This PR adds the following

🏆  Enhancements
- Exposes the following props on `<BoxplotSeries />` to enable more customization: `containerProps`, `boxProps`, `outlierProps`, `minProps`, `maxProps`, `medianProps`
- Adds the ability to set mouse events on the boxplot container or on its component parts (whiskers, etc)
- Consolidates some of examples for [demo][boxplot]:
![boxplot-violin-examples](https://user-images.githubusercontent.com/4496521/33092449-06d9766a-ceaf-11e7-8b29-a5c6af81c669.gif)


TODO
- [x] bump `@vx/stats` upon merging of [boxplot container bugfix](https://github.com/hshoff/vx/pull/204) 🐛 
- [x] add tests for new functionality
