### PR TITLE
[xy-chart] consider deltaX in findClosestDatums, fix tickLabelProps bug in <*Axis />

### DIFF
--- a/packages/demo/examples/01-xy-chart/LineSeriesExample.jsx
+++ b/packages/demo/examples/01-xy-chart/LineSeriesExample.jsx
@@ -91,7 +91,6 @@ class LineSeriesExample extends React.PureComponent {
 
   eventTriggerRefs(triggers) {
     this.triggers = triggers;
-    this.triggerTooltip();
   }
 
   triggerTooltip() {

--- a/packages/xy-chart/src/axis/XAxis.jsx
+++ b/packages/xy-chart/src/axis/XAxis.jsx
@@ -59,9 +59,11 @@ export default class XAxis extends React.PureComponent {
     if (!scale || !innerHeight) return null;
     const Axis = orientation === 'bottom' ? AxisBottom : AxisTop;
 
-    const tickLabelProps = passedTickLabelProps ||
-      (tickStyles.label && tickStyles.label[orientation])
+    let tickLabelProps = passedTickLabelProps;
+    if (!tickLabelProps) {
+      tickLabelProps = (tickStyles.label && tickStyles.label[orientation])
         ? () => tickStyles.label[orientation] : undefined;
+    }
 
     return (
       <Axis

--- a/packages/xy-chart/src/axis/YAxis.jsx
+++ b/packages/xy-chart/src/axis/YAxis.jsx
@@ -63,9 +63,11 @@ export default class YAxis extends React.PureComponent {
 
     const Axis = orientation === 'left' ? AxisLeft : AxisRight;
 
-    const tickLabelProps = passedTickLabelProps ||
-      (tickStyles.label && tickStyles.label[orientation])
+    let tickLabelProps = passedTickLabelProps;
+    if (!tickLabelProps) {
+      tickLabelProps = (tickStyles.label && tickStyles.label[orientation])
         ? () => tickStyles.label[orientation] : undefined;
+    }
 
     return (
       <Axis

--- a/packages/xy-chart/test/axis/XAxis.test.js
+++ b/packages/xy-chart/test/axis/XAxis.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import AxisBottom from '@vx/axis/build/axis/AxisBottom';
 import AxisTop from '@vx/axis/build/axis/AxisTop';
+import scaleLinear from '@vx/scale/build/scales/linear';
 import { XYChart, XAxis, LineSeries } from '../../src/';
 
 describe('<XAxis />', () => {
@@ -82,5 +83,71 @@ describe('<XAxis />', () => {
     );
     const tick = wrapper.render().find('.vx-axis-tick').first();
     expect(tick.find('text').text()).toBe(tickFormat());
+  });
+
+  test('tickLabelProps should be passed tick value and indexif passed, and tickStyles.label[orientation] if not', () => {
+    const props = {
+      scale: scaleLinear({ range: [0, 100], domain: [0, 100] }),
+      innerHeight: 100,
+    };
+
+    const wrapper = shallow(
+      <XAxis
+        {...props}
+        tickLabelProps={(val, i) => ({
+          fill: i === 0 ? 'pink' : 'blue',
+        })}
+      />,
+    );
+
+    const label0 = wrapper.find(AxisBottom)
+      .dive() // Axis
+      .dive() // Group
+      .find('.vx-axis-tick')
+      .first()
+      .dive()
+      .find('text');
+
+    const label1 = wrapper.find(AxisBottom)
+      .dive() // Axis
+      .dive() // Group
+      .find('.vx-axis-tick')
+      .last()
+      .dive()
+      .find('text');
+
+    expect(label0.prop('fill')).toBe('pink');
+    expect(label1.prop('fill')).toBe('blue');
+  });
+
+  test.only('tickStyles.label[orientation] should be used if tickLabelProps is not passed', () => {
+    const props = {
+      scale: scaleLinear({ range: [0, 100], domain: [0, 100] }),
+      innerHeight: 100,
+    };
+
+    const wrapper = shallow(
+      <XAxis
+        {...props}
+        tickLabelProps={null}
+        tickStyles={{
+          label: {
+            bottom: {
+              fill: 'skyblue',
+            },
+          },
+        }}
+      />,
+    );
+
+    const label0 = wrapper.find(AxisBottom)
+      .dive() // Axis
+      .dive() // Group
+      .find('.vx-axis-tick')
+      .first()
+      .dive()
+      .find('text');
+
+    expect(label0.prop('fill')).toBe('skyblue');
   });
 });

--- a/packages/xy-chart/test/axis/YAxis.test.js
+++ b/packages/xy-chart/test/axis/YAxis.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import AxisLeft from '@vx/axis/build/axis/AxisLeft';
 import AxisRight from '@vx/axis/build/axis/AxisRight';
+import scaleLinear from '@vx/scale/build/scales/linear';
 import { XYChart, YAxis, LineSeries } from '../../src/';
 
 describe('<YAxis />', () => {
@@ -82,5 +83,71 @@ describe('<YAxis />', () => {
     );
     const tick = wrapper.render().find('.vx-axis-tick').first();
     expect(tick.find('text').text()).toBe(tickFormat());
+  });
+
+  test('tickLabelProps should be passed tick value and indexif passed, and tickStyles.label[orientation] if not', () => {
+    const props = {
+      scale: scaleLinear({ range: [100, 0], domain: [0, 100] }),
+      innerWidth: 100,
+    };
+
+    const wrapper = shallow(
+      <YAxis
+        {...props}
+        tickLabelProps={(val, i) => ({
+          fill: i === 0 ? 'pink' : 'blue',
+        })}
+      />,
+    );
+
+    const label0 = wrapper.find(AxisRight)
+      .dive() // Axis
+      .dive() // Group
+      .find('.vx-axis-tick')
+      .first()
+      .dive()
+      .find('text');
+
+    const label1 = wrapper.find(AxisRight)
+      .dive() // Axis
+      .dive() // Group
+      .find('.vx-axis-tick')
+      .last()
+      .dive()
+      .find('text');
+
+    expect(label0.prop('fill')).toBe('pink');
+    expect(label1.prop('fill')).toBe('blue');
+  });
+
+  test('tickStyles.label[orientation] should be used if tickLabelProps is not passed', () => {
+    const props = {
+      scale: scaleLinear({ range: [100, 0], domain: [0, 100] }),
+      innerWidth: 100,
+    };
+
+    const wrapper = shallow(
+      <YAxis
+        {...props}
+        tickLabelProps={null}
+        tickStyles={{
+          label: {
+            right: {
+              fill: 'skyblue',
+            },
+          },
+        }}
+      />,
+    );
+
+    const label0 = wrapper.find(AxisRight)
+      .dive() // Axis
+      .dive() // Group
+      .find('.vx-axis-tick')
+      .first()
+      .dive()
+      .find('text');
+
+    expect(label0.prop('fill')).toBe('skyblue');
   });
 });


### PR DESCRIPTION
This PR does the following 

🐛 Bug Fix
- Fixes a bug where `tickLabelProps` is not used when passed in either `<XAxis />` or `<YAxis />`. This prop enables per-tick styles so is importanté!

- Improves the logic for finding closest `datum`s across series when `eventTrigger=container` by considering `deltaX` from `mouseX` in addition to `deltaY` from `mouseY`. If `deltaX` is not considered, the "closest" `datum` in the `y` dimension might belong to a series whose nearest `x` value is quite far from `mouseX` (if the other data points are `null`, for instance):

**Before**
<img src="https://user-images.githubusercontent.com/4496521/33747739-a1725454-db79-11e7-8352-2df7ad6f98bf.gif" width="400" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/33747775-c1f44e9e-db79-11e7-85af-91aa70debb73.gif" width="400" />
