### PR TITLE
🐛  added `innerHeight`  to props destructure

### DIFF
--- a/packages/histogram/src/axis/YAxis.jsx
+++ b/packages/histogram/src/axis/YAxis.jsx
@@ -50,6 +50,7 @@ export default function YAxis({
   tickLabelProps: passedTickLabelProps,
   tickStyles,
   tickValues,
+  innerHeight
 }) {
   if (!scale || !innerHeight) return null;
   const Axis = orientation === 'left' ? AxisLeft : AxisRight;


### PR DESCRIPTION
`innerHeight` was being referenced in the guard at the top of the component, but since it wasn't destructured from props in the func param, it was undefined.

🐛 Bug Fix

