### PR TITLE
[accessibility] add FocusBlurHandler, add to most xy-chart series

### DIFF
--- a/packages/shared/src/components/FocusBlurHandler.jsx
+++ b/packages/shared/src/components/FocusBlurHandler.jsx
@@ -34,7 +34,8 @@ export default class FocusBlurHandler extends React.PureComponent {
 
     return (
       <a // eslint-disable-line jsx-a11y/no-static-element-interactions
-        xlinkHref="#"
+        xlinkHref={(onBlur || onFocus) && '#'}
+        role="button"
         onBlur={onBlur}
         onFocus={onFocus}
         onClick={this.handleOnClick}

--- a/packages/shared/src/components/FocusBlurHandler.jsx
+++ b/packages/shared/src/components/FocusBlurHandler.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  children: PropTypes.node,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+};
+
+const defaultProps = {
+  children: null,
+  onFocus: null,
+  onBlur: null,
+};
+
+// This component wraps its children in an <a /> tag which is the most reliable way to
+// support tabIndex focusing accross browsers for SVG < v2.0
+export default class FocusBlurHandler extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.handleOnClick = this.handleOnClick.bind(this);
+  }
+
+  handleOnClick(e) { // eslint-disable-line class-methods-use-this
+    e.preventDefault();
+  }
+
+  render() {
+    const {
+      children,
+      onFocus,
+      onBlur,
+    } = this.props;
+
+    return (
+      <a // eslint-disable-line jsx-a11y/no-static-element-interactions
+        xlinkHref="#"
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onClick={this.handleOnClick}
+      >
+        {children}
+      </a>
+    );
+  }
+}
+
+FocusBlurHandler.propTypes = propTypes;
+FocusBlurHandler.defaultProps = defaultProps;
+FocusBlurHandler.displayName = 'FocusBlurHandler';

--- a/packages/shared/src/index.js
+++ b/packages/shared/src/index.js
@@ -1,2 +1,3 @@
+export { default as FocusBlurHandler } from './components/FocusBlurHandler';
 export { default as WithTooltip, withTooltipPropTypes } from './enhancer/WithTooltip';
 export { default as Tooltip } from '@vx/tooltip/build/tooltips/Tooltip';

--- a/packages/shared/test/components/FocusBlurHandler.test.jsx
+++ b/packages/shared/test/components/FocusBlurHandler.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { FocusBlurHandler } from '../../src';
+
+describe('<FocusBlurHandler />', () => {
+  test('it should be defined', () => {
+    expect(FocusBlurHandler).toBeDefined();
+  });
+
+  test('it should render an <a /> tag', () => {
+    const wrapper = shallow(<FocusBlurHandler />);
+    expect(wrapper.find('a')).toHaveLength(1);
+  });
+
+  test('it should render its children', () => {
+    const wrapper = shallow(<svg><FocusBlurHandler><circle id="test" /></FocusBlurHandler></svg>);
+    expect(wrapper.find(FocusBlurHandler).dive().find('circle#test')).toHaveLength(1);
+  });
+
+  test('it should invoke onFocus when focused', () => {
+    const onFocus = jest.fn();
+    const wrapper = shallow(<FocusBlurHandler onFocus={onFocus} />);
+
+    wrapper.find('a').simulate('focus');
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke onBlur when blurred', () => {
+    const onBlur = jest.fn();
+    const wrapper = shallow(<FocusBlurHandler onBlur={onBlur} />);
+
+    wrapper.find('a').simulate('blur');
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/test/enhancer/WithTooltip.test.js
+++ b/packages/shared/test/enhancer/WithTooltip.test.js
@@ -87,7 +87,7 @@ describe('<WithTooltip />', () => {
     expect(wrapper.find('#test').length).toBe(1);
   });
 
-  test.only('it should use the provided `coords` if passed to onMouseMove', () => {
+  test('it should use the provided `coords` if passed to onMouseMove', () => {
     let mouseMove;
     const wrapper = mount(
       <WithTooltip

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -123,19 +123,19 @@ tickValues | PropTypes.arrayOf( PropTypes.oneOfType([ PropTypes.number, PropType
 Several types of series types are exported by the package, and can be used in combination. See the storybook source for more proptables for your series of interest. Here is an overview of scale support and data shapes:
 
 
-Series | supported x scale type | supported y scale types | data shape | supported `eventTrigger`s | shared tooltip compatible
+Series | supported x scale type | supported y scale types | data shape | supported `eventTrigger`s | shared tooltip compatible | supports onFocus + onBlur
 ------------ | ------------- | ------- | ---- | ---- | ----
-`<AreaSeries />` | `time`, `linear` | `linear` | `{ x, y [, y0, y1, fill, stroke] }`* | `series`, `container`, `voronoi`* | yes
-`<BarSeries />` | `time`, `linear`, `band` | `linear` | `{ x, y [, fill, stroke] }` | `series`, `container` | yes
-`<LineSeries />` | `time`, `linear` | `linear` | `{ x, y [, stroke] }` | `series`, `container`, `voronoi` | yes
-`<PointSeries />` | `time`, `linear` | `time`, `linear` | `{ x, y [size, fill, stroke, label] }` | `series`, `container` (not best for dense data) `voronoi` | yes
-`<StackedAreaSeries />` | `time`, `linear` | `linear` | `{ x, y [, [stackKey(s)]] }`* | `series` | data for all stack keys should be in passed `datum`
-`<StackedBarSeries />` | `band` | `linear` | `{ x, y }` (colors controlled with stackFills & stackKeys) | `series` | data for all stack keys should be in passed `datum`
-`<GroupedBarSeries />` | `band` | `linear` | `{ x, y }` (colors controlled with groupFills & groupKeys) | `series` | data for all group keys should be in passed `datum`
-`<CirclePackSeries />` | `time`, `linear` | y is computed | `{ x [, size] }` | `series` | no
-`<IntervalSeries />` | `time`, `linear` | `linear` | `{ x0, x1 [, fill, stroke] }` | `series` | no
-`<BoxPlotSeries />` | `linear`, `band` | `band`, `linear` | `{ x (or y), min, max, median, firstQuartile, thirdQuartile, outliers [, fill, stroke] }` | `series` | no
-`<ViolinPlotSeries />` | `linear`, `band` | `band`, `linear` | `{ x (or y), binData [, fill, stroke] }` | `series` | no
+`<AreaSeries />` | `time`, `linear` | `linear` | `{ x, y [, y0, y1, fill, stroke] }`* | `series`, `container`, `voronoi`* | yes | yes
+`<BarSeries />` | `time`, `linear`, `band` | `linear` | `{ x, y [, fill, stroke] }` | `series`, `container` | yes | yes
+`<LineSeries />` | `time`, `linear` | `linear` | `{ x, y [, stroke] }` | `series`, `container`, `voronoi` | yes | yes
+`<PointSeries />` | `time`, `linear` | `time`, `linear` | `{ x, y [size, fill, stroke, label] }` | `series`, `container` (not best for dense data) `voronoi` | yes | yes (pointComponent must implement)
+`<StackedAreaSeries />` | `time`, `linear` | `linear` | `{ x, y [, [stackKey(s)]] }`* | `series` | data for all stack keys should be in passed `datum` | no
+`<StackedBarSeries />` | `band` | `linear` | `{ x, y }` (colors controlled with stackFills & stackKeys) | `series` | data for all stack keys should be in passed `datum` | no
+`<GroupedBarSeries />` | `band` | `linear` | `{ x, y }` (colors controlled with groupFills & groupKeys) | `series` | data for all group keys should be in passed `datum` | no
+`<CirclePackSeries />` | `time`, `linear` | y is computed | `{ x [, size] }` | `series` | no | yes (pointComponent must implement)
+`<IntervalSeries />` | `time`, `linear` | `linear` | `{ x0, x1 [, fill, stroke] }` | `series` | no | yes
+`<BoxPlotSeries />` | `linear`, `band` | `band`, `linear` | `{ x (or y), min, max, median, firstQuartile, thirdQuartile, outliers [, fill, stroke] }` | `series` | no | yes
+`<ViolinPlotSeries />` | `linear`, `band` | `band`, `linear` | `{ x (or y), binData [, fill, stroke] }` | `series` | no | yes
 
 
 \* The y boundaries of the `<AreaSeries/>` may be specified by either
@@ -179,6 +179,9 @@ tooltipTimeout | PropTypes.number | 200 | Timeout in ms for the tooltip to hide 
 
 
 Note that to correctly position a tooltip, the `<WithTooltip />` `onMouseMove` function minimally requires an `event` or `coords` object of the form `{ x: Number, y: Number }`. If `coords` is specified it takes precedent over any position computed from the event. See function signatures below for more.
+
+##### Accessibility
+Note that unless `disableMouseEvents=true`, most series currently invoke `onMouseMove` and `onMouseLeave` when `focus`ed and `blur`ed, respectively, so that tooltips are accessible for keyboard-only users. Support for these events is reflected in the `SeriesComponent` table above.
 
 ##### `<CrossHair />`
 The `<CrossHair />` component may be used in combination with tooltips for additional visual feedback (see the storybook for many examples!). Simply pass the component as a child of `<XYChart />` and it will automatically position itself upon tooltip trigger. Compared to a tooltip, this component snaps to actual data points for improved precision. It accepts the following props:

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -1,15 +1,15 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-
 import Area from '@vx/shape/build/shapes/Area';
+import color from '@data-ui/theme/build/color';
+import FocusBlurHandler from '@data-ui/shared/build/components/FocusBlurHandler';
 import Group from '@vx/group/build/Group';
 import LinePath from '@vx/shape/build/shapes/LinePath';
-import color from '@data-ui/theme/build/color';
+import PropTypes from 'prop-types';
+import React from 'react';
 
-import interpolatorLookup from '../utils/interpolatorLookup';
+import { areaSeriesDataShape, interpolationShape } from '../utils/propShapes';
 import { callOrValue, isDefined } from '../utils/chartUtils';
 import findClosestDatum from '../utils/findClosestDatum';
-import { areaSeriesDataShape, interpolationShape } from '../utils/propShapes';
+import interpolatorLookup from '../utils/interpolatorLookup';
 import sharedSeriesProps from '../utils/sharedSeriesProps';
 
 const propTypes = {
@@ -127,8 +127,15 @@ export default class AreaSeries extends React.PureComponent {
             strokeDasharray={strokeDasharrayValue}
             strokeLinecap={strokeLinecap}
             curve={curve}
-            glyph={null}
             defined={defined}
+            glyph={(d, i) => (
+              <FocusBlurHandler
+                key={`areapoint-${i}`}
+                onBlur={disableMouseEvents ? null : onMouseLeave}
+                onFocus={disableMouseEvents ? null : (event) => {
+                  onMouseMove({ event, data, datum: d, color: strokeValue, index: i });
+                }}
+              />)}
           />}
       </Group>
     );

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -115,28 +115,28 @@ export default class AreaSeries extends React.PureComponent {
             glyph={null}
             defined={defined}
           />}
-        {strokeWidthValue > 0 &&
-          <LinePath
-            data={data}
-            x={x}
-            y={y1}
-            xScale={xScale}
-            yScale={yScale}
-            stroke={strokeValue}
-            strokeWidth={strokeWidthValue}
-            strokeDasharray={strokeDasharrayValue}
-            strokeLinecap={strokeLinecap}
-            curve={curve}
-            defined={defined}
-            glyph={(d, i) => (
-              <FocusBlurHandler
-                key={`areapoint-${i}`}
-                onBlur={disableMouseEvents ? null : onMouseLeave}
-                onFocus={disableMouseEvents ? null : (event) => {
-                  onMouseMove({ event, data, datum: d, color: strokeValue, index: i });
-                }}
-              />)}
-          />}
+        {/* draw this path even if strokewidth is 0, for focus/blur support */}
+        <LinePath
+          data={data}
+          x={x}
+          y={y1}
+          xScale={xScale}
+          yScale={yScale}
+          stroke={strokeValue}
+          strokeWidth={strokeWidthValue}
+          strokeDasharray={strokeDasharrayValue}
+          strokeLinecap={strokeLinecap}
+          curve={curve}
+          defined={defined}
+          glyph={(d, i) => (
+            <FocusBlurHandler
+              key={`areapoint-${i}`}
+              onBlur={disableMouseEvents ? null : onMouseLeave}
+              onFocus={disableMouseEvents ? null : (event) => {
+                onMouseMove({ event, data, datum: d, color: strokeValue, index: i });
+              }}
+            />)}
+        />
       </Group>
     );
   }

--- a/packages/xy-chart/src/series/BarSeries.jsx
+++ b/packages/xy-chart/src/series/BarSeries.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-
 import Bar from '@vx/shape/build/shapes/Bar';
+import FocusBlurHandler from '@data-ui/shared/build/components/FocusBlurHandler';
 import Group from '@vx/group/build/Group';
+import PropTypes from 'prop-types';
+import React from 'react';
 import themeColors from '@data-ui/theme/build/color';
 
 import { barSeriesDataShape } from '../utils/propShapes';
@@ -58,25 +58,34 @@ export default class BarSeries extends React.PureComponent {
         {data.map((d, i) => {
           const barHeight = maxHeight - yScale(y(d));
           const color = d.fill || callOrValue(fill, d, i);
+          const barX = xScale(x(d)) - offset;
+
           return isDefined(d.y) && (
-            <Bar
-              key={`bar-${xScale(x(d))}`}
-              x={xScale(x(d)) - offset}
-              y={maxHeight - barHeight}
-              width={barWidth}
-              height={barHeight}
-              fill={color}
-              fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
-              stroke={d.stroke || callOrValue(stroke, d, i)}
-              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-              onClick={disableMouseEvents ? null : onClick && (() => (event) => {
-                onClick({ event, data, datum: d, color, index: i });
-              })}
-              onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
+            <FocusBlurHandler
+              key={`bar-${barX}`}
+              onBlur={disableMouseEvents ? null : onMouseLeave}
+              onFocus={disableMouseEvents ? null : (event) => {
                 onMouseMove({ event, data, datum: d, color, index: i });
-              })}
-              onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
-            />
+              }}
+            >
+              <Bar
+                x={barX}
+                y={maxHeight - barHeight}
+                width={barWidth}
+                height={barHeight}
+                fill={color}
+                fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
+                stroke={d.stroke || callOrValue(stroke, d, i)}
+                strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+                onClick={disableMouseEvents ? null : onClick && (() => (event) => {
+                  onClick({ event, data, datum: d, color, index: i });
+                })}
+                onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
+                  onMouseMove({ event, data, datum: d, color, index: i });
+                })}
+                onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
+              />
+            </FocusBlurHandler>
           );
         })}
       </Group>

--- a/packages/xy-chart/src/series/BoxPlotSeries.jsx
+++ b/packages/xy-chart/src/series/BoxPlotSeries.jsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Group from '@vx/group/build/Group';
 import BoxPlot from '@vx/stats/build/boxplot/BoxPlot';
+import FocusBlurHandler from '@data-ui/shared/build/components/FocusBlurHandler';
+import Group from '@vx/group/build/Group';
+import PropTypes from 'prop-types';
+import React from 'react';
 import themeColors from '@data-ui/theme/build/color';
 
 import { callOrValue, isDefined } from '../utils/chartUtils';
@@ -104,48 +105,56 @@ export default class BoxPlotSeries extends React.PureComponent {
         {data.map((d, i) => {
           const mouseEvents = mouseEventProps(d, i);
           return isDefined(min(d)) && (
-            <BoxPlot
+            <FocusBlurHandler
               key={offsetValue(d)}
-              min={min(d)}
-              max={max(d)}
-              {...offsetProp(d)}
-              firstQuartile={firstQuartile(d)}
-              thirdQuartile={thirdQuartile(d)}
-              median={median(d)}
-              boxWidth={actualWidth * widthRatio}
-              outliers={outliers(d)}
-              fill={d.fill || callOrValue(fill, d, i)}
-              stroke={d.stroke || callOrValue(stroke, d, i)}
-              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-              fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
-              valueScale={valueScale}
-              horizontal={horizontal}
-              container={containerEvents}
-              containerProps={
-                (containerEvents || containerProps || undefined)
-                && { ...containerProps, ...(containerEvents && mouseEvents) }
-              }
-              outlierProps={
-                (!containerEvents || outlierProps || undefined)
-                && { ...outlierProps, ...(!containerEvents && mouseEvents) }
-              }
-              boxProps={
-                (!containerEvents || boxProps || undefined)
-                && { ...boxProps, ...(!containerEvents && mouseEvents) }
-              }
-              minProps={
-                (!containerEvents || minProps || undefined)
-                && { ...minProps, ...(!containerEvents && mouseEvents) }
-              }
-              maxProps={
-                (!containerEvents || maxProps || undefined)
-                && { ...maxProps, ...(!containerEvents && mouseEvents) }
-              }
-              medianProps={
-                (!containerEvents || medianProps || undefined)
-                && { ...medianProps, ...(!containerEvents && mouseEvents) }
-              }
-            />
+              xlinkHref="#"
+              onBlur={disableMouseEvents ? null : onMouseLeave}
+              onFocus={disableMouseEvents ? null : (event) => {
+                onMouseMove({ event, data, datum: d, index: i });
+              }}
+            >
+              <BoxPlot
+                min={min(d)}
+                max={max(d)}
+                {...offsetProp(d)}
+                firstQuartile={firstQuartile(d)}
+                thirdQuartile={thirdQuartile(d)}
+                median={median(d)}
+                boxWidth={actualWidth * widthRatio}
+                outliers={outliers(d)}
+                fill={d.fill || callOrValue(fill, d, i)}
+                stroke={d.stroke || callOrValue(stroke, d, i)}
+                strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+                fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
+                valueScale={valueScale}
+                horizontal={horizontal}
+                container={containerEvents}
+                containerProps={
+                  (containerEvents || containerProps || undefined)
+                  && { ...containerProps, ...(containerEvents && mouseEvents) }
+                }
+                outlierProps={
+                  (!containerEvents || outlierProps || undefined)
+                  && { ...outlierProps, ...(!containerEvents && mouseEvents) }
+                }
+                boxProps={
+                  (!containerEvents || boxProps || undefined)
+                  && { ...boxProps, ...(!containerEvents && mouseEvents) }
+                }
+                minProps={
+                  (!containerEvents || minProps || undefined)
+                  && { ...minProps, ...(!containerEvents && mouseEvents) }
+                }
+                maxProps={
+                  (!containerEvents || maxProps || undefined)
+                  && { ...maxProps, ...(!containerEvents && mouseEvents) }
+                }
+                medianProps={
+                  (!containerEvents || medianProps || undefined)
+                  && { ...medianProps, ...(!containerEvents && mouseEvents) }
+                }
+              />
+            </FocusBlurHandler>
           );
         })}
       </Group>

--- a/packages/xy-chart/src/series/IntervalSeries.jsx
+++ b/packages/xy-chart/src/series/IntervalSeries.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import FocusBlurHandler from '@data-ui/shared/build/components/FocusBlurHandler';
 import Group from '@vx/group/build/Group';
 import Bar from '@vx/shape/build/shapes/Bar';
 import color from '@data-ui/theme/build/color';
@@ -54,24 +55,31 @@ export default class IntervalSeries extends React.PureComponent {
           const barWidth = xScale(x1(d)) - x;
           const intervalFill = d.fill || callOrValue(fill, d, i);
           return (
-            <Bar
+            <FocusBlurHandler
               key={`interval-${x}`}
-              x={x}
-              y={0}
-              width={barWidth}
-              height={barHeight}
-              fill={intervalFill}
-              fillOpacity={fillOpacity}
-              stroke={d.stroke || callOrValue(stroke, d, i)}
-              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-              onClick={disableMouseEvents ? null : onClick && (() => (event) => {
-                onClick({ event, datum: d, index: i, data, color: intervalFill });
-              })}
-              onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
+              onBlur={disableMouseEvents ? null : onMouseLeave}
+              onFocus={disableMouseEvents ? null : (event) => {
                 onMouseMove({ event, datum: d, index: i, data, color: intervalFill });
-              })}
-              onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
-            />
+              }}
+            >
+              <Bar
+                x={x}
+                y={0}
+                width={barWidth}
+                height={barHeight}
+                fill={intervalFill}
+                fillOpacity={fillOpacity}
+                stroke={d.stroke || callOrValue(stroke, d, i)}
+                strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+                onClick={disableMouseEvents ? null : onClick && (() => (event) => {
+                  onClick({ event, datum: d, index: i, data, color: intervalFill });
+                })}
+                onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
+                  onMouseMove({ event, datum: d, index: i, data, color: intervalFill });
+                })}
+                onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
+              />
+            </FocusBlurHandler>
           );
         })}
       </Group>

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-
+import color from '@data-ui/theme/build/color';
+import FocusBlurHandler from '@data-ui/shared/build/components/FocusBlurHandler';
 import GlyphDot from '@vx/glyph/build/glyphs/Dot';
 import LinePath from '@vx/shape/build/shapes/LinePath';
-import color from '@data-ui/theme/build/color';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { callOrValue, isDefined } from '../utils/chartUtils';
 import findClosestDatum from '../utils/findClosestDatum';
@@ -79,31 +79,42 @@ export default class LineSeries extends React.PureComponent {
           onMouseMove({ event, data, datum: d, color: strokeValue });
         })}
         onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
-        glyph={showPoints && ((d, i) => (
-          isDefined(x(d)) && isDefined(y(d)) &&
-            <GlyphDot
-              key={`${i}-${x(d)}`}
-              cx={xScale(x(d))}
-              cy={yScale(y(d))}
-              r={4}
-              fill={d.stroke || callOrValue(stroke, d, i)}
-              stroke="#FFFFFF"
-              strokeWidth={1}
-              style={{ pointerEvents: 'none' }}
+        glyph={((d, i) => (
+          // <a /> wrapper is needed for focusing with SVG 1.2 regardless of whether we show a point
+          isDefined(x(d)) &&
+            isDefined(y(d)) &&
+            <FocusBlurHandler
+              key={`linepoint-${i}`}
+              onBlur={disableMouseEvents ? null : onMouseLeave}
+              onFocus={disableMouseEvents ? null : (event) => {
+                onMouseMove({ event, data, datum: d, color, index: i });
+              }}
             >
-              {d.label &&
-                <text
-                  x={xScale(x(d))}
-                  y={yScale(y(d))}
-                  dx={10}
+              {showPoints &&
+                <GlyphDot
+                  key={`${i}-${x(d)}`}
+                  cx={xScale(x(d))}
+                  cy={yScale(y(d))}
+                  r={4}
                   fill={d.stroke || callOrValue(stroke, d, i)}
-                  stroke={'#fff'}
+                  stroke="#FFFFFF"
                   strokeWidth={1}
-                  fontSize={12}
+                  style={{ pointerEvents: 'none' }}
                 >
-                  {d.label}
-                </text>}
-            </GlyphDot>
+                  {d.label &&
+                    <text
+                      x={xScale(x(d))}
+                      y={yScale(y(d))}
+                      dx={10}
+                      fill={d.stroke || callOrValue(stroke, d, i)}
+                      stroke={'#fff'}
+                      strokeWidth={1}
+                      fontSize={12}
+                    >
+                      {d.label}
+                    </text>}
+                </GlyphDot>}
+            </FocusBlurHandler>
         ))}
       />
     );

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import Group from '@vx/group/build/Group';
-
 import chartTheme from '@data-ui/theme/build/chartTheme';
 import color from '@data-ui/theme/build/color';
+import FocusBlurHandler from '@data-ui/shared/build/components/FocusBlurHandler';
+import Group from '@vx/group/build/Group';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 import { callOrValue, isDefined } from '../utils/chartUtils';
-import { pointSeriesDataShape } from '../utils/propShapes';
 import GlyphDotComponent from '../glyph/GlyphDotComponent';
+import { pointSeriesDataShape } from '../utils/propShapes';
 import sharedSeriesProps from '../utils/sharedSeriesProps';
 
 export const pointComponentPropTypes = {
@@ -92,7 +92,6 @@ export default class PointSeries extends React.PureComponent {
           const computedStrokeWidth = d.strokeWidth || callOrValue(strokeWidth, d, i);
           const computedStrokeDasharray = d.strokeDasharray || callOrValue(strokeDasharray, d, i);
           const props = {
-            key,
             x,
             y,
             size: computedSize,
@@ -107,7 +106,17 @@ export default class PointSeries extends React.PureComponent {
             data,
             datum: d,
           };
-          return defined && React.createElement(pointComponent, props);
+          return defined &&
+            <FocusBlurHandler
+              key={key}
+              xlinkHref="#"
+              onBlur={props.onMouseLeave}
+              onFocus={disableMouseEvents ? null : (event) => {
+                onMouseMove({ event, data, datum: d, color: computedFill, index: i });
+              }}
+            >
+              {React.createElement(pointComponent, props)}
+            </FocusBlurHandler>;
         })}
         {/* Put labels on top */}
         {labels.map(d => React.cloneElement(labelComponent, d, d.label))}

--- a/packages/xy-chart/src/series/PointSeries.jsx
+++ b/packages/xy-chart/src/series/PointSeries.jsx
@@ -110,7 +110,7 @@ export default class PointSeries extends React.PureComponent {
             <FocusBlurHandler
               key={key}
               xlinkHref="#"
-              onBlur={props.onMouseLeave}
+              onBlur={disableMouseEvents ? null : props.onMouseLeave}
               onFocus={disableMouseEvents ? null : (event) => {
                 onMouseMove({ event, data, datum: d, color: computedFill, index: i });
               }}

--- a/packages/xy-chart/src/series/ViolinPlotSeries.jsx
+++ b/packages/xy-chart/src/series/ViolinPlotSeries.jsx
@@ -1,13 +1,13 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import FocusBlurHandler from '@data-ui/shared/build/components/FocusBlurHandler';
 import Group from '@vx/group/build/Group';
-import ViolinPlot from '@vx/stats/build/violinplot/ViolinPlot';
+import PropTypes from 'prop-types';
+import React from 'react';
 import themeColors from '@data-ui/theme/build/color';
+import ViolinPlot from '@vx/stats/build/violinplot/ViolinPlot';
 
 import { callOrValue } from '../utils/chartUtils';
-
-import { violinPlotSeriesDataShape } from '../utils/propShapes';
 import sharedSeriesProps from '../utils/sharedSeriesProps';
+import { violinPlotSeriesDataShape } from '../utils/propShapes';
 
 const propTypes = {
   ...sharedSeriesProps,
@@ -60,24 +60,31 @@ export default function ViolinPlotSeries({
   return (
     <Group>
       {data.map((d, i) => (
-        <ViolinPlot
+        <FocusBlurHandler
           key={offsetValue(d)}
-          {...offsetProp(d)}
-          binData={d.binData}
-          width={actualWidth * widthRatio}
-          fill={d.fill || callOrValue(fill, d, i)}
-          stroke={d.stroke || callOrValue(stroke, d, i)}
-          strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-          valueScale={valueScale}
-          horizontal={horizontal}
-          onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
+          onBlur={disableMouseEvents ? null : onMouseLeave}
+          onFocus={disableMouseEvents ? null : (event) => {
             onMouseMove({ event, data, datum: d, index: i });
-          })}
-          onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
-          onClick={disableMouseEvents ? null : onClick && (() => (event) => {
-            onClick({ event, data, datum: d, index: i });
-          })}
-        />
+          }}
+        >
+          <ViolinPlot
+            {...offsetProp(d)}
+            binData={d.binData}
+            width={actualWidth * widthRatio}
+            fill={d.fill || callOrValue(fill, d, i)}
+            stroke={d.stroke || callOrValue(stroke, d, i)}
+            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+            valueScale={valueScale}
+            horizontal={horizontal}
+            onMouseMove={disableMouseEvents ? null : onMouseMove && (() => (event) => {
+              onMouseMove({ event, data, datum: d, index: i });
+            })}
+            onMouseLeave={disableMouseEvents ? null : onMouseLeave && (() => onMouseLeave)}
+            onClick={disableMouseEvents ? null : onClick && (() => (event) => {
+              onClick({ event, data, datum: d, index: i });
+            })}
+          />
+        </FocusBlurHandler>
       ))
     }
     </Group>

--- a/packages/xy-chart/test/axis/XAxis.test.js
+++ b/packages/xy-chart/test/axis/XAxis.test.js
@@ -120,7 +120,7 @@ describe('<XAxis />', () => {
     expect(label1.prop('fill')).toBe('blue');
   });
 
-  test.only('tickStyles.label[orientation] should be used if tickLabelProps is not passed', () => {
+  test('tickStyles.label[orientation] should be used if tickLabelProps is not passed', () => {
     const props = {
       scale: scaleLinear({ range: [0, 100], domain: [0, 100] }),
       innerHeight: 100,

--- a/packages/xy-chart/test/series/AreaSeries.test.js
+++ b/packages/xy-chart/test/series/AreaSeries.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import Area from '@vx/shape/build/shapes/Area';
 import LinePath from '@vx/shape/build/shapes/LinePath';
-
+import { FocusBlurHandler } from '@data-ui/shared';
 import { XYChart, AreaSeries } from '../../src/';
 
 describe('<AreaSeries />', () => {
@@ -126,5 +126,48 @@ describe('<AreaSeries />', () => {
 
     area.simulate('click');
     expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
+  test('it should render a FocusBlurHandler for each point', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+
+    const wrapper = mount(
+      <XYChart {...mockProps}>
+        <AreaSeries data={data} fill="hot-pink" />
+      </XYChart>,
+    );
+
+    const area = wrapper.find(AreaSeries);
+    expect(area.find(FocusBlurHandler)).toHaveLength(data.length);
+  });
+
+  test('it should invoke onMouseMove when focused', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+
+    const wrapper = mount(
+      <XYChart {...mockProps} onMouseMove={onMouseMove}>
+        <AreaSeries data={data} fill="hot-pink" />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(AreaSeries).find(FocusBlurHandler).first();
+    firstPoint.simulate('focus');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke onMouseLeave when blured', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseLeave = jest.fn();
+
+    const wrapper = mount(
+      <XYChart {...mockProps} onMouseLeave={onMouseLeave}>
+        <AreaSeries data={data} fill="hot-pink" />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(AreaSeries).find(FocusBlurHandler).first();
+    firstPoint.simulate('blur');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xy-chart/test/series/BarSeries.test.js
+++ b/packages/xy-chart/test/series/BarSeries.test.js
@@ -1,6 +1,8 @@
 import Bar from '@vx/shape/build/shapes/Bar';
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
+import { FocusBlurHandler } from '@data-ui/shared';
+
 import { XYChart, BarSeries } from '../../src/';
 
 describe('<BarSeries />', () => {
@@ -84,7 +86,7 @@ describe('<BarSeries />', () => {
     const onMouseLeave = jest.fn();
     const onClick = jest.fn();
 
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart
         {...mockProps}
         onMouseMove={onMouseMove}
@@ -95,9 +97,13 @@ describe('<BarSeries />', () => {
       </XYChart>,
     );
 
-    const bar = wrapper.find(Bar).first();
+    const bar = wrapper.find(BarSeries)
+      .dive()
+      .find(Bar)
+      .first()
+      .dive();
 
-    bar.simulate('mousemove');
+    bar.simulate('mousemove', ({ event: {} }));
     expect(onMouseMove).toHaveBeenCalledTimes(1);
     let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(data);
@@ -105,10 +111,10 @@ describe('<BarSeries />', () => {
     expect(args.event).toBeDefined();
     expect(args.color).toBe('banana');
 
-    bar.simulate('mouseleave');
+    bar.simulate('mouseleave', ({ event: {} }));
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
 
-    bar.simulate('click');
+    bar.simulate('click', ({ event: {} }));
     expect(onClick).toHaveBeenCalledTimes(1);
     args = onClick.mock.calls[0][0];
     expect(args.data).toBe(data);
@@ -123,7 +129,7 @@ describe('<BarSeries />', () => {
     const onMouseLeave = jest.fn();
     const onClick = jest.fn();
 
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart
         {...mockProps}
         onMouseMove={onMouseMove}
@@ -134,7 +140,7 @@ describe('<BarSeries />', () => {
       </XYChart>,
     );
 
-    const bar = wrapper.find(Bar).first();
+    const bar = wrapper.find(BarSeries).dive().find(Bar).first();
 
     bar.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(0);
@@ -144,5 +150,48 @@ describe('<BarSeries />', () => {
 
     bar.simulate('click');
     expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
+  test('it should render a FocusBlurHandler for each point', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <BarSeries data={data} />
+      </XYChart>,
+    );
+
+    const bars = wrapper.find(BarSeries).dive();
+    expect(bars.find(FocusBlurHandler)).toHaveLength(data.length);
+  });
+
+  test('it should invoke onMouseMove when focused', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseMove={onMouseMove}>
+        <BarSeries data={data} />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(BarSeries).dive().find(FocusBlurHandler).first();
+    firstPoint.simulate('focus');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke onMouseLeave when blured', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseLeave = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseLeave={onMouseLeave}>
+        <BarSeries data={data} />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(BarSeries).dive().find(FocusBlurHandler).first();
+    firstPoint.simulate('blur');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xy-chart/test/series/BoxPlotSeries.test.js
+++ b/packages/xy-chart/test/series/BoxPlotSeries.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import BoxPlot from '@vx/stats/build/boxplot/BoxPlot';
+import { FocusBlurHandler } from '@data-ui/shared';
 
 import { XYChart, BoxPlotSeries, computeStats } from '../../src/';
 
@@ -143,5 +144,44 @@ describe('<BoxPlotSeries />', () => {
 
     boxplot.simulate('click', {});
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should render a FocusBlurHandler for each point', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <BoxPlotSeries {...boxplotProps} />
+      </XYChart>,
+    );
+
+    const boxes = wrapper.find(BoxPlotSeries).dive();
+    expect(boxes.find(FocusBlurHandler)).toHaveLength(boxplotProps.data.length);
+  });
+
+  test('it should invoke onMouseMove when focused', () => {
+    const onMouseMove = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseMove={onMouseMove}>
+        <BoxPlotSeries {...boxplotProps} />
+      </XYChart>,
+    );
+
+    const firstBox = wrapper.find(BoxPlotSeries).dive().find(FocusBlurHandler).first();
+    firstBox.simulate('focus');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke onMouseLeave when blured', () => {
+    const onMouseLeave = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseLeave={onMouseLeave}>
+        <BoxPlotSeries {...boxplotProps} />
+      </XYChart>,
+    );
+
+    const firstBox = wrapper.find(BoxPlotSeries).dive().find(FocusBlurHandler).first();
+    firstBox.simulate('blur');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xy-chart/test/series/IntervalSeries.test.js
+++ b/packages/xy-chart/test/series/IntervalSeries.test.js
@@ -1,6 +1,7 @@
 import Bar from '@vx/shape/build/shapes/Bar';
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
+import { FocusBlurHandler } from '@data-ui/shared';
 
 import { XYChart, IntervalSeries } from '../../src/';
 
@@ -43,7 +44,7 @@ describe('<PointSeries />', () => {
     const onMouseLeave = jest.fn();
     const onClick = jest.fn();
 
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart
         {...mockProps}
         onMouseMove={onMouseMove}
@@ -54,9 +55,13 @@ describe('<PointSeries />', () => {
       </XYChart>,
     );
 
-    const bar = wrapper.find(Bar).first();
+    const bar = wrapper.find(IntervalSeries)
+      .dive()
+      .find(Bar)
+      .first()
+      .dive();
 
-    bar.simulate('mousemove');
+    bar.simulate('mousemove', ({ event: {} }));
     expect(onMouseMove).toHaveBeenCalledTimes(1);
     let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(mockData);
@@ -67,7 +72,7 @@ describe('<PointSeries />', () => {
     bar.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
 
-    bar.simulate('click');
+    bar.simulate('click', ({ event: {} }));
     expect(onClick).toHaveBeenCalledTimes(1);
     args = onClick.mock.calls[0][0];
     expect(args.data).toBe(mockData);
@@ -81,7 +86,7 @@ describe('<PointSeries />', () => {
     const onMouseLeave = jest.fn();
     const onClick = jest.fn();
 
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart
         {...mockProps}
         onMouseMove={onMouseMove}
@@ -92,15 +97,70 @@ describe('<PointSeries />', () => {
       </XYChart>,
     );
 
-    const bar = wrapper.find(Bar).first();
+    const bar = wrapper.find(IntervalSeries)
+      .dive()
+      .find(Bar)
+      .first()
+      .dive();
 
-    bar.simulate('mousemove');
+    bar.simulate('mousemove', ({ event: {} }));
     expect(onMouseMove).toHaveBeenCalledTimes(0);
 
     bar.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(0);
 
-    bar.simulate('click');
+    bar.simulate('click', ({ event: {} }));
     expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
+  test('it should render a FocusBlurHandler for each point', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <IntervalSeries data={data} />
+      </XYChart>,
+    );
+
+    const intervals = wrapper.find(IntervalSeries).dive();
+    expect(intervals.find(FocusBlurHandler)).toHaveLength(data.length);
+  });
+
+  test('it should invoke onMouseMove when focused', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseMove={onMouseMove}>
+        <IntervalSeries data={data} />
+      </XYChart>,
+    );
+
+    const firstInterval = wrapper.find(IntervalSeries)
+      .dive()
+      .find(FocusBlurHandler)
+      .first();
+
+    firstInterval.simulate('focus');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke onMouseLeave when blured', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseLeave = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseLeave={onMouseLeave}>
+        <IntervalSeries data={data} />
+      </XYChart>,
+    );
+
+    const firstInterval = wrapper.find(IntervalSeries)
+      .dive()
+      .find(FocusBlurHandler)
+      .first();
+
+    firstInterval.simulate('blur');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xy-chart/test/series/LineSeries.test.js
+++ b/packages/xy-chart/test/series/LineSeries.test.js
@@ -1,7 +1,8 @@
 import GlyphDot from '@vx/glyph/build/glyphs/Dot';
 import LinePath from '@vx/shape/build/shapes/LinePath';
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
+import { FocusBlurHandler } from '@data-ui/shared';
 
 import { XYChart, LineSeries } from '../../src/';
 
@@ -84,7 +85,7 @@ describe('<LineSeries />', () => {
     const onMouseLeave = jest.fn();
     const onClick = jest.fn();
 
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart
         {...mockProps}
         onMouseMove={onMouseMove}
@@ -95,9 +96,13 @@ describe('<LineSeries />', () => {
       </XYChart>,
     );
 
-    const line = wrapper.find('path');
+    const line = wrapper.find(LineSeries)
+      .dive()
+      .find(LinePath)
+      .dive()
+      .find('path');
 
-    line.simulate('mousemove');
+    line.simulate('mousemove', ({ event: {} }));
     expect(onMouseMove).toHaveBeenCalledTimes(1);
     let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(data);
@@ -108,7 +113,7 @@ describe('<LineSeries />', () => {
     line.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
 
-    line.simulate('click');
+    line.simulate('click', ({ event: {} }));
     expect(onMouseMove).toHaveBeenCalledTimes(1);
     args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(data);
@@ -123,7 +128,7 @@ describe('<LineSeries />', () => {
     const onMouseLeave = jest.fn();
     const onClick = jest.fn();
 
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart
         {...mockProps}
         onMouseMove={onMouseMove}
@@ -134,7 +139,11 @@ describe('<LineSeries />', () => {
       </XYChart>,
     );
 
-    const line = wrapper.find('path');
+    const line = wrapper.find(LineSeries)
+      .dive()
+      .find(LinePath)
+      .dive()
+      .find('path');
 
     line.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(0);
@@ -144,5 +153,63 @@ describe('<LineSeries />', () => {
 
     line.simulate('click');
     expect(onMouseMove).toHaveBeenCalledTimes(0);
+  });
+
+  test('it should render a FocusBlurHandler for each point', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <LineSeries data={data} />
+      </XYChart>,
+    );
+
+    const line = wrapper.find(LineSeries)
+      .dive()
+      .find(LinePath)
+      .dive();
+
+    expect(line.find(FocusBlurHandler)).toHaveLength(data.length);
+  });
+
+  test('it should invoke onMouseMove when focused', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseMove={onMouseMove}>
+        <LineSeries data={data} />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(LineSeries)
+      .dive()
+      .find(LinePath)
+      .dive()
+      .find(FocusBlurHandler)
+      .first();
+
+    firstPoint.simulate('focus');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke onMouseLeave when blured', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseLeave = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseLeave={onMouseLeave}>
+        <LineSeries data={data} />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(LineSeries)
+      .dive()
+      .find(LinePath)
+      .dive()
+      .find(FocusBlurHandler)
+      .first();
+
+    firstPoint.simulate('blur');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xy-chart/test/series/PointSeries.test.js
+++ b/packages/xy-chart/test/series/PointSeries.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
+import { FocusBlurHandler } from '@data-ui/shared';
 
 import { XYChart, PointSeries } from '../../src/';
 import GlyphDotComponent from '../../src/glyph/GlyphDotComponent';
@@ -77,7 +78,7 @@ describe('<PointSeries />', () => {
     const onMouseLeave = jest.fn();
     const onClick = jest.fn();
 
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart
         {...mockProps}
         onMouseMove={onMouseMove}
@@ -88,9 +89,13 @@ describe('<PointSeries />', () => {
       </XYChart>,
     );
 
-    const point = wrapper.find('circle').first();
+    const point = wrapper.find(PointSeries)
+      .dive()
+      .find(GlyphDotComponent)
+      .first()
+      .dive();
 
-    point.simulate('mousemove');
+    point.simulate('mousemove', ({ event: {} }));
     expect(onMouseMove).toHaveBeenCalledTimes(1);
     let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(data);
@@ -101,7 +106,7 @@ describe('<PointSeries />', () => {
     point.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
 
-    point.simulate('click');
+    point.simulate('click', ({ event: {} }));
     expect(onClick).toHaveBeenCalledTimes(1);
     args = onClick.mock.calls[0][0];
     expect(args.data).toBe(data);
@@ -116,7 +121,7 @@ describe('<PointSeries />', () => {
     const onMouseLeave = jest.fn();
     const onClick = jest.fn();
 
-    const wrapper = mount(
+    const wrapper = shallow(
       <XYChart
         {...mockProps}
         onMouseMove={onMouseMove}
@@ -127,7 +132,11 @@ describe('<PointSeries />', () => {
       </XYChart>,
     );
 
-    const point = wrapper.find('circle').first();
+    const point = wrapper.find(PointSeries)
+      .dive()
+      .find(GlyphDotComponent)
+      .first()
+      .dive();
 
     point.simulate('mousemove');
     expect(onMouseMove).toHaveBeenCalledTimes(0);
@@ -137,5 +146,47 @@ describe('<PointSeries />', () => {
 
     point.simulate('click');
     expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
+  test('it should render a FocusBlurHandler for each point', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <PointSeries data={data} />
+      </XYChart>,
+    );
+
+    const line = wrapper.find(PointSeries).dive();
+    expect(line.find(FocusBlurHandler)).toHaveLength(data.length);
+  });
+
+  test('it should invoke onMouseMove when focused', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseMove = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseMove={onMouseMove}>
+        <PointSeries data={data} />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(PointSeries).dive().find(FocusBlurHandler).first();
+    firstPoint.simulate('focus');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke onMouseLeave when blured', () => {
+    const data = mockData.map(d => ({ ...d, x: d.date, y: d.num }));
+    const onMouseLeave = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseLeave={onMouseLeave}>
+        <PointSeries data={data} />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(PointSeries).dive().find(FocusBlurHandler).first();
+    firstPoint.simulate('blur');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/xy-chart/test/series/ViolinPlotSeries.test.js
+++ b/packages/xy-chart/test/series/ViolinPlotSeries.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ViolinPlot from '@vx/stats/build/violinplot/ViolinPlot';
+import { FocusBlurHandler } from '@data-ui/shared';
 
 import { XYChart, ViolinPlotSeries, computeStats } from '../../src/';
 
@@ -102,5 +103,52 @@ describe('<ViolinPlotSeries />', () => {
 
     violin.simulate('click', {});
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should render a FocusBlurHandler for each point', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <ViolinPlotSeries {...violinProps} />
+      </XYChart>,
+    );
+
+    const violins = wrapper.find(ViolinPlotSeries).dive();
+    expect(violins.find(FocusBlurHandler)).toHaveLength(violinProps.data.length);
+  });
+
+  test('it should invoke onMouseMove when focused', () => {
+    const onMouseMove = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseMove={onMouseMove}>
+        <ViolinPlotSeries {...violinProps} />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(ViolinPlotSeries)
+      .dive()
+      .find(FocusBlurHandler)
+      .first();
+
+    firstPoint.simulate('focus');
+    expect(onMouseMove).toHaveBeenCalledTimes(1);
+  });
+
+  test('it should invoke onMouseLeave when blured', () => {
+    const onMouseLeave = jest.fn();
+
+    const wrapper = shallow(
+      <XYChart {...mockProps} onMouseLeave={onMouseLeave}>
+        <ViolinPlotSeries {...violinProps} />
+      </XYChart>,
+    );
+
+    const firstPoint = wrapper.find(ViolinPlotSeries)
+      .dive()
+      .find(FocusBlurHandler)
+      .first();
+
+    firstPoint.simulate('blur');
+    expect(onMouseLeave).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
🏆 Enhancements
This PR is the first to address #86 to begin to make tooltips accessible to keyboard-only users via support of `onFocus` and `onBlur` props.

<img src="https://user-images.githubusercontent.com/4496521/37192068-2aedc200-2318-11e8-9030-92034f346d12.gif" width="400" />
<img src="https://user-images.githubusercontent.com/4496521/37192071-2f476536-2318-11e8-9c19-539c59bf6991.gif" width="400" />

This PR
- adds the `@data-ui/shared` `<FocusBlurHandler />` handler that wraps mouse target nodes in an `<a />` element, which [seems to be the most reliable way to support focusing in svg 1.1/1.2](https://allyjs.io/tutorials/focusing-in-svg.html)
- adds `onFocus` and `onBlur` support to the following `<*Series />` components (the remainder depend on `@vx` exposing hooks to series dom nodes (to wrap in `<a />`s)

  | Series  | `onFocus` + `onBlur` support added |
  | ------------- | ------------- |
  | AreaSeries  | x |
  | BarSeries  | x |
  | BoxPlotSeries  | x |
  | CirclePackSeries  | x |
  | IntervalSeries | x |
  | LineSeries  | x |
  | PointSeries  | x |
  | ViolinPlotSeries  | x |
  | GroupedBarSeries  |  |
  | StackedAreaSeries |  |
  | StackedBarSeries |  |

**TODO**
- [x] documentation
- [x] look into adding support for the remaining series (via `@vx` PRs)
- [x] tests for `onFocus` + `onBlur` triggers