### PR TITLE
[network] tooltip and mouse event updates

### DIFF
--- a/packages/demo/examples/04-network/ExpandableNetwork.jsx
+++ b/packages/demo/examples/04-network/ExpandableNetwork.jsx
@@ -10,10 +10,10 @@ class ExpandableNetwork extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = { graph: props.graph };
-    this.onNodeClick = this.onNodeClick.bind(this);
+    this.onClick = this.onClick.bind(this);
   }
 
-  onNodeClick({ index }) {
+  onClick({ index }) {
     const graph = this.state.graph;
     const newGraph = expandGraph(graph, graph.nodes[index]);
     this.setState(() => ({ graph: newGraph }));
@@ -30,7 +30,7 @@ class ExpandableNetwork extends React.PureComponent {
         animated={animated}
         ariaLabel={ariaLabel}
         graph={this.state.graph}
-        onNodeClick={this.onNodeClick}
+        onClick={this.onClick}
       />
     );
   }

--- a/packages/demo/examples/04-network/ExpandableNetworkWithCustomizedLayout.jsx
+++ b/packages/demo/examples/04-network/ExpandableNetworkWithCustomizedLayout.jsx
@@ -7,8 +7,8 @@ import { expandGraph } from './data';
 class ExpandableNetworkWithCustomizedLayout extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = { graph: props.graph, alpha: 0.5 };
-    this.onNodeClick = this.onNodeClick.bind(this);
+    this.state = { graph: props.graph, alpha: 0.4 };
+    this.onClick = this.onClick.bind(this);
     this.onSetAlpha = this.onSetAlpha.bind(this);
 
     this.layout = new AtlasForceDirectedLayout();
@@ -28,7 +28,7 @@ class ExpandableNetworkWithCustomizedLayout extends React.PureComponent {
     this.setState({ alpha, graph: nextGraph });
   }
 
-  onNodeClick({ index }) {
+  onClick({ index }) {
     const graph = this.state.graph;
     const newGraph = expandGraph(graph, graph.nodes[index]);
     this.setState(() => ({ graph: newGraph }));
@@ -41,15 +41,22 @@ class ExpandableNetworkWithCustomizedLayout extends React.PureComponent {
 
     return (
       <div>
-        <Range
-          id="data-ui-network-alpha"
-          label={`Alpha min (${alpha.toFixed(3)}, ~${iterations} iterations)`}
-          min={0.001}
-          max={0.5}
-          step={0.001}
-          value={alpha}
-          onMouseUp={this.onSetAlpha}
-        />
+        <h4>
+          {`Alpha min (${alpha.toFixed(3)}, ~${iterations} iterations)`}
+        </h4>
+        <div style={{ display: 'flex' }}>
+          more iterations&nbsp;
+          <Range
+            id="data-ui-network-alpha"
+            label=""
+            min={0.001}
+            max={0.5}
+            step={0.001}
+            value={alpha}
+            onChange={this.onSetAlpha}
+          />
+          &nbsp;fewer iterations
+        </div>
         <Network
           renderTooltip={renderTooltip}
           width={width}
@@ -58,7 +65,7 @@ class ExpandableNetworkWithCustomizedLayout extends React.PureComponent {
           animated={animated}
           ariaLabel={ariaLabel}
           graph={this.state.graph}
-          onNodeClick={this.onNodeClick}
+          onClick={this.onClick}
           layout={this.layout}
         />
       </div>

--- a/packages/demo/examples/04-network/NetworkWithCustomizedRenderer.jsx
+++ b/packages/demo/examples/04-network/NetworkWithCustomizedRenderer.jsx
@@ -11,12 +11,12 @@ class NetworkWithCustomizedRenderer extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = { graph: props.graph };
-    this.onNodeClick = this.onNodeClick.bind(this);
+    this.onClick = this.onClick.bind(this);
     this.renderNode = this.renderNode.bind(this);
     this.renderLink = this.renderLink.bind(this);
   }
 
-  onNodeClick({ index }) {
+  onClick({ index }) {
     const graph = this.state.graph;
     const newGraph = expandGraph(graph, graph.nodes[index]);
     this.setState(() => ({ graph: newGraph }));
@@ -62,7 +62,7 @@ class NetworkWithCustomizedRenderer extends React.PureComponent {
         animated={animated}
         ariaLabel={ariaLabel}
         graph={this.state.graph}
-        onNodeClick={this.onNodeClick}
+        onClick={this.onClick}
         renderNode={this.renderNode}
         renderLink={this.renderLink}
       />

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -16,6 +16,42 @@ Tooltips are controlled with the `renderTooltip` function passed to `<Network />
 
 Under the covers this will wrap the `<Network />` component in the exported `<WithTooltip />` HOC, which wraps the `svg` in a `<div />` and handles the positioning and rendering of an HTML-based tooltip with the contents returned by `renderTooltip()`. This tooltip is aware of the bounds of its container and should position itself "smartly".
 
+#### Customization
+If you'd like more customizability over tooltip rendering you can do either of the following:
+
+1) Roll your own tooltip positioning logic and pass `onMouseMove` and `onMouseLeave` functions to `<Network />`. These functions are triggered with the signature described below upon appropriate trigger.
+
+2) Wrap `<Network />` with `<WithTooltip />` yourself, which accepts props for additional customization:
+
+Name | Type | Default | Description
+------------ | ------------- | ------- | ----
+children | PropTypes.func or PropTypes.object | - | Child function (to call) or element (to clone) with `onMouseMove`, `onMouseLeave`, and `tooltipData` props
+className | PropTypes.string | - | Class name to add to the `<div>` container wrapper
+renderTooltip | PropTypes.func.isRequired | - | Renders the _contents_ of the tooltip, signature of `({ event, data, datum, color }) => node`. If this function returns a `falsy` value, a tooltip will not be rendered.
+styles | PropTypes.object | {} | Styles to add to the `<div>` container wrapper
+TooltipComponent | PropTypes.func or PropTypes.object | `@vx`'s `TooltipWithBounds` | Component (not instance) to use as the tooltip container component. It is passed `top` and `left` numbers for positioning
+tooltipProps | PropTypes.object | - | Props that are passed to `TooltipComponent`
+tooltipTimeout | PropTypes.number | 200 | Timeout in ms for the tooltip to hide upon calling `onMouseLeave`
+
+
+Note that to correctly position a tooltip, the `<WithTooltip />` `onMouseMove` function minimally requires an `event` _OR_ `coords` object of the form `{ x: Number, y: Number }`. If `coords` is specified it takes precedent over any position computed from the event. See function signatures below for more.
+
+#### Functions and Function Signatures
+`<Network />` supports `onMouseEnter`, `onMouseMove`, `onMouseLeave`, and `onClick` event handlers. These functions are passed to the `renderNode` components with the following signatures:
+
+```
+onMouseLeave(event);
+allOtherFunc({ event, index, id, data: node, coords] });
+```
+
+`coords` is an object of the form `{ x: Number, y: Number }`. `XYChart` passes `x` and `y` only if `snapTooltipToDataX` or `snapTooltipToDataY` are `true`, respectively.
+
+##### Programmatically triggering tooltips
+`<Network />` exposes hooks to manually trigger any of these handlers with the `eventTriggerRefs` prop. Similar to `React` `ref`s, this prop is a callback function that is called by `<Network />` after mounting. The callback receives an object as input, with keys corresponding to the event type names and respective handlers as values: `eventTriggerRefs({ click, mouseenter, mousemove, mouseleave })`. The ref handlers have the same signatures as defined above.
+
+Note that `snapTooltipToData*` props will still apply (i.e., `coords` will be passed in the event signature) when events are triggered this way.
+
+
 ### Roadmap
 - more layout algorithms
 - dragging interaction enabled


### PR DESCRIPTION
💔 Breaking Changes
Mouse events renamed
- `onNodeClick` => `onClick`
- `onNodeMouseEnter` => `onMouseEnter`
- `onNodeMouseLeave` => `onMouseLeave`

🏆 Enhancements
- allow user to wrap `<Network />` in WithTooltip to support programmatic triggering and custom tooltip logic
- add `eventTriggerRefs` callback to support programmatic tooltip triggering
- add `snapToTooltipX` and `snapToTooltipY` support

📜 Documentation
- updates readme with new props

🏡Internal
- fix broken network example
- remove unused/add new `Network.propTypes`

cc @conglei 
