### PR TITLE
[network] changed the init layout in mounted, and add aspectraio control

### DIFF
--- a/packages/demo/examples/04-network/ExpandableNetwork.jsx
+++ b/packages/demo/examples/04-network/ExpandableNetwork.jsx
@@ -31,6 +31,7 @@ class ExpandableNetwork extends React.PureComponent {
         ariaLabel={ariaLabel}
         graph={this.state.graph}
         onClick={this.onClick}
+        keepAspectRatio={false}
       />
     );
   }

--- a/packages/demo/examples/04-network/ExpandableNetwork.jsx
+++ b/packages/demo/examples/04-network/ExpandableNetwork.jsx
@@ -31,7 +31,7 @@ class ExpandableNetwork extends React.PureComponent {
         ariaLabel={ariaLabel}
         graph={this.state.graph}
         onClick={this.onClick}
-        keepAspectRatio={false}
+        preserveAspectRatio={false}
       />
     );
   }

--- a/packages/demo/examples/04-network/index.jsx
+++ b/packages/demo/examples/04-network/index.jsx
@@ -70,7 +70,7 @@ export default {
       ),
     },
     {
-      description: 'Expandable network',
+      description: 'Expandable network without keeping aspect ratio',
       components: [ExpandableNetwork],
       example: () => (
         <ResponsiveNetwork
@@ -80,7 +80,7 @@ export default {
       ),
     },
     {
-      description: 'Animated expandable network',
+      description: 'Animated expandable network without keeping aspect ratio',
       components: [ExpandableNetwork],
       example: () => (
         <ResponsiveNetwork

--- a/packages/network/README.md
+++ b/packages/network/README.md
@@ -11,6 +11,45 @@ See the demo at <a href="https://williaster.github.io/data-ui" target="_blank">w
 <img width="500" alt="Network Visualization" src="https://user-images.githubusercontent.com/2024960/30942113-d1baa152-a39d-11e7-940f-f7780bf15fb9.gif">
 
 
+## Components
+
+Check out the example source code and PropTable tabs in the Storybook <a href="https://williaster.github.io/data-ui" target="_blank">williaster.github.io/data-ui</a> for more!
+
+#### `<Network />`
+The `Network ` component renders the network visualization. It takes the following props:
+
+Name | Type | Default | Description
+------------ | ------------- | ------- | ----
+ariaLabel | PropTypes.string.isRequired | - | Accessibility label for the svg
+children | PropTypes.node.isRequired | - | Child series, reference lines, defs, or other valid svg children
+className | PropTypes.string | - | Optional className to add to the svg
+graph | PropTypes.shape({nodes: PropTypes.array, links: PropTypes.array }) | - | A valid graph structure with nodes and links.
+height | PropTypes.number.isRequired | - | Height of the svg including top/bottom margin
+width | PropTypes.number.isRequired | - | Width of the svg including left/right margin
+margin | PropTypes.shape({ top: PropTypes.number, right: PropTypes.number, bottom: PropTypes.number, left: PropTypes.number }) | { top: 16, right: 16, bottom: 16, left: 16 } | Chart margin
+onMouseMove | PropTypes.func | null | `func({ data, id, event, index })`, passed to a NodeComponent
+onMouseLeave | PropTypes.func | null | `func({ data, id, event, index })`, passed to a NodeComponent
+onMouseEnter | PropTypes.func | null | `func({ data, id, event, index })`, passed to a NodeComponent
+onClick | PropTypes.func | null | `func({ data, id, event, index })`, passed to a NodeComponent
+waitingForLayoutLabel | PropTypes.string | 'Computing layout...' | Placeholder message when the layout algorithm is running
+preserveAspectRatio | PropTypes.bool | true | A flag to indiate if the aspect ratio will be preserved when scaling the layout to fit for the width and height of the component.
+renderLink | PropTypes.func | Link | Customized Link Renderer for an link object
+renderNode | PropTypes.func | Node | Customized Node Renderer for an node object
+layout | PropTypes.object | atlasForce | Customized layout object created by an Layout Class
+
+#### Layout Class
+
+Users can creat their own layout algorithm class and pass the object created by the class to the network visualization. For a layout class, it must implement the following functions:
+
+Function | Parameters | Description
+-------------- | -------- | ----------------
+setGraph | graph: graphShape  | Assign a graph to the object
+getGraph | | return the graph
+layout | { callback: function } | Layout the graph and call the callback function with the layouted graph as the input parameter.
+setAnimated | isAnimated: bool | Render the graph layout process with animated transition
+isAnimated | | Return the animated status
+clear | | Post-process used to clear any states, such as clear all the callback functions
+
 ### Tooltips
 Tooltips are controlled with the `renderTooltip` function passed to `<Network />`. This function takes an object with the shape `{ event, index, id, data }` as input and is expected to return the inner _contents_ of the tooltip (not the tooltip container!) as shown above. If this function returns a `falsy` value, a tooltip will not be rendered.
 

--- a/packages/network/src/chart/Network.jsx
+++ b/packages/network/src/chart/Network.jsx
@@ -40,7 +40,7 @@ export const propTypes = {
   waitingForLayoutLabel: PropTypes.string,
   width: PropTypes.number.isRequired,
   layout: PropTypes.object,
-  keepAspectRatio: PropTypes.bool,
+  preserveAspectRatio: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -65,7 +65,7 @@ const defaultProps = {
   onMouseLeave: null,
   eventTriggerRefs: null,
   waitingForLayoutLabel: 'Computing layout...',
-  keepAspectRatio: true,
+  preserveAspectRatio: true,
 };
 
 function updateArgsWithCoordsIfNecessary(args, props) {
@@ -106,19 +106,27 @@ class Network extends React.PureComponent {
         click: this.handleClick,
       });
     }
-    const { graph, animated, width, height, margin, layout, keepAspectRatio } = this.props;
+    const { graph, animated, width, height, margin, layout, preserveAspectRatio } = this.props;
     this.layout = layout || new Layout();
     this.layout.setAnimated(animated);
     this.layout.setGraph(graph);
     this.layout.layout({
       callback: (newGraph) => {
-        this.setGraphState({ graph: newGraph, width, height, margin, keepAspectRatio });
+        this.setGraphState({ graph: newGraph, width, height, margin, preserveAspectRatio });
       },
     });
   }
 
   componentWillReceiveProps(nextProps) {
-    const { graph, animated, width, height, margin, renderTooltip, keepAspectRatio } = nextProps;
+    const {
+      graph,
+      animated,
+      width,
+      height,
+      margin,
+      renderTooltip,
+      preserveAspectRatio,
+    } = nextProps;
     if (
       !renderTooltip && (
         this.props.graph.links !== graph.links
@@ -131,11 +139,11 @@ class Network extends React.PureComponent {
       this.layout.setAnimated(animated);
       this.layout.layout({
         callback: (newGraph) => {
-          this.setGraphState({ graph: newGraph, width, height, margin, keepAspectRatio });
+          this.setGraphState({ graph: newGraph, width, height, margin, preserveAspectRatio });
         },
       });
     } else {
-      this.setGraphState({ graph, width, height, margin, keepAspectRatio });
+      this.setGraphState({ graph, width, height, margin, preserveAspectRatio });
     }
   }
 
@@ -143,7 +151,7 @@ class Network extends React.PureComponent {
     if (this.layout) this.layout.clear();
   }
 
-  setGraphState({ graph, width, height, margin, keepAspectRatio }) {
+  setGraphState({ graph, width, height, margin, preserveAspectRatio }) {
     const range = graph.nodes.reduce(
       ({ x, y }, node) =>
         ({
@@ -175,8 +183,8 @@ class Network extends React.PureComponent {
     let xZoomLevel = dataXRange / actualWidth;
     let yZoomLevel = dataYRange / actualheight;
 
-    const zoomLevel = Math.max(xZoomLevel, yZoomLevel);
-    if (keepAspectRatio) {
+    if (preserveAspectRatio) {
+      const zoomLevel = Math.max(xZoomLevel, yZoomLevel);
       xZoomLevel = zoomLevel;
       yZoomLevel = zoomLevel;
     }


### PR DESCRIPTION
🏆 Enhancements

In this PR, the aspectratio control is added. For some layout algorithm, we don't need to keep the original aspect ratio for responsive scaling. In `<Network />`, `keepAspectRatio` is added. 

🐛 Bug Fix

Before, the layout will be run in constructor. However, in some case, when the layout algorithm is fast enough, the callback function with `setGraphState` will be called before the component is mounted, which will cause the graph not properly rendered. 

In this PR, the initial layout is called in `componentDidMount`. 

@williaster 