### PR TITLE
exposed circle packing layout as a prop

### DIFF
--- a/packages/demo/examples/01-xy-chart/computeForceBasedCirclePack.js
+++ b/packages/demo/examples/01-xy-chart/computeForceBasedCirclePack.js
@@ -1,0 +1,27 @@
+/* eslint no-param-reassign: 0 */
+import * as d3Force from 'd3-force';
+
+export default function computeForceBasedCirclePack(rawData, xScale, size) {
+  const data = rawData.map(d => ({ ...d, orgX: d.x }));
+  const simulation = d3Force.forceSimulation(data)
+   .force('x', d3Force.forceX(d => xScale(d.orgX)).strength(1))
+   .force('y', d3Force.forceY(0))
+   .force('collide', d3Force.forceCollide(d => size(d)))
+   .stop();
+
+  for (let i = 0; i < 500; i += 1) {
+    simulation.tick();
+    data.forEach((d) => {
+      d.x = Math.min(d.x, xScale.range()[1]);
+      d.x = Math.max(d.x, xScale.range()[0]);
+    });
+  }
+
+  const result = data.map(d => ({
+    ...d,
+    offset: Math.abs(d.x - xScale(d.orgX)) / (xScale.range()[1] - xScale.range()[0]),
+    x: xScale.invert(d.x),
+  }));
+
+  return result;
+}

--- a/packages/demo/examples/01-xy-chart/data.js
+++ b/packages/demo/examples/01-xy-chart/data.js
@@ -122,6 +122,11 @@ export const circlePackData = Array(400).fill(null).map((_, i) => ({
   r: minSize + (Math.random() * (maxSize - minSize)),
   fillOpacity: Math.max(0.4, Math.random()),
   fill: theme.colors.categories[i % 2 === 0 ? 1 : 3],
-}));
+})).concat(Array(70).fill(null).map((_, i) => ({
+  x: start,
+  r: minSize + (Math.random() * (maxSize - minSize)),
+  fillOpacity: Math.max(0.4, Math.random()),
+  fill: theme.colors.categories[i % 2 === 0 ? 1 : 3],
+})));
 
 export const statsData = genStats(5);

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -55,6 +55,8 @@ import {
 
 import WithToggle from '../shared/WithToggle';
 
+import computeForceBasedCirclePack from './computeForceBasedCirclePack';
+
 PatternLines.displayName = 'PatternLines';
 LinearGradient.displayName = 'LinearGradient';
 
@@ -472,6 +474,34 @@ export default {
           <CirclePackSeries
             data={circlePackData}
             size={d => d.r}
+          />
+          <HorizontalReferenceLine
+            reference={0}
+          />
+          <CrossHair
+            showHorizontalLine={false}
+            fullHeight
+            stroke={colors.darkGray}
+            circleFill="white"
+            circleStroke={colors.darkGray}
+          />
+          <XAxis label="Time" numTicks={5} />
+        </ResponsiveXYChart>
+      ),
+    },
+    {
+      description: 'CirclePackSeries with customized layout',
+      components: [CirclePackSeries],
+      example: () => (
+        <ResponsiveXYChart
+          ariaLabel="Required label"
+          xScale={{ type: 'time' }}
+          yScale={{ type: 'linear' }}
+        >
+          <CirclePackSeries
+            data={circlePackData}
+            size={d => d.r}
+            layout={computeForceBasedCirclePack}
           />
           <HorizontalReferenceLine
             reference={0}

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -64,6 +64,7 @@
   },
   "private": true,
   "dependencies": {
+    "d3-force": "^1.1.0",
     "d3-random": "^1.1.0"
   }
 }

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -149,7 +149,7 @@ Series | supported x scale type | supported y scale types | data shape | support
   <img src="https://user-images.githubusercontent.com/4496521/30147216-07514a16-9352-11e7-9459-5802b771c750.png" width="500" />
 </p>
 
-This series implements the Circle packing algorithm described by <a href="https://www.researchgate.net/publication/221516201_Visualization_of_large_hierarchical_data_by_circle_packing" target="_blank">Wang et al. Visualization of large hierarchical data by circle packing</a>, but attempts to preserve datum x values (although they may be modified slightly). It is useful for visualizing e.g., atomic events where x values may partially overlap, and provides an alternative to an atomic histogram without a requirement for binning x values.
+This series implements the Circle packing algorithm described by <a href="https://www.researchgate.net/publication/221516201_Visualization_of_large_hierarchical_data_by_circle_packing" target="_blank">Wang et al. Visualization of large hierarchical data by circle packing</a>, but attempts to preserve datum x values (although they may be modified slightly). It is useful for visualizing e.g., atomic events where x values may partially overlap, and provides an alternative to an atomic histogram without a requirement for binning x values. Alternatively, users can pass their own layout algorithm as the value of prop `layout` (one example is included in the demo package.)
 
 Note that only `x` values are needed for `CirclePackSeries`, `y` values are computed based on `x` and `size` (if specified). Similar to `PointSeries`, `size`, `fill`, and `fillOpacity` may be set on datum themseleves or passed as props to the `CirclePackSeries` component.
 

--- a/packages/xy-chart/src/series/CirclePackSeries.jsx
+++ b/packages/xy-chart/src/series/CirclePackSeries.jsx
@@ -19,12 +19,14 @@ const propTypes = {
     }),
   ).isRequired,
   layoutCallback: PropTypes.func,
+  layout: PropTypes.func,
 };
 
 const defaultProps = {
   ...pointSeriesDefaultProps,
   size: d => d.size || 4,
   layoutCallback: null,
+  layout: computeCirclePack,
 };
 
 class CirclePackSeries extends React.PureComponent {
@@ -44,8 +46,8 @@ class CirclePackSeries extends React.PureComponent {
     if (this.timeout) clearTimeout(this.timeout);
   }
 
-  computeCirclePack({ data: rawData, xScale, yScale, size, layoutCallback }) {
-    const data = computeCirclePack(rawData, xScale, size);
+  computeCirclePack({ data: rawData, xScale, yScale, size, layoutCallback, layout }) {
+    const data = layout(rawData, xScale, size);
 
     // callback enables the user to re-set the chart height if there is overflow
     if (layoutCallback) {


### PR DESCRIPTION
🏆 Enhancements
In this PR, we exposed circle packing layout as a prop so users can pass their own layout algorithm into circle packing charts. In the demo, we show an example of a customized layout algorithm. 

📜 Documentation
Updated the documentation.

@williaster 