### PR TITLE
[shared] role=button => role=presentation on FocusBlurHandler

### DIFF
--- a/packages/shared/src/components/FocusBlurHandler.jsx
+++ b/packages/shared/src/components/FocusBlurHandler.jsx
@@ -35,7 +35,7 @@ export default class FocusBlurHandler extends React.PureComponent {
     return (
       <a // eslint-disable-line jsx-a11y/no-static-element-interactions
         xlinkHref={(onBlur || onFocus) && '#'}
-        role="button"
+        role="presentation"
         onBlur={onBlur}
         onFocus={onFocus}
         onClick={this.handleOnClick}


### PR DESCRIPTION
[shared]
🐛 Bug Fix
- prefer `role="presentation"` instead of `role="button"` on `<FocusBlurHandler />` to fix [this a11y axe violation](https://dequeuniversity.com/rules/axe/2.5/button-name?application=axeAPI)

tested locally by sym-linking to our internal component library that flags axe violations.

cc @backwardok