### PR TITLE
relayout when bounding box changes for layout algorithm

### DIFF
--- a/packages/network/src/chart/Network.jsx
+++ b/packages/network/src/chart/Network.jsx
@@ -158,6 +158,11 @@ class Network extends React.PureComponent {
         this.props.graph.links !== graph.links
         || this.props.graph.nodes !== graph.nodes
         || this.state.computingLayout
+        || (this.setBoundingBox && (
+          this.props.width !== width
+          || this.props.height !== height
+          || this.props.margin !== margin
+        ))
       )) {
       this.layout.clear();
       this.setState(() => ({ computingLayout: true }));

--- a/packages/network/src/chart/Network.jsx
+++ b/packages/network/src/chart/Network.jsx
@@ -158,7 +158,7 @@ class Network extends React.PureComponent {
         this.props.graph.links !== graph.links
         || this.props.graph.nodes !== graph.nodes
         || this.state.computingLayout
-        || (this.setBoundingBox && (
+        || (this.layout.setBoundingBox && (
           this.props.width !== width
           || this.props.height !== height
           || this.props.margin !== margin


### PR DESCRIPTION
🐛 Bug Fix
The layout algorithm won't be triggered when the width, height, or margin changes while the layout algorithm do need the new values for calculating the layout again. 
