### PR TITLE
[histogram] add onClick support to BarSeries

### DIFF
--- a/packages/demo/examples/02-histogram/HistogramPlayground.jsx
+++ b/packages/demo/examples/02-histogram/HistogramPlayground.jsx
@@ -50,6 +50,10 @@ const defaultProps = {
 };
 
 class HistogramPlayground extends React.PureComponent {
+  static onClick({ datum, index }) {
+    console.log('clicked bar', index, datum);
+  }
+
   constructor(props) {
     super(props);
 
@@ -107,7 +111,9 @@ class HistogramPlayground extends React.PureComponent {
             id={key}
             label={key}
             checked={Boolean(this.state[key])}
-            onChange={() => { this.setState({ [key]: !this.state[key] }); }}
+            onChange={() => {
+              this.setState({ [key]: !this.state[key] });
+            }}
           />
         ))}
         <Range
@@ -150,7 +156,9 @@ class HistogramPlayground extends React.PureComponent {
           max={10}
           step={1}
           value={mu}
-          onChange={(e) => { this.handleChangeMu(datasetKey, e.target.value); }}
+          onChange={(e) => {
+            this.handleChangeMu(datasetKey, e.target.value);
+          }}
         />
         <Range
           id={`sigma-${datasetKey}`}
@@ -159,7 +167,9 @@ class HistogramPlayground extends React.PureComponent {
           max={15}
           step={1}
           value={sigma}
-          onChange={(e) => { this.handleChangeSigma(datasetKey, e.target.value); }}
+          onChange={(e) => {
+            this.handleChangeSigma(datasetKey, e.target.value);
+          }}
         />
         <Checkbox
           id={`show-density-${datasetKey}`}
@@ -175,7 +185,7 @@ class HistogramPlayground extends React.PureComponent {
             });
           }}
         />
-        {showDensity &&
+        {showDensity && (
           <Checkbox
             id={`show-bars-${datasetKey}`}
             label="Show bars"
@@ -185,7 +195,8 @@ class HistogramPlayground extends React.PureComponent {
                 [datasetKey]: { ...this.state[datasetKey], showBars: !showBars },
               });
             }}
-          />}
+          />
+        )}
       </div>
     );
   }
@@ -203,26 +214,33 @@ class HistogramPlayground extends React.PureComponent {
           binCount={binCount}
           horizontal={horizontal}
         >
-          {datasets.map(key => (
-            !this.state[key].showDensity || this.state[key].showBars ? (
-              <BarSeries
-                key={key}
-                fill={this.state[key].color}
-                rawData={this.state[key].rawData}
-              />
-            ) : null
-          ))}
+          {datasets.map((key) => {
+            if (!this.state[key].showDensity || this.state[key].showBars) {
+              return (
+                <BarSeries
+                  key={key}
+                  fill={this.state[key].color}
+                  rawData={this.state[key].rawData}
+                  onClick={HistogramPlayground.onClick}
+                />
+              );
+            }
+            return null;
+          })}
 
-          {datasets.map(key => (
-            this.state[key].showDensity ? (
-              <DensitySeries
-                key={key}
-                rawData={this.state[key].rawData}
-                stroke={this.state[key].color}
-                fill={this.state[key].color}
-              />
-            ) : null
-          ))}
+          {datasets.map((key) => {
+            if (this.state[key].showDensity) {
+              return (
+                <DensitySeries
+                  key={key}
+                  rawData={this.state[key].rawData}
+                  stroke={this.state[key].color}
+                  fill={this.state[key].color}
+                />
+              );
+            }
+            return null;
+          })}
 
           {xAxis && <XAxis />}
           {yAxis && <YAxis />}

--- a/packages/demo/examples/02-histogram/index.jsx
+++ b/packages/demo/examples/02-histogram/index.jsx
@@ -5,12 +5,10 @@ import {
   Histogram,
   BarSeries,
   DensitySeries,
-
   XAxis,
   YAxis,
   PatternLines,
   LinearGradient,
-
   withScreenSize,
 } from '@data-ui/histogram';
 
@@ -42,9 +40,7 @@ export default {
     {
       description: 'Playground',
       components: [Histogram, BarSeries, DensitySeries, XAxis, YAxis],
-      example: () => (
-        <HistogramPlayground HistogramComponent={ResponsiveHistogram} />
-      ),
+      example: () => <HistogramPlayground HistogramComponent={ResponsiveHistogram} />,
     },
     {
       description: 'normal',
@@ -114,7 +110,7 @@ export default {
       description: 'categorical',
       components: [BarSeries, DensitySeries],
       example: () => (
-        <ResponsiveHistogram binType="categorical" >
+        <ResponsiveHistogram binType="categorical">
           <PatternLines
             id="categorical"
             height={8}
@@ -124,11 +120,7 @@ export default {
             strokeWidth={0.5}
             orientation={['diagonal']}
           />
-          <DensitySeries
-            showLine={false}
-            rawData={categorical}
-            fillOpacity={0.2}
-          />
+          <DensitySeries showLine={false} rawData={categorical} fillOpacity={0.2} />
           <BarSeries
             rawData={categorical}
             stroke={chartTheme.colors.default}
@@ -175,10 +167,7 @@ export default {
             rotate={45}
             vertical={false}
           />
-          <BarSeries
-            fill="url(#normalized)"
-            rawData={normal[mus[2]][2]}
-          />
+          <BarSeries fill="url(#normalized)" rawData={normal[mus[2]][2]} />
           <XAxis />
           <YAxis />
         </ResponsiveHistogram>
@@ -260,9 +249,7 @@ export default {
             fillOpacity={0.3}
             binnedData={binnedCategorical}
           />
-          <DensitySeries
-            binnedData={binnedCategorical}
-          />
+          <DensitySeries binnedData={binnedCategorical} />
           <XAxis label="Letter frequency" />
           <YAxis />
         </ResponsiveHistogram>
@@ -288,11 +275,7 @@ export default {
             fill="url(#categorical)"
             fillOpacity={0.7}
           />
-          <DensitySeries
-            showLine={false}
-            binnedData={binnedNumeric}
-            fillOpacity={0.2}
-          />
+          <DensitySeries showLine={false} binnedData={binnedNumeric} fillOpacity={0.2} />
           <XAxis />
           <YAxis />
         </ResponsiveHistogram>

--- a/packages/histogram/README.md
+++ b/packages/histogram/README.md
@@ -116,6 +116,7 @@ fill | PropTypes.oneOfType([PropTypes.func, PropTypes.string]) | @data-ui/theme.
 fillOpacity | PropTypes.oneOfType([PropTypes.func, PropTypes.number]) | 0.7 | opacity of bar fill
 stroke | PropTypes.oneOfType([PropTypes.func, PropTypes.string]) | 'white' | determines bar stroke color
 strokeWidth | PropTypes.oneOfType([PropTypes.func, PropTypes.number]) | 1 | determines width of bar outline
+onClick | PropTypes.func | -- | Called on bar click with a signature of `({ event, data, datum, color, index })`
 
 
 ### `<DensitySeries />`
@@ -169,7 +170,7 @@ Name | Type | Default | Description
 ------------ | ------------- | ------- | ----
 children | PropTypes.func or PropTypes.object | - | Child function (to call) or element (to clone) with onMouseMove, onMouseLeave, and tooltipData props/keys
 className | PropTypes.string | - | Class name to add to the `<div>` container wrapper
-renderTooltip | PropTypes.func.isRequired | - | Renders the _contents_ of the tooltip, signature of `({ event, data, datum, color }) => node`. If this function returns a `falsy` value, a tooltip will not be rendered.
+renderTooltip | PropTypes.func.isRequired | - | Renders the _contents_ of the tooltip, signature of `({ event, data, datum, color, index }) => node`. If this function returns a `falsy` value, a tooltip will not be rendered.
 styles | PropTypes.object | {} | Styles to add to the `<div>` container wrapper
 TooltipComponent | PropTypes.func or PropTypes.object | `@vx`'s `TooltipWithBounds` | Component (not instance) to use as the tooltip container component. It is passed `top` and `left` numbers for positioning
 tooltipProps | PropTypes.object | - | Props that are passed to `TooltipComponent`

--- a/packages/histogram/src/chart/Histogram.jsx
+++ b/packages/histogram/src/chart/Histogram.jsx
@@ -160,12 +160,7 @@ class Histogram extends React.PureComponent {
     } = this.state;
 
     return (
-      <svg
-        aria-label={ariaLabel}
-        role="img"
-        width={width}
-        height={height}
-      >
+      <svg aria-label={ariaLabel} role="img" width={width} height={height}>
         <Group left={margin.left} top={margin.top}>
           {React.Children.map(children, (Child, index) => {
             const name = componentName(Child);
@@ -186,13 +181,11 @@ class Histogram extends React.PureComponent {
               const styleKey = name[0].toLowerCase();
               const binOrValue =
                 (name === 'XAxis' && !horizontal) || (name === 'YAxis' && horizontal)
-                ? 'bin'
-                : 'value';
+                  ? 'bin'
+                  : 'value';
 
-              const tickValues = (
-                Child.props.tickValues ||
-                (binOrValue === 'bin' && binValues ? binValues : null)
-              );
+              const tickValues =
+                Child.props.tickValues || (binOrValue === 'bin' && binValues ? binValues : null);
 
               return React.cloneElement(Child, {
                 top: name === 'YAxis' || Child.props.orientation === 'top' ? 0 : innerHeight,

--- a/packages/histogram/src/series/BarSeries.jsx
+++ b/packages/histogram/src/series/BarSeries.jsx
@@ -19,6 +19,7 @@ export const propTypes = {
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
   valueKey: PropTypes.string,
+  onClick: PropTypes.func,
 
   // likely injected by parent Histogram
   binScale: PropTypes.func,
@@ -36,6 +37,7 @@ export const defaultProps = {
   fill: chartTheme.colors.default,
   fillOpacity: 0.7,
   horizontal: false,
+  onClick: null,
   onMouseMove: null,
   onMouseLeave: null,
   stroke: '#FFFFFF',
@@ -51,6 +53,7 @@ function BarSeries({
   fill,
   fillOpacity,
   horizontal,
+  onClick,
   onMouseMove,
   onMouseLeave,
   stroke,
@@ -64,53 +67,65 @@ function BarSeries({
 
   // @TODO with custom bin values, bin1 - bin0 may be different for each bar, account for this
   const barWidth = binScale.bandwidth
-      ? binScale.bandwidth() // categorical
-      : Math.abs(binScale(binnedData[0].bin1) - binScale(binnedData[0].bin0)); // numeric
+    ? binScale.bandwidth() // categorical
+    : Math.abs(binScale(binnedData[0].bin1) - binScale(binnedData[0].bin0)); // numeric
 
   return (
     <Group>
-      {animated &&
+      {animated && (
         <AnimatedBarSeries
           binnedData={binnedData}
           binScale={binScale}
           horizontal={horizontal}
           fill={fill}
           fillOpacity={fillOpacity}
+          onClick={onClick}
           onMouseMove={onMouseMove}
           onMouseLeave={onMouseLeave}
           stroke={stroke}
           strokeWidth={strokeWidth}
           valueKey={valueKey}
           valueScale={valueScale}
-        />}
+        />
+      )}
 
-      {!animated && binnedData.map((d, i) => {
-        const binPosition = binScale(d.bin || (horizontal ? d.bin1 : d.bin0));
-        const barLength = horizontal
-          ? valueScale(d[valueKey])
-          : maxBarLength - valueScale(d[valueKey]);
+      {!animated &&
+        binnedData.map((d, i) => {
+          const binPosition = binScale(d.bin || (horizontal ? d.bin1 : d.bin0));
+          const barLength = horizontal
+            ? valueScale(d[valueKey])
+            : maxBarLength - valueScale(d[valueKey]);
 
-        const color = d.fill || callOrValue(fill, d, i);
-        return (
-          <Bar
-            key={`bar-${binPosition}`}
-            x={horizontal ? 0 : binPosition}
-            y={horizontal ? binPosition : (maxBarLength - barLength)}
-            width={horizontal ? barLength : barWidth}
-            height={horizontal ? barWidth : barLength}
-            fill={color}
-            fillOpacity={
-              typeof fillOpacity !== 'undefined' ? fillOpacity : callOrValue(fillOpacity, d, i)
-            }
-            stroke={d.stroke || callOrValue(stroke, d, i)}
-            strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
-            onMouseMove={onMouseMove && (() => (event) => {
-              onMouseMove({ event, data: binnedData, datum: d, color });
-            })}
-            onMouseLeave={onMouseLeave && (() => onMouseLeave)}
-          />
-        );
-      })}
+          const color = d.fill || callOrValue(fill, d, i);
+          return (
+            <Bar
+              key={`bar-${binPosition}`}
+              x={horizontal ? 0 : binPosition}
+              y={horizontal ? binPosition : maxBarLength - barLength}
+              width={horizontal ? barLength : barWidth}
+              height={horizontal ? barWidth : barLength}
+              fill={color}
+              fillOpacity={
+                typeof fillOpacity !== 'undefined' ? fillOpacity : callOrValue(fillOpacity, d, i)
+              }
+              stroke={d.stroke || callOrValue(stroke, d, i)}
+              strokeWidth={d.strokeWidth || callOrValue(strokeWidth, d, i)}
+              onClick={
+                onClick &&
+                (() => (event) => {
+                  onClick({ event, data: binnedData, datum: d, color, index: i });
+                })
+              }
+              onMouseMove={
+                onMouseMove &&
+                (() => (event) => {
+                  onMouseMove({ event, data: binnedData, datum: d, color, index: i });
+                })
+              }
+              onMouseLeave={onMouseLeave && (() => onMouseLeave)}
+            />
+          );
+        })}
     </Group>
   );
 }

--- a/packages/histogram/src/series/animated/AnimatedBarSeries.jsx
+++ b/packages/histogram/src/series/animated/AnimatedBarSeries.jsx
@@ -33,6 +33,7 @@ function AnimatedBarSeries({
   keyAccessor,
   fill,
   fillOpacity,
+  onClick,
   onMouseMove,
   onMouseLeave,
   stroke,
@@ -42,8 +43,8 @@ function AnimatedBarSeries({
   const maxBarLength = Math.max(...valueScale.range());
 
   const barWidth = binScale.bandwidth
-      ? binScale.bandwidth() // categorical
-      : Math.abs(binScale(binnedData[0].bin1) - binScale(binnedData[0].bin0)); // numeric
+    ? binScale.bandwidth() // categorical
+    : Math.abs(binScale(binnedData[0].bin1) - binScale(binnedData[0].bin0)); // numeric
 
   const getValue = d => d[valueKey];
 
@@ -104,13 +105,28 @@ function AnimatedBarSeries({
                 stroke={d.stroke}
                 fillOpacity={
                   typeof fillOpacity !== 'undefined'
-                  ? fillOpacity
-                  : callOrValue(fillOpacity, rawDatum, i)
+                    ? fillOpacity
+                    : callOrValue(fillOpacity, rawDatum, i)
                 }
                 strokeWidth={rawDatum.strokeWidth || callOrValue(strokeWidth, rawDatum, i)}
-                onMouseMove={onMouseMove && (() => (event) => {
-                  onMouseMove({ event, datum: rawDatum, data: binnedData, color: d.fill });
-                })}
+                onClick={
+                  onClick &&
+                  (() => (event) => {
+                    onClick({ event, datum: rawDatum, data: binnedData, color: d.fill, index: i });
+                  })
+                }
+                onMouseMove={
+                  onMouseMove &&
+                  (() => (event) => {
+                    onMouseMove({
+                      event,
+                      datum: rawDatum,
+                      data: binnedData,
+                      color: d.fill,
+                      index: i,
+                    });
+                  })
+                }
                 onMouseLeave={onMouseLeave && (() => onMouseLeave)}
               />
             );

--- a/packages/histogram/test/components/AnimatedBarSeries.test.js
+++ b/packages/histogram/test/components/AnimatedBarSeries.test.js
@@ -73,10 +73,16 @@ describe('<AnimatedBarSeries />', () => {
   test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
       <Histogram {...histogramProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
-        <BarSeries animated binnedData={numericBinnedData} fill="cabbage-purple" />
+        <BarSeries
+          animated
+          binnedData={numericBinnedData}
+          fill="cabbage-purple"
+          onClick={onClick}
+        />
       </Histogram>,
     );
 
@@ -85,10 +91,20 @@ describe('<AnimatedBarSeries />', () => {
       bar.simulate('mousemove');
 
       expect(onMouseMove).toHaveBeenCalledTimes(1);
-      const args = onMouseMove.mock.calls[0][0];
+      let args = onMouseMove.mock.calls[0][0];
       expect(args.data).toBe(numericBinnedData);
       expect(args.datum).toBe(numericBinnedData[0]);
       expect(args.event).toBeDefined();
+      expect(args.index).toBe(0);
+      expect(args.color).toBe('cabbage-purple');
+
+      bar.simulate('click');
+      expect(onClick).toHaveBeenCalledTimes(1);
+      args = onClick.mock.calls[0][0];
+      expect(args.data).toBe(numericBinnedData);
+      expect(args.datum).toBe(numericBinnedData[0]);
+      expect(args.event).toBeDefined();
+      expect(args.index).toBe(0);
       expect(args.color).toBe('cabbage-purple');
 
       bar.simulate('mouseleave');

--- a/packages/histogram/test/components/BarSeries.test.js
+++ b/packages/histogram/test/components/BarSeries.test.js
@@ -61,13 +61,19 @@ describe('<BarSeries />', () => {
     expect(barWrapper.find(AnimatedBarSeries).length).toBe(1);
   });
 
-  test('it should call onMouseMove({ datum, data, event, color }) and onMouseLeave() on trigger', () => {
+  test('it should call onMouseMove(), onClick() and onMouseLeave() on trigger', () => {
     const onMouseMove = jest.fn();
     const onMouseLeave = jest.fn();
+    const onClick = jest.fn();
 
     const wrapper = mount(
       <Histogram {...histogramProps} onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
-        <BarSeries animated={false} binnedData={numericBinnedData} fill="cabbage-purple" />
+        <BarSeries
+          animated={false}
+          binnedData={numericBinnedData}
+          fill="cabbage-purple"
+          onClick={onClick}
+        />
       </Histogram>,
     );
 
@@ -75,13 +81,23 @@ describe('<BarSeries />', () => {
     bar.simulate('mousemove');
 
     expect(onMouseMove).toHaveBeenCalledTimes(1);
-    const args = onMouseMove.mock.calls[0][0];
+    let args = onMouseMove.mock.calls[0][0];
     expect(args.data).toBe(numericBinnedData);
     expect(args.datum).toBe(numericBinnedData[0]);
     expect(args.event).toBeDefined();
+    expect(args.index).toBe(0);
     expect(args.color).toBe('cabbage-purple');
 
     bar.simulate('mouseleave');
     expect(onMouseLeave).toHaveBeenCalledTimes(1);
+
+    bar.simulate('click');
+    expect(onClick).toHaveBeenCalledTimes(1);
+    args = onClick.mock.calls[0][0];
+    expect(args.data).toBe(numericBinnedData);
+    expect(args.datum).toBe(numericBinnedData[0]);
+    expect(args.event).toBeDefined();
+    expect(args.index).toBe(0);
+    expect(args.color).toBe('cabbage-purple');
   });
 });


### PR DESCRIPTION
Fixes #102 

🏆 Enhancements
- Adds `onClick` support to `BarSeries` and `AnimatedBarSeries`
- `onClick` and `onMouseMove` functions are passed `index` in addition to `data`, `datum`, `event`, and `color`

![image](https://user-images.githubusercontent.com/4496521/40440001-7ecd1198-5e71-11e8-8f0b-f15def7e1d89.png)

cc @bmantoni