### PR TITLE
add @data-ui/shared as a @data-ui/demo dep, add prepublish scrip to @data-ui/shared

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -31,6 +31,7 @@
     "@data-ui/histogram": "^0.0.62",
     "@data-ui/network": "^0.0.62",
     "@data-ui/radial-chart": "^0.0.62",
+    "@data-ui/shared": "^0.0.62",
     "@data-ui/sparkline": "^0.0.62",
     "@data-ui/theme": "^0.0.62",
     "@data-ui/xy-chart": "^0.0.62",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -18,7 +18,8 @@
     "lint": "npm run prettier && npm run eslint",
     "test": "npm run jest",
     "prettier": "beemo prettier \"./{src,test}/**/*.{js,jsx,json,md}\"",
-    "sync:gitignore": "beemo sync-dotfiles --filter=gitignore"
+    "sync:gitignore": "beemo sync-dotfiles --filter=gitignore",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
🐛 Bug Fix 
🏠 Internal

fixes a bug for local dev where `demo` is broken because

1.  it doesn't have a `@data-ui/shared` dependency and 
2. `@data-ui/shared` was not building itself on a fresh install due to a missing `prepublish` script.

cc @conglei 