### PR TITLE
[histogram] don't trim (or make it necessary to trim) numeric data bins

### DIFF
--- a/packages/demo/examples/02-histogram/renderHistogramTooltip.jsx
+++ b/packages/demo/examples/02-histogram/renderHistogramTooltip.jsx
@@ -7,7 +7,9 @@ export default function RenderTooltip({ datum, color }) {
   return (
     <div>
       <div>
-        <strong style={{ color }}>{typeof bin === 'undefined' ? `${bin0} to ${bin1}` : bin}</strong>
+        <strong style={{ color }}>
+          {typeof bin === 'undefined' ? `${bin0.toFixed(1)} to ${bin1.toFixed(1)}` : bin}
+        </strong>
       </div>
       <br />
       <div>

--- a/packages/histogram/src/chart/Histogram.jsx
+++ b/packages/histogram/src/chart/Histogram.jsx
@@ -11,6 +11,7 @@ import collectBinnedDataFromChildSeries from '../utils/collectBinnedDataFromChil
 import componentName from '../utils/componentName';
 import computeDomainsFromBins from '../utils/computeDomainsFromBins';
 import getValueKey from '../utils/getValueKey';
+import shallowCompareObjectEntries from '../utils/shallowCompareObjectEntries';
 import { themeShape } from '../utils/propShapes';
 
 export const propTypes = {
@@ -63,7 +64,20 @@ class Histogram extends React.PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState(this.getStateFromProps(nextProps));
+    let shouldComputeBinsAndScales = false;
+    // eslint-disable-next-line react/destructuring-assignment
+    if (['width', 'height', 'children'].some(prop => this.props[prop] !== nextProps[prop])) {
+      shouldComputeBinsAndScales = true;
+    }
+    if (
+      ['margin'].some(
+        // eslint-disable-next-line react/destructuring-assignment
+        prop => !shallowCompareObjectEntries(this.props[prop], nextProps[prop]),
+      )
+    ) {
+      shouldComputeBinsAndScales = true;
+    }
+    if (shouldComputeBinsAndScales) this.setState(this.getStateFromProps(nextProps));
   }
 
   getStateFromProps(props) {

--- a/packages/histogram/src/series/BarSeries.jsx
+++ b/packages/histogram/src/series/BarSeries.jsx
@@ -64,11 +64,6 @@ function BarSeries({
 
   const maxBarLength = Math.max(...valueScale.range());
 
-  // @TODO with custom bin values, bin1 - bin0 may be different for each bar, account for this
-  const barWidth = binScale.bandwidth
-    ? binScale.bandwidth() // categorical
-    : Math.abs(binScale(binnedData[0].bin1) - binScale(binnedData[0].bin0)); // numeric
-
   return (
     <Group>
       {animated && (
@@ -94,6 +89,10 @@ function BarSeries({
           const barLength = horizontal
             ? valueScale(d[valueKey])
             : maxBarLength - valueScale(d[valueKey]);
+
+          const barWidth = binScale.bandwidth
+            ? binScale.bandwidth() // categorical
+            : Math.abs(binScale(binnedData[i].bin1) - binScale(binnedData[i].bin0)); // numeric
 
           const color = d.fill || callOrValue(fill, d, i);
 

--- a/packages/histogram/src/series/animated/AnimatedBarSeries.jsx
+++ b/packages/histogram/src/series/animated/AnimatedBarSeries.jsx
@@ -67,9 +67,13 @@ function AnimatedBarSeries({
 }) {
   const maxBarLength = Math.max(...valueScale.range());
 
-  const barWidth = binScale.bandwidth
-    ? binScale.bandwidth() // categorical
-    : Math.abs(binScale(binnedData[0].bin1) - binScale(binnedData[0].bin0)); // numeric
+  // compute once and use throughout
+  const barWidths = binnedData.map(
+    (_, i) =>
+      binScale.bandwidth
+        ? binScale.bandwidth() // categorical
+        : Math.abs(binScale(binnedData[i].bin1) - binScale(binnedData[i].bin0)), // numeric
+  );
 
   const getValue = d => d[valueKey];
 
@@ -86,14 +90,14 @@ function AnimatedBarSeries({
         x: horizontal ? 0 : xScale(getX(d)),
         y: horizontal ? yScale(getY(d)) : maxBarLength,
         fill: d.fill || callOrValue(fill, d, i),
-        width: horizontal ? 0 : barWidth,
-        height: horizontal ? barWidth : 0,
+        width: horizontal ? 0 : barWidths[i],
+        height: horizontal ? barWidths[i] : 0,
       })}
       enter={(d, i) => ({
         x: [horizontal ? 0 : xScale(getX(d))],
         y: [yScale(getY(d))],
-        width: [horizontal ? xScale(getX(d)) : barWidth],
-        height: [horizontal ? barWidth : maxBarLength - yScale(getY(d))],
+        width: [horizontal ? xScale(getX(d)) : barWidths[i]],
+        height: [horizontal ? barWidths[i] : maxBarLength - yScale(getY(d))],
         fill: [d.fill || callOrValue(fill, d, i)],
         stroke: [d.stroke || callOrValue(stroke, d, i)],
         timing: { duration: 300, delay: INDEX_DELAY_MULTIPLIER * i },
@@ -101,8 +105,8 @@ function AnimatedBarSeries({
       update={(d, i) => ({
         x: [horizontal ? 0 : xScale(getX(d))],
         y: [yScale(getY(d))],
-        width: [horizontal ? xScale(getX(d)) : barWidth],
-        height: [horizontal ? barWidth : maxBarLength - yScale(getY(d))],
+        width: [horizontal ? xScale(getX(d)) : barWidths[i]],
+        height: [horizontal ? barWidths[i] : maxBarLength - yScale(getY(d))],
         fill: [d.fill || callOrValue(fill, d, i)],
         stroke: [d.stroke || callOrValue(stroke, d, i)],
         timing: { duration: 300, delay: INDEX_DELAY_MULTIPLIER * i },
@@ -110,8 +114,8 @@ function AnimatedBarSeries({
       leave={(d, i) => ({
         x: horizontal ? 0 : xScale(getX(d)),
         y: horizontal ? yScale(getY(d)) : maxBarLength,
-        width: horizontal ? 0 : barWidth,
-        height: horizontal ? barWidth : 0,
+        width: horizontal ? 0 : barWidths[i],
+        height: horizontal ? barWidths[i] : 0,
         timing: { duration: 300, delay: (INDEX_DELAY_MULTIPLIER / 2) * i },
       })}
     >

--- a/packages/histogram/src/utils/shallowCompareObjectEntries.js
+++ b/packages/histogram/src/utils/shallowCompareObjectEntries.js
@@ -1,0 +1,7 @@
+export default function shallowCompareObjectEntries(a, b) {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+
+  return keysA.every(k => a[k] === b[k]);
+}

--- a/packages/histogram/test/utils/shallowCompareObjectEntries.test.js
+++ b/packages/histogram/test/utils/shallowCompareObjectEntries.test.js
@@ -1,0 +1,25 @@
+import shallowCompareObjectEntries from '../../src/utils/shallowCompareObjectEntries';
+
+describe('shallowCompareObjectEntries', () => {
+  it('should be defined', () => {
+    expect(shallowCompareObjectEntries).toBeDefined();
+  });
+
+  it('should return false if objects have different key counts', () => {
+    expect(shallowCompareObjectEntries({ a: 'a' }, {})).toBe(false);
+  });
+
+  it('should return false if objects have different keys', () => {
+    expect(shallowCompareObjectEntries({ a: 'a' }, { b: 'a' })).toBe(false);
+    expect(shallowCompareObjectEntries({ b: 'a' }, { a: 'a' })).toBe(false);
+  });
+
+  it('should return false if objects have different values', () => {
+    expect(shallowCompareObjectEntries({ a: 'a' }, { a: 'b' })).toBe(false);
+    expect(shallowCompareObjectEntries({ b: 'a' }, { b: 'b' })).toBe(false);
+  });
+
+  it('should return true if objects have the same entries', () => {
+    expect(shallowCompareObjectEntries({ a: 'a', b: 1 }, { a: 'a', b: 1 })).toBe(true);
+  });
+});


### PR DESCRIPTION
🐛 Bug Fix
This fixes #100 and #118 which both arise due to an issue with binning for numeric, raw data. 

Previously an extra bin was generated, which was then trimmed. In the cases highlighted in the two issues, this resulted in errors or inaccurate bins/bin counts.

When there is only one raw data value (#100):

```javascript
<Histogram
  ariaLabel=""
  height={250}
  width={500}
>
  <BarSeries rawData={[0, 0, 0, 0]} />
  <XAxis />
  <YAxis />
</Histogram>
```
<img width="491" alt="screen shot 2018-08-21 at 11 50 39 pm" src="https://user-images.githubusercontent.com/4496521/44447669-be8a8e00-a59d-11e8-9ddd-0200856f4889.png">


0s and 1s (#118)

```javascript
<Histogram
  ariaLabel=""
  height={250}
  width={500}
>
  <BarSeries rawData={[1, 1, 1, 1, 0, 0]} />
  <XAxis />
  <YAxis />
</Histogram>
```
<img width="491" alt="screen shot 2018-08-21 at 11 54 58 pm" src="https://user-images.githubusercontent.com/4496521/44447639-a6b30a00-a59d-11e8-9092-54f0b5d80fe3.png">

Note that the binning here is due to the default `binCount={10}`, set to `2` instead:

<img width="494" alt="screen shot 2018-08-21 at 11 56 14 pm" src="https://user-images.githubusercontent.com/4496521/44447715-dcf08980-a59d-11e8-9a8c-ce0a7c5ea839.png">

cc @kaiyoma @PAK90