### PR TITLE
[histogram] fix edge bin, add dev script

### DIFF
--- a/packages/histogram/package.json
+++ b/packages/histogram/package.json
@@ -13,6 +13,7 @@
     "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
     "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
     "build": "npm run build:cjs && npm run build:esm",
+    "dev": "beemo babel --watch ./src --out-dir esm/ --react --esm",
     "jest": "beemo jest --react --color --coverage",
     "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,json,md}\"",
     "lint": "npm run prettier && npm run eslint",

--- a/packages/histogram/src/utils/binNumericData.js
+++ b/packages/histogram/src/utils/binNumericData.js
@@ -43,7 +43,7 @@ export default function binNumericData({
 
   histogram
     .domain(limits || scale.domain())
-    .thresholds(binValues || scale.ticks(binThresholdCount)); // || scale.ticks(binThresholdCount));
+    .thresholds(binValues || scale.ticks(binThresholdCount));
 
   Object.keys(rawDataByIndex).forEach(index => {
     const data = rawDataByIndex[index];
@@ -58,8 +58,6 @@ export default function binNumericData({
       id: i.toString(),
     }));
   });
-
-  console.log(binCount, binValues, binsByIndex);
 
   return binsByIndex;
 }


### PR DESCRIPTION
🐛 Bug Fix
Fix for `histogram` when the last numeric bin computed for raw data has equal start/end, was incorrectly setting the upper bound.  

