### PR TITLE
misc bug fixes

### DIFF
--- a/packages/demo/examples/01-xy-chart/BrushableLineChart.jsx
+++ b/packages/demo/examples/01-xy-chart/BrushableLineChart.jsx
@@ -15,7 +15,7 @@ import {
   Brush,
 } from '@data-ui/xy-chart';
 
-import colors from '@data-ui/theme/lib/color';
+import colors, { allColors } from '@data-ui/theme/lib/color';
 
 import { timeSeriesData } from './data';
 import PointSeries from '../../node_modules/@data-ui/xy-chart/lib/series/PointSeries';
@@ -38,11 +38,6 @@ class BrushableLineChart extends React.PureComponent {
       disableDraggingSelection: false,
     };
     this.handleBrushChange = this.handleBrushChange.bind(this);
-    this.handleBrushEnd = this.handleBrushEnd.bind(this);
-  }
-
-  handleBrushEnd(domain) {
-    console.log(domain);
   }
 
   handleBrushChange(domain) {
@@ -385,8 +380,16 @@ class BrushableLineChart extends React.PureComponent {
           yScale={{ type: 'linear' }}
           margin={{ left: 100, top: 64, bottom: 64 }}
         >
-          <LineSeries seriesKey="one" data={timeSeriesData} strokeWidth={1} />
-          <PointSeries seriesKey="one" data={pointData} strokeWidth={1} />
+          <PatternLines
+            id="brush_pattern"
+            height={8}
+            width={8}
+            stroke={allColors.blue[1]}
+            strokeWidth={1}
+            orientation={['diagonal']}
+          />
+          <LineSeries data={timeSeriesData} strokeWidth={2} stroke={allColors.blue[3]} />
+          <PointSeries data={pointData} fillOpacity={1} fill={allColors.blue[7]} strokeWidth={1} />
           <CrossHair
             showHorizontalLine={false}
             fullHeight
@@ -401,9 +404,12 @@ class BrushableLineChart extends React.PureComponent {
             resizeTriggerAreas={resizeTriggerAreas}
             brushDirection={brushDirection}
             onChange={this.handleBrushChange}
-            onBrushEnd={this.handleBrushEnd}
             brushRegion={brushRegion}
             disableDraggingSelection={disableDraggingSelection}
+            selectedBoxStyle={{
+              fill: 'url(#brush_pattern)',
+              stroke: allColors.blue[5],
+            }}
           />
         </XYChart>
 

--- a/packages/demo/examples/01-xy-chart/ResponsiveXYChart.jsx
+++ b/packages/demo/examples/01-xy-chart/ResponsiveXYChart.jsx
@@ -2,7 +2,10 @@
 import React from 'react';
 import { timeParse, timeFormat } from 'd3-time-format';
 
-import { XYChart, theme, withScreenSize } from '@data-ui/xy-chart';
+import { XYChart, theme, withScreenSize, withTheme } from '@data-ui/xy-chart';
+
+// test that withTheme works
+const XYChartWithTheme = withTheme(theme)(XYChart);
 
 export const parseDate = timeParse('%Y%m%d');
 export const formatDate = timeFormat('%b %d');
@@ -47,15 +50,14 @@ export function renderTooltip({ datum, seriesKey, color, data }) {
 
 function ResponsiveXYChart({ screenWidth, children, ...rest }) {
   return (
-    <XYChart
-      theme={theme}
+    <XYChartWithTheme
       width={Math.min(700, screenWidth / 1.5)}
       height={Math.min(700 / 2, screenWidth / 1.5 / 2)}
       renderTooltip={renderTooltip}
       {...rest}
     >
       {children}
-    </XYChart>
+    </XYChartWithTheme>
   );
 }
 

--- a/packages/demo/examples/02-histogram/index.jsx
+++ b/packages/demo/examples/02-histogram/index.jsx
@@ -281,5 +281,30 @@ export default {
         </ResponsiveHistogram>
       ),
     },
+    {
+      description: 'un-binned numeric',
+      components: [BarSeries, DensitySeries],
+      example: () => (
+        <ResponsiveHistogram>
+          <PatternLines
+            id="categorical"
+            height={8}
+            width={8}
+            background="#fff"
+            stroke={chartTheme.colors.default}
+            strokeWidth={0.5}
+            orientation={['diagonal']}
+          />
+          <BarSeries
+            rawData={[100]}
+            stroke={chartTheme.colors.default}
+            fill="url(#categorical)"
+            fillOpacity={0.7}
+          />
+          <XAxis />
+          <YAxis />
+        </ResponsiveHistogram>
+      ),
+    },
   ],
 };

--- a/packages/histogram/src/utils/binNumericData.js
+++ b/packages/histogram/src/utils/binNumericData.js
@@ -60,7 +60,6 @@ export default function binNumericData({
       count: bin.length,
       id: i.toString(),
     }));
-    console.log(seriesBins, binsByIndex[index]);
   });
 
   return binsByIndex;

--- a/packages/histogram/src/utils/binNumericData.js
+++ b/packages/histogram/src/utils/binNumericData.js
@@ -52,11 +52,15 @@ export default function binNumericData({
     binsByIndex[index] = seriesBins.map((bin, i) => ({
       bin0: bin.x0,
       // if the upper limit equals the lower one, use the delta between this bin and the last
-      bin1: bin.x0 === bin.x1 ? (i > 0 && bin.x0 + bin.x0 - seriesBins[i - 1].x0) || 1 : bin.x1,
+      bin1:
+        bin.x0 === bin.x1
+          ? (i > 0 && bin.x0 + bin.x0 - seriesBins[i - 1].x0) || bin.x1 + 1
+          : bin.x1,
       data: bin,
       count: bin.length,
       id: i.toString(),
     }));
+    console.log(seriesBins, binsByIndex[index]);
   });
 
   return binsByIndex;

--- a/packages/xy-chart/src/enhancer/withTheme.jsx
+++ b/packages/xy-chart/src/enhancer/withTheme.jsx
@@ -13,7 +13,9 @@ function withTheme(theme = defaultTheme) {
     // eslint-disable-next-line react/prefer-stateless-function
     class EnhancedComponent extends React.PureComponent {
       render() {
-        return <WrappedComponent theme={theme} {...this.props} />;
+        const { theme: componentTheme, ...restProps } = this.props;
+
+        return <WrappedComponent {...restProps} theme={{ ...theme, ...componentTheme }} />;
       }
     }
 

--- a/packages/xy-chart/test/enhancer/withTheme.test.js
+++ b/packages/xy-chart/test/enhancer/withTheme.test.js
@@ -30,6 +30,7 @@ describe('HOC', () => {
   });
 
   it('passes the theme prop to the wrapped component', () => {
+    expect.assertions(1);
     const testTheme = { my: 'theme' };
     function MyComponent({ theme }) {
       expect(theme).toBe(testTheme);
@@ -41,6 +42,7 @@ describe('HOC', () => {
   });
 
   it('passes the default theme when no theme is passed', () => {
+    expect.assertions(1);
     function MyComponent({ theme }) {
       expect(theme).toBe(defaultTheme);
 
@@ -50,7 +52,7 @@ describe('HOC', () => {
     shallow(<HOC />).dive();
   });
 
-  it('allows theme to be overridden', () => {
+  it('allows theme keys to be overridden', () => {
     const overrideTheme = { override: 'theme' };
     function MyComponent() {
       return null;
@@ -61,6 +63,6 @@ describe('HOC', () => {
     expect(wrapper.find(MyComponent).prop('theme')).toBe(defaultTheme);
 
     wrapper = shallow(<HOC theme={overrideTheme} />);
-    expect(wrapper.find(MyComponent).prop('theme')).toBe(overrideTheme);
+    expect(wrapper.find(MyComponent).prop('theme').override).toBe(overrideTheme.override);
   });
 });

--- a/packages/xy-chart/test/enhancer/withTheme.test.js
+++ b/packages/xy-chart/test/enhancer/withTheme.test.js
@@ -33,7 +33,7 @@ describe('HOC', () => {
     expect.assertions(1);
     const testTheme = { my: 'theme' };
     function MyComponent({ theme }) {
-      expect(theme).toBe(testTheme);
+      expect(theme).toEqual(expect.objectContaining(testTheme));
 
       return null;
     }
@@ -44,7 +44,7 @@ describe('HOC', () => {
   it('passes the default theme when no theme is passed', () => {
     expect.assertions(1);
     function MyComponent({ theme }) {
-      expect(theme).toBe(defaultTheme);
+      expect(theme).toEqual(expect.objectContaining(defaultTheme));
 
       return null;
     }
@@ -53,16 +53,16 @@ describe('HOC', () => {
   });
 
   it('allows theme keys to be overridden', () => {
-    const overrideTheme = { override: 'theme' };
+    const overrideTheme = { colors: 'my-colors' };
     function MyComponent() {
       return null;
     }
     const HOC = withTheme()(MyComponent);
 
     let wrapper = shallow(<HOC />);
-    expect(wrapper.find(MyComponent).prop('theme')).toBe(defaultTheme);
+    expect(wrapper.find(MyComponent).prop('theme')).toEqual(expect.objectContaining(defaultTheme));
 
     wrapper = shallow(<HOC theme={overrideTheme} />);
-    expect(wrapper.find(MyComponent).prop('theme').override).toBe(overrideTheme.override);
+    expect(wrapper.find(MyComponent).prop('theme')).toEqual(expect.objectContaining(overrideTheme));
   });
 });


### PR DESCRIPTION
🐛 Bug Fix
[xy-chart]
- the `withTheme` HOC would override the passed theme with the empty default theme from `XYChart`. To support overrides, combine the two objects. 

[histogram]
- in the case that there's one un-binned numeric value, enforce a bin length of 1