### PR TITLE
[xy-chart] wrap y-axis label based on height not inner height

### DIFF
--- a/packages/demo/examples/01-xy-chart/BrushableLineChart.jsx
+++ b/packages/demo/examples/01-xy-chart/BrushableLineChart.jsx
@@ -11,7 +11,6 @@ import {
   withScreenSize,
   LineSeries,
   PatternLines,
-  LinearGradient,
   Brush,
 } from '@data-ui/xy-chart';
 
@@ -382,9 +381,9 @@ class BrushableLineChart extends React.PureComponent {
         >
           <PatternLines
             id="brush_pattern"
-            height={8}
-            width={8}
-            stroke={allColors.blue[1]}
+            height={12}
+            width={12}
+            stroke={allColors.blue[2]}
             strokeWidth={1}
             orientation={['diagonal']}
           />
@@ -394,7 +393,7 @@ class BrushableLineChart extends React.PureComponent {
             showHorizontalLine={false}
             fullHeight
             stroke={colors.darkGray}
-            circleFill={colors.categories[2]}
+            circleFill={allColors.blue[7]}
             circleStroke="white"
           />
           <YAxis label="Value" numTicks={5} orientation={yAxisOrientation} />

--- a/packages/xy-chart/src/annotation/VerticalReferenceLine.jsx
+++ b/packages/xy-chart/src/annotation/VerticalReferenceLine.jsx
@@ -23,7 +23,7 @@ export const defaultLabelProps = {
 export const propTypes = {
   label: PropTypes.node,
   labelProps: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
-  reference: PropTypes.number.isRequired,
+  reference: PropTypes.oneOfType([PropTypes.number, PropTypes.object]).isRequired, // number or date/moment object
   stroke: PropTypes.string,
   strokeDasharray: PropTypes.string,
   strokeLinecap: PropTypes.oneOf(['butt', 'square', 'round', 'inherit']),

--- a/packages/xy-chart/src/axis/YAxis.jsx
+++ b/packages/xy-chart/src/axis/YAxis.jsx
@@ -24,6 +24,7 @@ const propTypes = {
 
   // probably injected by parent
   innerWidth: PropTypes.number,
+  height: PropTypes.number,
   scale: PropTypes.func,
 };
 
@@ -31,9 +32,10 @@ const defaultProps = {
   axisStyles: {},
   hideZero: false,
   innerWidth: null,
+  height: null,
   label: null,
   labelProps: null,
-  labelOffset: 0,
+  labelOffset: undefined,
   numTicks: null,
   orientation: 'right',
   rangePadding: null,
@@ -51,6 +53,7 @@ export default class YAxis extends React.PureComponent {
       axisStyles,
       hideZero,
       innerWidth,
+      height,
       label,
       labelProps,
       labelOffset,
@@ -86,7 +89,7 @@ export default class YAxis extends React.PureComponent {
         label={label}
         labelProps={{
           verticalAnchor: 'start',
-          width: Math.max(...scale.range()),
+          width: Math.max(...scale.range(), height || 0),
           ...(labelProps || (axisStyles.label || {})[orientation]),
         }}
         labelOffset={labelOffset}

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -297,6 +297,10 @@ class XYChart extends React.PureComponent {
               const name = componentName(Child);
               if (isAxis(name)) {
                 const styleKey = name[0].toLowerCase();
+                const labelOffset =
+                  typeof Child.props.labelOffset === 'number'
+                    ? Child.props.labelOffset
+                    : (name === 'YAxis' && Y_LABEL_OFFSET * margin[Child.props.orientation]) || 0;
                 if (name === 'XAxis') {
                   xAxisOrientation = Child.props.orientation;
                 } else {
@@ -306,8 +310,9 @@ class XYChart extends React.PureComponent {
                 return React.cloneElement(Child, {
                   innerHeight,
                   innerWidth,
-                  labelOffset:
-                    name === 'YAxis' ? Y_LABEL_OFFSET * margin[Child.props.orientation] : 0,
+                  height,
+                  width,
+                  labelOffset,
                   numTicks: name === 'XAxis' ? numXTicks : numYTicks,
                   scale: name === 'XAxis' ? xScale : yScale,
                   rangePadding: name === 'XAxis' ? xScale.offset : null,

--- a/packages/xy-chart/test/axis/YAxis.test.js
+++ b/packages/xy-chart/test/axis/YAxis.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { AxisLeft, AxisRight } from '@vx/axis';
 import { scaleLinear } from '@vx/scale';
+import { Text } from '@vx/text';
 import { XYChart, YAxis, LineSeries } from '../../src';
 
 describe('<YAxis />', () => {
@@ -103,6 +104,26 @@ describe('<YAxis />', () => {
         .first()
         .text(),
     ).toBe('apple');
+  });
+
+  it('should pass the height prop as labelProps.width for wrapping', () => {
+    const wrapper = shallow(
+      <YAxis
+        scale={scaleLinear({ range: [0, 100], domain: [0, 100] })}
+        innerWidth={100}
+        label="test"
+        height={chartProps.height}
+      />,
+    );
+    expect(
+      wrapper
+        .find(AxisRight)
+        .dive() // Axis
+        .dive() // Group
+        .find(Text)
+        .last() // not ticks
+        .prop('width'),
+    ).toBe(chartProps.height);
   });
 
   it('should use the output of tickFormat() when passed', () => {

--- a/packages/xy-chart/test/chart/XYChart.test.js
+++ b/packages/xy-chart/test/chart/XYChart.test.js
@@ -94,8 +94,46 @@ describe('<XYChart />', () => {
     );
     const series = wrapper.find(LineSeries);
     expect(series).toHaveLength(1);
-    expect(series.prop('xScale')).toBeDefined();
-    expect(series.prop('yScale')).toBeDefined();
+    expect(series.prop('xScale')).toEqual(expect.any(Function));
+    expect(series.prop('yScale')).toEqual(expect.any(Function));
+  });
+
+  it('should pass scales and dimensions to child axes', () => {
+    const wrapper = shallow(
+      <XYChart {...mockProps}>
+        <LineSeries label="label" data={mockData.map(d => ({ ...d, x: d.date, y: d.num }))} />
+        <XAxis />
+        <YAxis />
+      </XYChart>,
+    );
+    const xaxis = wrapper.find(XAxis);
+    const yaxis = wrapper.find(YAxis);
+
+    expect(xaxis.prop('scale')).toEqual(expect.any(Function));
+    expect(yaxis.prop('scale')).toEqual(expect.any(Function));
+
+    expect(xaxis.prop('innerHeight')).toEqual(expect.any(Number));
+    expect(yaxis.prop('innerWidth')).toEqual(expect.any(Number));
+
+    expect(yaxis.prop('height')).toEqual(expect.any(Number));
+  });
+
+  it('should set labelOffset on child YAxis if it is not already set', () => {
+    let wrapper = shallow(
+      <XYChart {...mockProps}>
+        <YAxis />
+      </XYChart>,
+    );
+
+    expect(wrapper.find(YAxis).prop('labelOffset')).toEqual(expect.any(Number));
+
+    wrapper = shallow(
+      <XYChart {...mockProps}>
+        <YAxis labelOffset={-101} />
+      </XYChart>,
+    );
+
+    expect(wrapper.find(YAxis).prop('labelOffset')).toBe(-101);
   });
 
   it('should compute time, linear, and band domains across all child series', () => {


### PR DESCRIPTION
🏆 Enhancements
- Improves y-axis label wrapping logic to use full chart height, not inner height
- Enable setting `labelOffset` on `XAxis` and `YAxis` labels instead of setting a constant `0.7 * margin.left/right` and `0` for `YAxis` and `XAxis` respectively
- Adds tests for these things
