### PR TITLE
[xy-chart][crosshair] support multiple circles

### DIFF
--- a/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
+++ b/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
@@ -2,18 +2,10 @@
 import React from 'react';
 import { timeParse, timeFormat } from 'd3-time-format';
 
-import {
-  XYChart,
-  CrossHair,
-  XAxis,
-  YAxis,
-  theme,
-  withScreenSize,
-  BarSeries,
-  PatternLines,
-} from '@data-ui/xy-chart';
+import { CrossHair, XAxis, YAxis, BarSeries, PatternCircles } from '@data-ui/xy-chart';
 
 import colors, { allColors } from '@data-ui/theme/lib/color';
+import ResponsiveXYChart from './ResponsiveXYChart';
 
 import { timeSeriesData } from './data';
 
@@ -44,7 +36,8 @@ class HorizontalBarChartExample extends React.PureComponent {
     return (
       <div className="bar-demo--form">
         <div>
-          Direction:
+          Bar direction:
+          {'  '}
           <label>
             <input
               type="radio"
@@ -69,51 +62,58 @@ class HorizontalBarChartExample extends React.PureComponent {
   }
 
   render() {
-    const { screenWidth } = this.props;
     const { direction } = this.state;
-    const categoryScale = { type: 'band', paddingInner: 0.15 };
+    const categoryScale = { type: 'band', paddingInner: 0.4 };
     const valueScale = { type: 'linear' };
     const horizontal = direction === 'horizontal';
 
     return (
       <div className="horizontal-bar-demo">
         {this.renderControls()}
-        <XYChart
-          theme={theme}
-          width={Math.min(700, screenWidth / 1.5)}
-          height={Math.min(700 / 2, screenWidth / 1.5 / 2)}
+        <ResponsiveXYChart
           ariaLabel="Required label"
+          eventTrigger="series"
           xScale={horizontal ? valueScale : categoryScale}
           yScale={horizontal ? categoryScale : valueScale}
           margin={{ left: 100, top: 64, bottom: 64 }}
         >
+          <PatternCircles
+            id="horizontal_bar_circles"
+            width={6}
+            height={6}
+            radius={2}
+            fill={allColors.blue[horizontal ? 2 : 8]}
+            strokeWidth={0}
+          />
           <BarSeries
+            fill={allColors.blue[horizontal ? 8 : 2]}
             horizontal={horizontal}
             data={horizontal ? categoryHorizontalData : categoryData}
           />
+          <BarSeries
+            fill="url(#horizontal_bar_circles)"
+            horizontal={horizontal}
+            data={horizontal ? categoryHorizontalData : categoryData}
+            stroke={allColors.blue[8]}
+            strokeWidth={1.5}
+          />
           <CrossHair
-            showHorizontalLine={false}
+            showHorizontalLine={!horizontal}
+            showVerticalLine={horizontal}
             fullHeight
-            stroke={colors.darkGray}
+            fullWidth
+            strokeDasharray=""
+            stroke={allColors.blue[8]}
             circleFill={allColors.blue[7]}
             circleStroke="white"
           />
           <YAxis numTicks={5} orientation="left" />
           <XAxis numTicks={5} />
-        </XYChart>
+        </ResponsiveXYChart>
 
         <style type="text/css">
           {`
-          .horizontal-bar-demo {
-             display: flex;
-             flex-direction: row;
-             flex-wrap: wrap;
-             align-items: center;
-          }
-
           .bar-demo--form > div {
-            display: flex;
-            justify-content: space-between;
             margin-bottom: 8px;
             margin-right: 12px;
           }
@@ -124,4 +124,4 @@ class HorizontalBarChartExample extends React.PureComponent {
   }
 }
 
-export default withScreenSize(HorizontalBarChartExample);
+export default HorizontalBarChartExample;

--- a/packages/demo/examples/shared/Checkbox.jsx
+++ b/packages/demo/examples/shared/Checkbox.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 import Spacer from './Spacer';
 
-export default function Checkbox({ id, label, checked, onChange }) {
+export default function Checkbox({ id, label, checked, onChange, disabled }) {
   return (
     <Spacer>
-      <input id={id} type="checkbox" checked={checked} onChange={onChange} />
+      <input id={id} type="checkbox" checked={checked} onChange={onChange} disabled={disabled} />
       <label style={{ textTransform: 'capitalize' }} htmlFor={id}>
         {label}
       </label>
@@ -19,4 +19,9 @@ Checkbox.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   checked: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+Checkbox.defaultProps = {
+  disabled: false,
 };

--- a/packages/demo/examples/shared/WithToggle.jsx
+++ b/packages/demo/examples/shared/WithToggle.jsx
@@ -8,10 +8,12 @@ const propTypes = {
   children: PropTypes.func.isRequired,
   label: PropTypes.string.isRequired,
   initialChecked: PropTypes.bool,
+  disabled: PropTypes.bool,
 };
 
 const defaultProps = {
   initialChecked: false,
+  disabled: false,
 };
 
 class WithToggle extends React.PureComponent {
@@ -21,7 +23,7 @@ class WithToggle extends React.PureComponent {
   }
 
   render() {
-    const { children, id, label } = this.props;
+    const { children, id, label, disabled } = this.props;
     const { checked } = this.state;
 
     return (
@@ -33,6 +35,7 @@ class WithToggle extends React.PureComponent {
           onChange={() => {
             this.setState({ checked: !checked });
           }}
+          disabled={disabled}
         />
         {children(checked)}
       </div>

--- a/packages/xy-chart/README.md
+++ b/packages/xy-chart/README.md
@@ -1,11 +1,11 @@
 # @data-ui/xy-chart
-A package of charts with standard x- and y- axes.
+A package that supports making charts with x- and y- cartesian coordinates.
 
 <a title="package version" href="https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat-square">
   <img src="https://img.shields.io/npm/v/@data-ui/xy-chart.svg?style=flat-square" />
 </a>
 <p align="center">
-  <img width="600px" src="https://user-images.githubusercontent.com/4496521/29149889-e34d14f6-7d2b-11e7-8f8f-b5021dc8f1b8.gif" />
+  <img width="400px" src="https://user-images.githubusercontent.com/4496521/45108737-4e7a1d00-b0f2-11e8-85db-09361c9b67b1.gif" />
 </p>
 
 See it live at <a href="https://williaster.github.io/data-ui" target="_blank">williaster.github.io/data-ui</a>.
@@ -180,7 +180,7 @@ The result will show the difference between the two `AreaSeries`, with a fill th
   />
   <VerticalReferenceLine
     reference={new Date('2018-01-05')}
-    label="My birthday" 
+    label="My birthday"
     labelProps={{ width: 100, textAnchor: 'start', dx: '0.5em' }}
   />
 </XYChart>
@@ -208,7 +208,7 @@ Under the covers this will wrap the `<XYChart />` component in the exported `<Wi
 
 If you'd like more customizability over tooltip rendering you can do either of the following:
 
-1) Roll your own tooltip positioning logic and pass `onMouseMove` and `onMouseLeave` functions to `XYChart`. These functions are triggered according to the `eventTrigger` prop and are called with the signature described below upon appropriate trigger. Note that you must also pass `tooltipData` to `XYChart` if you are using the `CrossHair` component, which has an expected shape of `{ datum }` containing the datum to emphasize.
+1) Roll your own tooltip positioning logic and pass `onMouseMove` and `onMouseLeave` functions to `XYChart`. These functions are triggered according to the `eventTrigger` prop and are called with the signature described below upon appropriate trigger. Note that you must also pass `tooltipData` to `XYChart` if you are using the `CrossHair` component, which has an expected shape of `{ datum [, series] }` containing the datum(s) to emphasize.
 
 2) Wrap `<XYChart />` with `<WithTooltip />` yourself, which accepts props for additional customization:
 
@@ -235,16 +235,17 @@ Name | Type | Default | Description
 ------------ | ------------- | ------- | ----
 fullHeight | PropTypes.bool | false | whether the vertical line should span the entire height of the chart
 fullWidth | PropTypes.bool | false | whether the horizontal line should span the entire width of the chart
-circleSize | PropTypes.number | 4 | the radius of the circle
-circleFill | PropTypes.string | data-ui/theme.colors.grays[7] | the fill of the circle
-circleStroke | PropTypes.string | white | the stroke of the circle
-circleStyles| PropTypes.object | { pointerEvents: 'none' } | styles passed to the circle
+circleSize | PropTypes.number or func(d,i) => PropTypes.number | 4 | the radius of the circle
+circleFill | PropTypes.string or func(d,i) => PropTypes.string | data-ui/theme.colors.grays[7] | the fill of the circle
+circleStroke | PropTypes.string or func(d,i) => PropTypes.string | white | the stroke of the circle
+circleStyles| PropTypes.object or func(d,i) => PropTypes.object | { pointerEvents: 'none' } | styles passed to the circle
 lineStyles | PropTypes.object | { pointerEvents: 'none' } | styles passed to both horizontal and vertical lines
 showCircle | PropTypes.bool | true | whether to show the circle
+showMultipleCircles | PropTypes.bool | false | whether to show _multiple_ circles when `tooltipData` includes a `series` key (when `XYChart`'s `eventTrigger="container"`)
 showHorizontalLine | PropTypes.bool | true | whether to show the horizontal crosshair line
 showVerticalLine | PropTypes.bool | true | whether to show the vertical crosshair line
-stroke | PropTypes.oneOfType([PropTypes.func, PropTypes.string]) | data-ui/theme.colors.grays[7] | the stroke of both horizontal and vertical lines
-strokeDasharray | PropTypes.oneOfType([PropTypes.func, PropTypes.string]) | `3, 3` | The stroke-dash-array of both horizontal and vertical lines
+stroke | PropTypes.oneOfType([PropTypes.func, PropTypes.string]) | data-ui/theme.colors.grays[6] | the stroke of both horizontal and vertical lines
+strokeDasharray | PropTypes.oneOfType([PropTypes.func, PropTypes.string]) | `5,2` | The stroke-dash-array of both horizontal and vertical lines
 strokeWidth | PropTypes.oneOfType([PropTypes.func, PropTypes.number]) | 1 | The strokeWidth of both horizontal and vertical lines
 
 

--- a/packages/xy-chart/src/chart/CrossHair.jsx
+++ b/packages/xy-chart/src/chart/CrossHair.jsx
@@ -6,15 +6,21 @@ import { color } from '@data-ui/theme';
 import { Group } from '@vx/group';
 import { Line } from '@vx/shape';
 
+import { callOrValue, isDefined } from '../utils/chartUtils';
+
 const propTypes = {
   fullHeight: PropTypes.bool,
   fullWidth: PropTypes.bool,
-  circleSize: PropTypes.number,
-  circleFill: PropTypes.string,
-  circleStroke: PropTypes.string,
-  circleStyles: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  circleSize: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
+  circleFill: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  circleStroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  circleStyles: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  ]),
   lineStyles: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
   showCircle: PropTypes.bool,
+  showMultipleCircles: PropTypes.bool,
   showHorizontalLine: PropTypes.bool,
   showVerticalLine: PropTypes.bool,
   stroke: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
@@ -22,27 +28,32 @@ const propTypes = {
   strokeWidth: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
 
   // likely injected by parent
-  left: PropTypes.number,
-  top: PropTypes.number,
+  datum: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+  series: PropTypes.objectOf(PropTypes.object),
+  getScaledX: PropTypes.func,
+  getScaledY: PropTypes.func,
   xScale: PropTypes.func,
   yScale: PropTypes.func,
 };
 
 const defaultProps = {
-  left: 0,
-  top: 0,
   circleSize: 4,
   circleFill: color.grays[7],
   circleStroke: '#ffffff',
   circleStyles: {
     pointerEvents: 'none',
   },
+  datum: {},
+  getScaledX: null,
+  getScaledY: null,
   lineStyles: {
     pointerEvents: 'none',
   },
   fullHeight: false,
   fullWidth: false,
+  series: {},
   showCircle: true,
+  showMultipleCircles: false,
   showHorizontalLine: true,
   showVerticalLine: true,
   stroke: color.grays[7],
@@ -53,35 +64,46 @@ const defaultProps = {
 };
 
 function CrossHair({
-  left,
-  top,
   circleFill,
   circleSize,
   circleStroke,
   circleStyles,
+  datum,
+  getScaledX,
+  getScaledY,
   fullHeight,
   fullWidth,
+  lineStyles,
+  series,
   showHorizontalLine,
   showCircle,
+  showMultipleCircles,
   showVerticalLine,
   stroke,
   strokeDasharray,
   strokeWidth,
   xScale,
   yScale,
-  lineStyles,
 }) {
-  if (!xScale || !yScale) return null;
+  if (!xScale || !yScale || !getScaledX || !getScaledY) return null;
   const [xMin, xMax] = extent(xScale.range());
   const [yMin, yMax] = extent(yScale.range());
+
+  const circleData =
+    showMultipleCircles && Object.keys(series).length > 0
+      ? Object.keys(series).map(seriesKey => ({ seriesKey, ...series[seriesKey] }))
+      : [datum];
+
+  const circlePositions = circleData.map(d => ({ x: getScaledX(d), y: getScaledY(d) }));
 
   return (
     <Group>
       {showHorizontalLine &&
-        top !== null && (
+        !showMultipleCircles &&
+        isDefined(circlePositions[0].y) && (
           <Line
-            from={{ x: xMin, y: top }}
-            to={{ x: fullWidth || left === null ? xMax : left, y: top }}
+            from={{ x: xMin, y: circlePositions[0].y }}
+            to={{ x: fullWidth ? xMax : circlePositions[0].x, y: circlePositions[0].y }}
             style={lineStyles}
             stroke={stroke}
             strokeDasharray={strokeDasharray}
@@ -89,29 +111,37 @@ function CrossHair({
           />
         )}
       {showVerticalLine &&
-        top !== null && (
+        isDefined(circlePositions[0].x) && (
           <Line
-            from={{ x: left, y: yMax }}
-            to={{ x: left, y: top === null || fullHeight ? yMin : top }}
+            from={{ x: circlePositions[0].x, y: yMax }}
+            to={{ x: circlePositions[0].x, y: fullHeight ? yMin : circlePositions[0].y }}
             style={lineStyles}
             stroke={stroke}
             strokeDasharray={strokeDasharray}
             strokeWidth={strokeWidth}
           />
         )}
-      {showCircle &&
-        top !== null &&
-        left !== null && (
-          <circle
-            cx={left}
-            cy={top}
-            r={circleSize}
-            fill={circleFill}
-            stroke={circleStroke}
-            strokeWidth={1}
-            style={circleStyles}
-          />
-        )}
+
+      {(showCircle || showMultipleCircles) &&
+        circleData.map((d, i) => {
+          const { x, y } = circlePositions[i];
+
+          return (
+            isDefined(x) &&
+            isDefined(y) && (
+              <circle
+                key={`circle-${d.seriesKey || i}`}
+                cx={x}
+                cy={y}
+                r={callOrValue(circleSize, d, i)}
+                fill={callOrValue(circleFill, d, i)}
+                strokeWidth={1}
+                stroke={callOrValue(circleStroke, d, i)}
+                style={callOrValue(circleStyles, d, i)}
+              />
+            )
+          );
+        })}
     </Group>
   );
 }

--- a/packages/xy-chart/src/chart/CrossHair.jsx
+++ b/packages/xy-chart/src/chart/CrossHair.jsx
@@ -56,8 +56,8 @@ const defaultProps = {
   showMultipleCircles: false,
   showHorizontalLine: true,
   showVerticalLine: true,
-  stroke: color.grays[7],
-  strokeDasharray: '3,3',
+  stroke: color.grays[6],
+  strokeDasharray: '5,2',
   strokeWidth: 1,
   xScale: null,
   yScale: null,
@@ -90,7 +90,7 @@ function CrossHair({
   const [yMin, yMax] = extent(yScale.range());
 
   const circleData =
-    showMultipleCircles && Object.keys(series).length > 0
+    showMultipleCircles && series && Object.keys(series).length > 0
       ? Object.keys(series).map(seriesKey => ({ seriesKey, ...series[seriesKey] }))
       : [datum];
 

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -402,12 +402,12 @@ class XYChart extends React.PureComponent {
               CrossHairs.map((CrossHair, i) =>
                 React.cloneElement(CrossHair, {
                   key: `crosshair-${i}`, // eslint-disable-line react/no-array-index-key
-                  left:
-                    xScale(getX(tooltipData.datum) || 0) +
-                    (xScale.bandwidth ? xScale.bandwidth() / 2 : 0),
-                  top:
-                    yScale(getY(tooltipData.datum) || 0) +
-                    (yScale.bandwidth ? yScale.bandwidth() / 2 : 0),
+                  datum: tooltipData.datum,
+                  series: tooltipData.series,
+                  getScaledX: d =>
+                    xScale(getX(d) || 0) + (xScale.bandwidth ? xScale.bandwidth() / 2 : 0),
+                  getScaledY: d =>
+                    yScale(getY(d) || 0) + (yScale.bandwidth ? yScale.bandwidth() / 2 : 0),
                   xScale,
                   yScale,
                 }),

--- a/packages/xy-chart/test/chart/CrossHair.test.js
+++ b/packages/xy-chart/test/chart/CrossHair.test.js
@@ -6,50 +6,55 @@ import { scaleLinear } from '@vx/scale';
 import { CrossHair } from '../../src';
 
 describe('<CrossHair />', () => {
+  const xScaleProp = scaleLinear({
+    domain: [0, 100],
+    range: [0, 100],
+  });
+
+  const yScaleProp = scaleLinear({
+    domain: [0, 100],
+    range: [100, 0],
+  });
+
   const props = {
-    top: 20,
-    left: 70,
-    xScale: scaleLinear({
-      domain: [0, 100],
-      range: [0, 100],
-    }),
-    yScale: scaleLinear({
-      domain: [0, 100],
-      range: [100, 0],
-    }),
+    datum: { x: 10, y: 33 },
+    series: { seriesA: { x: 10, y: 33 }, seriesB: { x: 10, y: 1 }, seriesC: { x: 10, y: 99 } },
+    xScale: xScaleProp,
+    yScale: yScaleProp,
+    getScaledX: d => xScaleProp(d.x),
+    getScaledY: d => yScaleProp(d.y),
   };
 
   it('should be defined', () => {
     expect(CrossHair).toBeDefined();
   });
 
-  it('should render a horizontal line, vertical line, and a circle depending on props', () => {
-    let wrapper = shallow(<CrossHair {...props} showHorizontalLine showVerticalLine showCircle />);
+  it('should render a horizontal and vertical lines as specified', () => {
+    const horiz = shallow(<CrossHair {...props} showHorizontalLine showVerticalLine={false} />);
+    const vert = shallow(<CrossHair {...props} showHorizontalLine={false} showVerticalLine />);
+    const both = shallow(<CrossHair {...props} showHorizontalLine showVerticalLine />);
 
-    expect(wrapper.find(Line)).toHaveLength(2);
-    expect(wrapper.find('circle')).toHaveLength(1);
+    expect(horiz.find(Line)).toHaveLength(1);
+    expect(vert.find(Line)).toHaveLength(1);
+    expect(both.find(Line)).toHaveLength(2);
+  });
 
-    wrapper = shallow(<CrossHair {...props} showHorizontalLine showVerticalLine={false} />);
+  it('should render one or more circles depending on props', () => {
+    const zero = shallow(<CrossHair {...props} showCircle={false} />);
+    const one = shallow(<CrossHair {...props} showCircle />);
+    const multi = shallow(<CrossHair {...props} showMultipleCircles />);
 
-    expect(wrapper.find(Line)).toHaveLength(1);
-    expect(wrapper.find('circle')).toHaveLength(1);
-
-    wrapper = shallow(
-      <CrossHair {...props} showHorizontalLine={false} showVerticalLine showCircle={false} />,
-    );
-
-    expect(wrapper.find(Line)).toHaveLength(1);
-    expect(wrapper.find('circle')).toHaveLength(0);
-
-    wrapper = shallow(<CrossHair {...props} showHorizontalLine={false} showVerticalLine={false} />);
-    expect(wrapper.find(Line)).toHaveLength(0);
+    const { series } = props;
+    expect(zero.find('circle')).toHaveLength(0);
+    expect(one.find('circle')).toHaveLength(1);
+    expect(multi.find('circle')).toHaveLength(Object.keys(series).length);
   });
 
   it('should render a fullWidth line if specified', () => {
     const fullWidthWrapper = shallow(
       <CrossHair {...props} showHorizontalLine fullWidth showVerticalLine={false} />,
     );
-    const { xScale, left } = props;
+    const { xScale, datum } = props;
     const fullWidthLine = fullWidthWrapper.find(Line).dive();
     expect(fullWidthLine.prop('x1')).toBe(Math.min(...xScale.range()));
     expect(fullWidthLine.prop('x2')).toBe(Math.max(...xScale.range()));
@@ -60,14 +65,14 @@ describe('<CrossHair />', () => {
 
     const partialWidthLine = partialWidthWrapper.find(Line).dive();
     expect(partialWidthLine.prop('x1')).toBe(Math.min(...xScale.range()));
-    expect(partialWidthLine.prop('x2')).toBe(left);
+    expect(partialWidthLine.prop('x2')).toBe(datum.x);
   });
 
   it('should render a fullHeight line if specified', () => {
     const fullHeightWrapper = shallow(
       <CrossHair {...props} showVerticalLine fullHeight showHorizontalLine={false} />,
     );
-    const { yScale, top } = props;
+    const { yScale, datum } = props;
     const fullHeightLine = fullHeightWrapper.find(Line).dive();
     expect(fullHeightLine.prop('y1')).toBe(Math.max(...yScale.range()));
     expect(fullHeightLine.prop('y2')).toBe(Math.min(...yScale.range()));
@@ -78,6 +83,6 @@ describe('<CrossHair />', () => {
 
     const partialHeightLine = partialHeightWrapper.find(Line).dive();
     expect(partialHeightLine.prop('y1')).toBe(Math.max(...yScale.range()));
-    expect(partialHeightLine.prop('y2')).toBe(top);
+    expect(partialHeightLine.prop('y2')).toBe(yScale(datum.y));
   });
 });

--- a/packages/xy-chart/test/chart/CrossHair.test.js
+++ b/packages/xy-chart/test/chart/CrossHair.test.js
@@ -43,11 +43,20 @@ describe('<CrossHair />', () => {
     const zero = shallow(<CrossHair {...props} showCircle={false} />);
     const one = shallow(<CrossHair {...props} showCircle />);
     const multi = shallow(<CrossHair {...props} showMultipleCircles />);
+    const multi2 = shallow(<CrossHair {...props} showMultipleCircles showCircle={false} />);
 
     const { series } = props;
     expect(zero.find('circle')).toHaveLength(0);
     expect(one.find('circle')).toHaveLength(1);
     expect(multi.find('circle')).toHaveLength(Object.keys(series).length);
+    expect(multi2.find('circle')).toHaveLength(Object.keys(series).length);
+  });
+
+  it('should not render multiple circles without the `series` prop', () => {
+    const noSeriesProps = { ...props, series: null };
+    const one = shallow(<CrossHair {...noSeriesProps} showMultipleCircles />);
+
+    expect(one.find('circle')).toHaveLength(1);
   });
 
   it('should render a fullWidth line if specified', () => {


### PR DESCRIPTION
🏆 Enhancements
This PR adds support for rendering  multiple circles on the `XYChart` `Crosshair` component when `XYChart`'s `eventTrigger='container'` (which passes `series` to support multiple circles). You can set styles per-circle as shown in the example:

![multi-circle-crosshair](https://user-images.githubusercontent.com/4496521/44999186-3da19e00-af70-11e8-8b49-1ac8ad179513.gif)

TODO
- [ ] documentation
- [ ] more tests around `series` prop