### PR TITLE
[build] @data-ui/build-config@^0.0.12, use codecov not coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: node_js
+
 node_js:
   - '10.7'
+
 cache:
   directories:
     - node_modules
+
 env:
   - PACKAGE=xy-chart
   - PACKAGE=sparkline
@@ -14,7 +17,12 @@ env:
   - PACKAGE=forms
   - PACKAGE=network
   - PACKAGE=shared
+
+install:
+  - npm install -g codecov
+
 script:
   - 'cd ./packages/$PACKAGE && npm install && npm prune && npm run test'
+
 after_script:
-  - 'cat ./packages/$PACKAGE/coverage/lcov.info | ./node_modules/.bin/coveralls'
+  - 'codecov'

--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -38,7 +38,7 @@
     "react-virtualized": "^9.7.3"
   },
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "react": "^16.0.0"
   },
   "peerDependencies": {

--- a/packages/data-ui-theme/package.json
+++ b/packages/data-ui-theme/package.json
@@ -34,7 +34,7 @@
     "babel-runtime": "^6.26.0"
   },
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8"
+    "@data-ui/build-config": "^0.0.12"
   },
   "beemo": {
     "module": "@data-ui/build-config",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "@data-ui/data-table": "^0.0.61",
     "@data-ui/event-flow": "^0.0.63",
     "@data-ui/forms": "^0.0.61",

--- a/packages/event-flow/package.json
+++ b/packages/event-flow/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-jest": "^23.4.0",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -26,7 +26,7 @@
     "react-select": "^1.0.0-rc.5"
   },
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "aphrodite": "^1.2.0",
     "babel-core": "^6.24.1",
     "babel-jest": "^23.4.0",

--- a/packages/histogram/package.json
+++ b/packages/histogram/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/radial-chart/package.json
+++ b/packages/radial-chart/package.json
@@ -44,7 +44,7 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/sparkline/package.json
+++ b/packages/sparkline/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -58,7 +58,7 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.8",
+    "@data-ui/build-config": "^0.0.12",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "watch": "^1.0.2"


### PR DESCRIPTION
🏠 Internal
- bump to `@data-ui/build-config@^0.0.12` which fixes a coverage collection issue
-  use `codecov` not `coveralls`