### PR TITLE
[xy-chart][reference lines] support number, string, and object types

### DIFF
--- a/packages/xy-chart/src/annotation/HorizontalReferenceLine.jsx
+++ b/packages/xy-chart/src/annotation/HorizontalReferenceLine.jsx
@@ -23,7 +23,7 @@ export const defaultLabelProps = {
 export const propTypes = {
   label: PropTypes.node,
   labelProps: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
-  reference: PropTypes.number.isRequired,
+  reference: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object]).isRequired,
   stroke: PropTypes.string,
   strokeDasharray: PropTypes.string,
   strokeLinecap: PropTypes.oneOf(['butt', 'square', 'round', 'inherit']),

--- a/packages/xy-chart/src/annotation/VerticalReferenceLine.jsx
+++ b/packages/xy-chart/src/annotation/VerticalReferenceLine.jsx
@@ -23,7 +23,7 @@ export const defaultLabelProps = {
 export const propTypes = {
   label: PropTypes.node,
   labelProps: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
-  reference: PropTypes.oneOfType([PropTypes.number, PropTypes.object]).isRequired, // number or date/moment object
+  reference: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object]).isRequired,
   stroke: PropTypes.string,
   strokeDasharray: PropTypes.string,
   strokeLinecap: PropTypes.oneOf(['butt', 'square', 'round', 'inherit']),


### PR DESCRIPTION
🐛 Bug Fix
- [xy-chart][reference lines] consistently support number, string, and object type `reference` props