### PR TITLE
🐛[xy-chart] fix top/left tooltip offset

### DIFF
--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -10,8 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
+    "build:cjs": "beemo babel ./src --out-dir lib/ --react",
+    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm",
     "build": "npm run build:cjs && npm run build:esm",
     "jest": "beemo jest --react --color --coverage",
     "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,json,md}\"",

--- a/packages/data-ui-theme/package.json
+++ b/packages/data-ui-theme/package.json
@@ -10,8 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --esm --minify",
+    "build:cjs": "beemo babel ./src --out-dir lib/",
+    "build:esm": "beemo babel ./src --out-dir esm/ --esm",
     "build": "npm run build:cjs && npm run build:esm",
     "jest": "beemo jest --color --coverage",
     "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,json,md}\"",

--- a/packages/histogram/package.json
+++ b/packages/histogram/package.json
@@ -10,8 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
+    "build:cjs": "beemo babel ./src --out-dir lib/ --react",
+    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm",
     "build": "npm run build:cjs && npm run build:esm",
     "dev": "beemo babel --watch ./src --out-dir esm/ --react --esm",
     "jest": "beemo jest --react --color --coverage",

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -10,8 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
+    "build:cjs": "beemo babel ./src --out-dir lib/ --react",
+    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm",
     "build": "npm run build:cjs && npm run build:esm",
     "jest": "beemo jest --react --color --coverage",
     "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,json,md}\"",

--- a/packages/radial-chart/package.json
+++ b/packages/radial-chart/package.json
@@ -10,8 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
+    "build:cjs": "beemo babel ./src --out-dir lib/ --react",
+    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm",
     "build": "npm run build:cjs && npm run build:esm",
     "jest": "beemo jest --react --color --coverage",
     "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,json,md}\"",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,8 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
+    "build:cjs": "beemo babel ./src --out-dir lib/ --react",
+    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm",
     "build": "npm run build:cjs && npm run build:esm",
     "jest": "beemo jest --react --color --coverage",
     "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,json,md}\"",

--- a/packages/shared/src/enhancer/WithTooltip.jsx
+++ b/packages/shared/src/enhancer/WithTooltip.jsx
@@ -122,7 +122,7 @@ class WithTooltip extends React.PureComponent {
           ? children(childProps)
           : React.cloneElement(React.Children.only(children), childProps)}
 
-        {Boolean(tooltipContent) && (
+        {!!tooltipContent && (
           <TooltipComponent
             key={Math.random()}
             top={tooltipTop}

--- a/packages/sparkline/package.json
+++ b/packages/sparkline/package.json
@@ -13,6 +13,7 @@
     "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
     "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
     "build": "npm run build:cjs && npm run build:esm",
+    "dev": "beemo babel --watch ./src --out-dir esm/ --react --esm",
     "jest": "beemo jest --react --color --coverage",
     "eslint": "beemo eslint \"./{src,test}/**/*.{js,jsx,json,md}\"",
     "lint": "npm run prettier && npm run eslint",

--- a/packages/sparkline/package.json
+++ b/packages/sparkline/package.json
@@ -10,8 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
+    "build:cjs": "beemo babel ./src --out-dir lib/ --react",
+    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm",
     "build": "npm run build:cjs && npm run build:esm",
     "dev": "beemo babel --watch ./src --out-dir esm/ --react --esm",
     "jest": "beemo jest --react --color --coverage",

--- a/packages/sparkline/src/chart/Sparkline.jsx
+++ b/packages/sparkline/src/chart/Sparkline.jsx
@@ -151,6 +151,7 @@ class Sparkline extends React.PureComponent {
       data,
       getX,
       getY,
+      margin,
     };
 
     return (

--- a/packages/sparkline/src/series/LineSeries.jsx
+++ b/packages/sparkline/src/series/LineSeries.jsx
@@ -29,6 +29,12 @@ export const propTypes = {
   getY: PropTypes.func,
   xScale: PropTypes.func,
   yScale: PropTypes.func,
+  margin: PropTypes.shape({
+    top: PropTypes.number,
+    right: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+  }),
 };
 
 export const defaultProps = {
@@ -48,6 +54,7 @@ export const defaultProps = {
   strokeLinecap: 'round',
   xScale: null,
   yScale: null,
+  margin: {},
 };
 
 const CURVE_LOOKUP = {
@@ -76,7 +83,9 @@ class LineSeries extends React.PureComponent {
       strokeLinecap,
       xScale,
       yScale,
+      margin,
     } = this.props;
+
     if (!xScale || !yScale || !getX || !getY || !data.length) return null;
     const curveFunc = CURVE_LOOKUP[curve];
 
@@ -85,7 +94,13 @@ class LineSeries extends React.PureComponent {
         onMouseMove={
           onMouseMove &&
           (event => {
-            const { datum, index } = findClosestDatum({ data, getX, event, xScale });
+            const { datum, index } = findClosestDatum({
+              data,
+              getX,
+              event,
+              xScale,
+              marginLeft: margin.left,
+            });
             onMouseMove({ event, data, datum, index, color: fill });
           })
         }

--- a/packages/sparkline/src/utils/findClosestDatum.js
+++ b/packages/sparkline/src/utils/findClosestDatum.js
@@ -1,12 +1,12 @@
 import { bisector } from 'd3-array';
 import localPoint from '@vx/event/build/localPoint';
 
-export default function findClosestDatum({ data, getX, xScale, event }) {
+export default function findClosestDatum({ data, getX, xScale, event, marginLeft = 0 }) {
   if (!event || !event.target || !event.target.ownerSVGElement) return {};
   const bisect = bisector(getX).right;
-  // if the g element has a transform we need to be in g coords not svg coords
-  const gElement = event.target.ownerSVGElement.firstChild;
-  const { x } = localPoint(gElement, event);
+
+  const svgCoords = localPoint(event.target.ownerSVGElement, event);
+  const x = svgCoords.x - marginLeft;
   const dataX = xScale.invert(x);
   const index = bisect(data, dataX, 1);
   const d0 = data[index - 1];

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -10,8 +10,8 @@
     "lib"
   ],
   "scripts": {
-    "build:cjs": "beemo babel ./src --out-dir lib/ --react --minify",
-    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm --minify",
+    "build:cjs": "beemo babel ./src --out-dir lib/ --react",
+    "build:esm": "beemo babel ./src --out-dir esm/ --react --esm",
     "build": "npm run build:cjs && npm run build:esm",
     "dev": "beemo babel --watch ./src --out-dir esm/ --react --esm",
     "jest": "beemo jest --react --color --coverage",

--- a/packages/xy-chart/src/chart/CrossHair.jsx
+++ b/packages/xy-chart/src/chart/CrossHair.jsx
@@ -8,6 +8,8 @@ import { Line } from '@vx/shape';
 
 import { callOrValue, isDefined } from '../utils/chartUtils';
 
+const GROUP_STYLE = { pointerEvents: 'none' };
+
 const propTypes = {
   fullHeight: PropTypes.bool,
   fullWidth: PropTypes.bool,
@@ -97,7 +99,7 @@ function CrossHair({
   const circlePositions = circleData.map(d => ({ x: getScaledX(d), y: getScaledY(d) }));
 
   return (
-    <Group>
+    <Group style={GROUP_STYLE}>
       {showHorizontalLine &&
         !showMultipleCircles &&
         isDefined(circlePositions[0].y) && (

--- a/packages/xy-chart/src/chart/Voronoi.jsx
+++ b/packages/xy-chart/src/chart/Voronoi.jsx
@@ -27,6 +27,12 @@ const defaultProps = {
 };
 
 class Voronoi extends React.PureComponent {
+  static getVoronoi(props) {
+    const { x, y, data, width, height } = props;
+
+    return voronoiLayout({ x, y, width, height })(data);
+  }
+
   constructor(props) {
     super(props);
     this.state = { voronoi: Voronoi.getVoronoi(props) };
@@ -40,12 +46,6 @@ class Voronoi extends React.PureComponent {
     ) {
       this.setState({ voronoi: Voronoi.getVoronoi(nextProps) });
     }
-  }
-
-  static getVoronoi(props) {
-    const { x, y, data, width, height } = props;
-
-    return voronoiLayout({ x, y, width, height })(data);
   }
 
   render() {

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -170,7 +170,7 @@ class XYChart extends React.PureComponent {
   }
 
   handleContainerEvent(event) {
-    const { xScale, yScale } = this.state;
+    const { xScale, yScale, margin } = this.state;
     const { children } = this.props;
     const { closestDatum, series } = findClosestDatums({
       children,
@@ -179,6 +179,7 @@ class XYChart extends React.PureComponent {
       getY,
       xScale,
       yScale,
+      margin,
     });
     if (closestDatum || Object.keys(series).length > 0) {
       event.persist();
@@ -328,6 +329,7 @@ class XYChart extends React.PureComponent {
                 return React.cloneElement(Child, {
                   xScale,
                   yScale,
+                  margin,
                   onClick:
                     Child.props.onClick ||
                     (Child.props.disableMouseEvents ? undefined : this.handleClick),

--- a/packages/xy-chart/src/selection/Brush.jsx
+++ b/packages/xy-chart/src/selection/Brush.jsx
@@ -39,16 +39,6 @@ export const propTypes = {
   xAxisOrientation: PropTypes.oneOf(['top', 'bottom']),
   disableDraggingSelection: PropTypes.bool,
   handleSize: PropTypes.number,
-  enabledRegion: PropTypes.shape({
-    start: PropTypes.shape({
-      x: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-      y: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    }),
-    end: PropTypes.shape({
-      x: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-      y: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
-    }),
-  }),
 };
 
 const defaultProps = {
@@ -82,7 +72,6 @@ const defaultProps = {
   onMouseMove: null,
   onMouseLeave: null,
   onClick: null,
-  enabledRegion: null,
 };
 
 class Brush extends React.Component {
@@ -176,7 +165,6 @@ class Brush extends React.Component {
       onMouseMove,
       onClick,
       handleSize,
-      enabledRegion,
     } = this.props;
     if (!xScale || !yScale) return null;
 

--- a/packages/xy-chart/src/series/AreaSeries.jsx
+++ b/packages/xy-chart/src/series/AreaSeries.jsx
@@ -48,6 +48,7 @@ export default class AreaSeries extends React.PureComponent {
       disableMouseEvents,
       xScale,
       yScale,
+      margin,
       stroke,
       strokeWidth,
       strokeDasharray,
@@ -80,7 +81,13 @@ export default class AreaSeries extends React.PureComponent {
             ? null
             : onClick &&
               (event => {
-                const d = findClosestDatum({ data, getX: x, event, xScale });
+                const d = findClosestDatum({
+                  data,
+                  getX: x,
+                  event,
+                  xScale,
+                  marginLeft: margin.left,
+                });
                 onClick({ event, data, datum: d, color: fillValue });
               })
         }
@@ -89,7 +96,13 @@ export default class AreaSeries extends React.PureComponent {
             ? null
             : onMouseMove &&
               (event => {
-                const d = findClosestDatum({ data, getX: x, event, xScale });
+                const d = findClosestDatum({
+                  data,
+                  getX: x,
+                  event,
+                  xScale,
+                  marginLeft: margin.left,
+                });
                 onMouseMove({ event, data, datum: d, color: fillValue });
               })
         }

--- a/packages/xy-chart/src/series/LineSeries.jsx
+++ b/packages/xy-chart/src/series/LineSeries.jsx
@@ -52,6 +52,7 @@ export default class LineSeries extends React.PureComponent {
       strokeOpacity,
       xScale,
       yScale,
+      margin,
       onClick,
       onMouseMove,
       onMouseLeave,
@@ -81,7 +82,13 @@ export default class LineSeries extends React.PureComponent {
             ? null
             : onClick &&
               (() => event => {
-                const d = findClosestDatum({ data, getX: x, event, xScale });
+                const d = findClosestDatum({
+                  data,
+                  getX: x,
+                  event,
+                  xScale,
+                  marginLeft: margin.left,
+                });
                 onClick({ event, data, datum: d, color: strokeValue });
               })
         }
@@ -90,7 +97,13 @@ export default class LineSeries extends React.PureComponent {
             ? null
             : onMouseMove &&
               (() => event => {
-                const d = findClosestDatum({ data, getX: x, event, xScale });
+                const d = findClosestDatum({
+                  data,
+                  getX: x,
+                  event,
+                  xScale,
+                  marginLeft: margin.left,
+                });
                 onMouseMove({ event, data, datum: d, color: strokeValue });
               })
         }

--- a/packages/xy-chart/src/series/StackedAreaSeries.jsx
+++ b/packages/xy-chart/src/series/StackedAreaSeries.jsx
@@ -43,6 +43,7 @@ export default class StackedAreaSeries extends React.PureComponent {
       disableMouseEvents,
       xScale,
       yScale,
+      margin,
       stackKeys,
       stackFills,
       fillOpacity,
@@ -79,6 +80,7 @@ export default class StackedAreaSeries extends React.PureComponent {
                     getX: d => x(d.data),
                     event,
                     xScale,
+                    marginLeft: margin.left,
                   });
                   onClick({
                     event,
@@ -99,6 +101,7 @@ export default class StackedAreaSeries extends React.PureComponent {
                     getX: d => x(d.data),
                     event,
                     xScale,
+                    marginLeft: margin.left,
                   });
                   onMouseMove({
                     event,

--- a/packages/xy-chart/src/utils/findClosestDatum.js
+++ b/packages/xy-chart/src/utils/findClosestDatum.js
@@ -1,13 +1,13 @@
 import { bisector, bisectLeft as d3BisectLeft } from 'd3-array';
 import localPoint from '@vx/event/build/localPoint';
 
-export default function findClosestDatum({ data, getX, xScale, event }) {
+export default function findClosestDatum({ data, getX, xScale, event, marginLeft = 0 }) {
   if (!event || !event.target || !event.target.ownerSVGElement) return null;
   const bisect = bisector(getX).left;
 
   // if the g element has a transform we need to be in g coords not svg coords
-  const gElement = event.target.ownerSVGElement.firstChild;
-  const { x: mouseX } = localPoint(gElement, event);
+  const svgCoords = localPoint(event.target.ownerSVGElement, event);
+  const mouseX = svgCoords.x - marginLeft;
 
   const isOrdinalScale = typeof xScale.invert !== 'function';
   let d;

--- a/packages/xy-chart/src/utils/findClosestDatums.js
+++ b/packages/xy-chart/src/utils/findClosestDatums.js
@@ -10,6 +10,7 @@ export default function findClosestDatums({
   children,
   xScale,
   yScale,
+  margin = {},
   getX,
   getY,
   event,
@@ -18,8 +19,11 @@ export default function findClosestDatums({
   if (!event || !event.target || !event.target.ownerSVGElement) return null;
   const series = {};
 
-  const gElement = event.target.ownerSVGElement.firstChild;
-  const { x: mouseX, y: mouseY } = localPoint(gElement, event);
+  const gElement = event.target.ownerSVGElement;
+  const { x: svgMouseX, y: svgMouseY } = localPoint(gElement, event);
+  const mouseX = svgMouseX - (margin.left || 0);
+  const mouseY = svgMouseY - (margin.top || 0);
+
   let closestDatum;
   let minDeltaX = Infinity;
   let minDeltaY = Infinity;
@@ -47,6 +51,7 @@ export default function findClosestDatums({
         getX,
         xScale,
         event,
+        marginLeft: margin.left,
       });
 
       const deltaX = Math.abs(xScale(getX(datum || {})) - mouseX);

--- a/packages/xy-chart/src/utils/propShapes.js
+++ b/packages/xy-chart/src/utils/propShapes.js
@@ -1,6 +1,13 @@
 import PropTypes from 'prop-types';
 import interpolatorLookup from './interpolatorLookup';
 
+const stringNumberDateObjectPropType = PropTypes.oneOfType([
+  PropTypes.string,
+  PropTypes.number,
+  PropTypes.instanceOf(Date),
+  PropTypes.object, // eg a moment() instance
+]);
+
 export const scaleShape = PropTypes.shape({
   type: PropTypes.oneOf(['time', 'timeUtc', 'linear', 'band']).isRequired,
 
@@ -15,13 +22,7 @@ export const scaleShape = PropTypes.shape({
 
 export const boxPlotSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
-    x: PropTypes.oneOfType([
-      // data with null x/y are not rendered
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-      PropTypes.object, // eg a moment() instance
-    ]),
+    x: stringNumberDateObjectPropType,
     median: PropTypes.number.isRequired,
     min: PropTypes.number.isRequired,
     max: PropTypes.number.isRequired,
@@ -33,39 +34,21 @@ export const boxPlotSeriesDataShape = PropTypes.arrayOf(
 
 export const violinPlotSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
-    x: PropTypes.oneOfType([
-      // data with null x/y are not rendered
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-      PropTypes.object, // eg a moment() instance
-    ]),
+    x: stringNumberDateObjectPropType,
     binData: PropTypes.array.isRequired,
   }),
 );
 
 export const lineSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
-    x: PropTypes.oneOfType([
-      // data with null x/y are not rendered
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-      PropTypes.object, // eg a moment() instance
-    ]),
+    x: stringNumberDateObjectPropType,
     y: PropTypes.number, // null data are not rendered
   }),
 );
 
 export const areaSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
-    x: PropTypes.oneOfType([
-      // data with null x/y are not rendered
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-      PropTypes.object, // eg a moment() instance
-    ]),
+    x: stringNumberDateObjectPropType,
     y: PropTypes.number, // null data are not rendered
     y0: PropTypes.number,
     y1: PropTypes.number,
@@ -74,12 +57,7 @@ export const areaSeriesDataShape = PropTypes.arrayOf(
 
 export const barSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
-    x: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-      PropTypes.object, // eg a moment() instance
-    ]).isRequired,
+    x: stringNumberDateObjectPropType,
     y: PropTypes.number, // null data are not rendered
     fill: PropTypes.string,
     stroke: PropTypes.string,
@@ -109,13 +87,7 @@ export const stackedBarSeriesDataShape = PropTypes.arrayOf(
 
 export const pointSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
-    x: PropTypes.oneOfType([
-      // data with null x/y are not rendered
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-      PropTypes.object, // eg a moment() instance
-    ]),
+    x: stringNumberDateObjectPropType,
     y: PropTypes.number,
     size: PropTypes.number,
     fill: PropTypes.string,
@@ -127,18 +99,8 @@ export const pointSeriesDataShape = PropTypes.arrayOf(
 
 export const intervalSeriesDataShape = PropTypes.arrayOf(
   PropTypes.shape({
-    x0: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-      PropTypes.object, // eg a moment() instance
-    ]).isRequired,
-    x1: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number,
-      PropTypes.instanceOf(Date),
-      PropTypes.object, // eg a moment() instance
-    ]).isRequired,
+    x0: stringNumberDateObjectPropType,
+    x1: stringNumberDateObjectPropType,
     fill: PropTypes.string,
     stroke: PropTypes.string,
     strokeWidth: PropTypes.number,

--- a/packages/xy-chart/src/utils/sharedSeriesProps.js
+++ b/packages/xy-chart/src/utils/sharedSeriesProps.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { marginShape } from './propShapes';
 
 export default {
   disableMouseEvents: PropTypes.bool,
@@ -8,4 +9,5 @@ export default {
   onMouseLeave: PropTypes.func,
   xScale: PropTypes.func,
   yScale: PropTypes.func,
+  margin: marginShape,
 };

--- a/packages/xy-chart/test/utils/findClosestDatum.test.js
+++ b/packages/xy-chart/test/utils/findClosestDatum.test.js
@@ -15,14 +15,11 @@ describe('findClosestDatum', () => {
     }));
   });
 
-  const node = document.createElement('g');
   const event = {
     // missing clientX
     clientY: 0,
     target: {
-      ownerSVGElement: {
-        firstChild: node,
-      },
+      ownerSVGElement: document.createElement('svg'),
     },
   };
 
@@ -32,29 +29,30 @@ describe('findClosestDatum', () => {
 
   it('should return the closest datum', () => {
     const data = [{ x: 0 }, { x: 5 }, { x: 10 }];
-    const props = {
+    const args = {
       data,
       getX: d => d.x,
       xScale: scaleLinear({ domain: [0, 10], range: [0, 10] }),
+      marginLeft: 0,
     };
 
     expect(
       findClosestDatum({
-        ...props,
+        ...args,
         event: { ...event, clientX: 1 },
       }),
     ).toBe(data[0]);
 
     expect(
       findClosestDatum({
-        ...props,
+        ...args,
         event: { ...event, clientX: 6 },
       }),
     ).toBe(data[1]);
 
     expect(
       findClosestDatum({
-        ...props,
+        ...args,
         event: { ...event, clientX: 9 },
       }),
     ).toBe(data[2]);
@@ -62,7 +60,7 @@ describe('findClosestDatum', () => {
 
   it('should work for ordinal scales', () => {
     const data = [{ x: 'a' }, { x: 'b' }, { x: 'c' }];
-    const props = {
+    const args = {
       data,
       getX: d => d.x,
       xScale: scaleBand({ domain: ['a', 'b', 'c'], range: [0, 10] }),
@@ -70,21 +68,21 @@ describe('findClosestDatum', () => {
 
     expect(
       findClosestDatum({
-        ...props,
+        ...args,
         event: { ...event, clientX: 0 },
       }),
     ).toBe(data[0]);
 
     expect(
       findClosestDatum({
-        ...props,
+        ...args,
         event: { ...event, clientX: 5 },
       }),
     ).toBe(data[1]);
 
     expect(
       findClosestDatum({
-        ...props,
+        ...args,
         event: { ...event, clientX: 10 },
       }),
     ).toBe(data[2]);

--- a/packages/xy-chart/test/utils/findClosestDatums.test.js
+++ b/packages/xy-chart/test/utils/findClosestDatums.test.js
@@ -21,14 +21,13 @@ describe('findClosestDatums', () => {
     clientX: 0,
     clientY: 0,
     target: {
-      ownerSVGElement: {
-        firstChild: document.createElement('g'),
-      },
+      ownerSVGElement: document.createElement('svg'),
     },
   };
 
   const getX = d => d.x;
   const getY = d => d.y;
+  const margin = { top: 0, left: 0 };
 
   it('should be defined', () => {
     expect(findClosestDatums).toBeDefined();
@@ -46,6 +45,7 @@ describe('findClosestDatums', () => {
       getY,
       xScale: scaleBand({ domain: ['a', 'b', 'c'], range: [0, 10] }),
       yScale: scaleLinear({ domain: [0, 10], range: [0, 10] }),
+      margin,
       children: [
         <LineSeries key="line1" seriesKey="line-1" data={data[0]} />,
         <LineSeries key="line2" seriesKey="line-2" data={data[1]} />,
@@ -75,6 +75,7 @@ describe('findClosestDatums', () => {
       getY,
       xScale: scaleBand({ domain: ['a', 'b', 'c'], range: [0, 10] }),
       yScale: scaleLinear({ domain: [0, 10], range: [0, 10] }),
+      margin,
       children: [
         <LineSeries key="line1" seriesKey="line-1" data={data[0]} />,
         <LineSeries key="line2" seriesKey="line-2" data={data[1]} />,
@@ -104,6 +105,7 @@ describe('findClosestDatums', () => {
       getY,
       xScale: scaleBand({ domain: ['a', 'b', 'c'], range: [0, 10] }),
       yScale: scaleLinear({ domain: [0, 10], range: [0, 10] }),
+      margin,
       children: [
         <LineSeries key="line" disableMouseEvents seriesKey="line-1" data={[]} />,
         null,


### PR DESCRIPTION
🐛 Bug Fix

This fixes #137 where tooltips have incorrect offsets when using `<YAxis orientation="left" />` or `<XAxis orientation="top" />`. 

This bug occurs specifically with `<AreaSeries />` and `<LineSeries />`, and the data point that is highlighted in these instances is approximately `margin.left` to the right of the point you expect it to be (for `<YAxis orientation="left" />`) or `margin.top` below the point you expect it to be (for `<XAxis orientation="top" />`).

<img width="400" src="https://user-images.githubusercontent.com/4496521/46634839-2756a700-cb07-11e8-8cde-eda060446531.png" />

cc @jhofstede

