### PR TITLE
[xy-chart][areadifference] pass margin to AreaSeries

### DIFF
--- a/packages/xy-chart/src/series/AreaDifferenceSeries.jsx
+++ b/packages/xy-chart/src/series/AreaDifferenceSeries.jsx
@@ -34,6 +34,7 @@ export default class AreaDifferenceSeries extends React.PureComponent {
       onMouseMove,
       onMouseLeave,
       children,
+      margin,
     } = this.props;
 
     if (!xScale || !yScale) return null;
@@ -100,6 +101,7 @@ export default class AreaDifferenceSeries extends React.PureComponent {
             interpolation,
             disableMouseEvents: Child.props.disableMouseEvents || disableMouseEvents,
             fill: 'transparent',
+            margin,
           }),
         )}
       </g>

--- a/packages/xy-chart/test/series/AreaDifferenceSeries.test.js
+++ b/packages/xy-chart/test/series/AreaDifferenceSeries.test.js
@@ -7,7 +7,7 @@ import { AreaDifferenceSeries, AreaSeries, LineSeries } from '../../src';
 
 describe('<AreaDifferenceSeries />', () => {
   const mockScale = scaleLinear({ domain: [0, 100], range: [0, 100] });
-
+  const mockMargin = { top: 5, right: 7, bottom: 27, left: 47 };
   const mockData = [
     { x: new Date('2017-01-05'), y: 15 },
     { x: new Date('2018-01-05'), y: 51 },
@@ -71,10 +71,11 @@ describe('<AreaDifferenceSeries />', () => {
     expect(threshold.prop('belowAreaProps').fillOpacity).toBe(seriesProps[1].fillOpacity);
   });
 
-  it('should pass xScale, yScale, onClick, onMouseMove, and onMouseLeave to child AreaSeries', () => {
+  it('should pass margin, xScale, yScale, onClick, onMouseMove, and onMouseLeave to child AreaSeries', () => {
     const propsToPass = {
       xScale: mockScale,
       yScale: mockScale,
+      margin: mockMargin,
       onClick: () => {},
       onMouseMove: () => {},
       onMouseLeave: () => {},


### PR DESCRIPTION
🐛 Bug Fix
- Fixes a bug introduced in #140 for tooltip interactions on `<AreaDifferenceSeries />` if `<XYChart eventTrigger="series" />` where `AreaDifferenceSeries` doesn't pass `margin` to its children. The error is `Cannot read property 'left' of undefined`

<img src="https://user-images.githubusercontent.com/4496521/48516220-a7171600-e817-11e8-99cd-42e7db4b52a2.png" width="300" />
