### PR TITLE
[theme] `babel-runtime@6` => `@babel/runtime@7`

### DIFF
--- a/packages/data-ui-theme/package.json
+++ b/packages/data-ui-theme/package.json
@@ -30,10 +30,9 @@
   "license": "MIT",
   "homepage": "https://github.com/williaster/data-ui#readme",
   "dependencies": {
-    "babel-runtime": "^6.26.0"
+    "@babel/runtime": "^7.1.2"
   },
   "devDependencies": {
-    "@babel/runtime": "^7.1.2",
     "@data-ui/build-config": "^0.0.28"
   },
   "beemo": {


### PR DESCRIPTION
🐛 Bug Fix

In the `babel 7` upgrade (#141) I mistakenly put the `@babel/runtime@7` dep in dev dependencies for `@data-ui/theme`, and left `babel-runtime@6` 🤦‍♂️  which may cause issues for downstream consumers.

@etripier