### PR TITLE
[build] .gitignore lock files per-package

### DIFF
--- a/packages/data-table/.gitignore
+++ b/packages/data-table/.gitignore
@@ -28,4 +28,7 @@ _gh-pages/
 babel.config.js
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/data-ui-theme/.gitignore
+++ b/packages/data-ui-theme/.gitignore
@@ -28,4 +28,7 @@ _gh-pages/
 babel.config.js
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/demo/.gitignore
+++ b/packages/demo/.gitignore
@@ -27,4 +27,7 @@ _gh-pages/
 .prettierignore
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/event-flow/.gitignore
+++ b/packages/event-flow/.gitignore
@@ -25,3 +25,7 @@ _gh-pages/
 .eslintrc.js
 .prettierignore
 prettier.config.js
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/forms/.gitignore
+++ b/packages/forms/.gitignore
@@ -25,3 +25,7 @@ _gh-pages/
 .eslintrc.js
 .prettierignore
 prettier.config.js
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/histogram/.gitignore
+++ b/packages/histogram/.gitignore
@@ -28,4 +28,7 @@ _gh-pages/
 babel.config.js
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/network/.gitignore
+++ b/packages/network/.gitignore
@@ -28,4 +28,7 @@ _gh-pages/
 babel.config.js
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/radial-chart/.gitignore
+++ b/packages/radial-chart/.gitignore
@@ -28,4 +28,7 @@ _gh-pages/
 babel.config.js
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/shared/.gitignore
+++ b/packages/shared/.gitignore
@@ -28,4 +28,7 @@ _gh-pages/
 babel.config.js
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/sparkline/.gitignore
+++ b/packages/sparkline/.gitignore
@@ -28,4 +28,7 @@ _gh-pages/
 babel.config.js
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock

--- a/packages/xy-chart/.gitignore
+++ b/packages/xy-chart/.gitignore
@@ -28,4 +28,7 @@ _gh-pages/
 babel.config.js
 jest.config.js
 prettier.config.js
-# @TODO webpack.config.js when this driver is added
+
+# Only apps should have lock files
+package-lock.json
+yarn.lock


### PR DESCRIPTION
🐛 Bug Fix
This fixes #151 where `yarn check` fails for `@data-ui/histogram` due to the `yarn.lock` file mistakenly being included in the published npm package. 

Previously lock files were ignored in the monorepo root, but `lerna` expects these to be set per-package (see [here](https://github.com/lerna/lerna/issues/296)).

cc @kaiyoma