### PR TITLE
[build][babel] let consumers polyfill

### DIFF
--- a/packages/data-table/package.json
+++ b/packages/data-table/package.json
@@ -36,7 +36,7 @@
     "react-virtualized": "^9.7.3"
   },
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "react": "^16.0.0"
   },
   "peerDependencies": {

--- a/packages/data-ui-theme/package.json
+++ b/packages/data-ui-theme/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28"
+    "@data-ui/build-config": "^0.0.32"
   },
   "beemo": {
     "module": "@data-ui/build-config",

--- a/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
+++ b/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
@@ -10,8 +10,6 @@ import ResponsiveXYChart from './ResponsiveXYChart';
 
 import { timeSeriesData } from './data';
 
-const { baseLabel } = svgLabel;
-
 export const parseDate = timeParse('%Y%m%d');
 export const formatDate = timeFormat('%b %d');
 export const formatYear = timeFormat('%Y');

--- a/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
+++ b/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { timeParse, timeFormat } from 'd3-time-format';
 
 import { CrossHair, XAxis, YAxis, BarSeries, PatternLines, Brush, Text } from '@data-ui/xy-chart';
-import { svgLabel } from '@data-ui/theme';
 import { allColors } from '@data-ui/theme/lib/color';
 import { xTickStyles, yTickStyles } from '@data-ui/theme/lib/chartTheme';
 import ResponsiveXYChart from './ResponsiveXYChart';

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "@data-ui/data-table": "^0.0.73",
     "@data-ui/event-flow": "^0.0.73",
     "@data-ui/forms": "^0.0.73",

--- a/packages/event-flow/package.json
+++ b/packages/event-flow/package.json
@@ -32,7 +32,7 @@
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",

--- a/packages/forms/babel.config.js
+++ b/packages/forms/babel.config.js
@@ -1,16 +1,5 @@
 module.exports = {
-  plugins: [
-    '@babel/plugin-proposal-export-default-from',
-    [
-      '@babel/plugin-transform-runtime',
-      {
-        helpers: true,
-        regenerator: false,
-        useESModules: true,
-      },
-    ],
-    'inline-react-svg',
-  ],
+  plugins: ['@babel/plugin-proposal-export-default-from', 'inline-react-svg'],
   presets: [
     [
       '@babel/preset-env',
@@ -21,7 +10,6 @@ module.exports = {
         targets: {
           ie: 10,
         },
-        useBuiltIns: 'usage',
       },
     ],
     '@babel/preset-react',

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -22,9 +22,8 @@
   "author": "Chris Williams <chris.williams@airbnb.com>",
   "license": "MIT",
   "dependencies": {
-    "@babel/plugin-transform-runtime": "^7.1.0",
     "prop-types": "^15.5.10",
-    "react-select": "^1.0.0-rc.5"
+    "react-select": "^1.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.1.2",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -31,7 +31,7 @@
     "@babel/plugin-proposal-export-default-from": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "aphrodite": "^1.2.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",

--- a/packages/histogram/package.json
+++ b/packages/histogram/package.json
@@ -43,7 +43,7 @@
   },
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/network/package.json
+++ b/packages/network/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/radial-chart/package.json
+++ b/packages/radial-chart/package.json
@@ -42,7 +42,7 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/sparkline/package.json
+++ b/packages/sparkline/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/williaster/data-ui#readme",
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },

--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -56,7 +56,7 @@
     "prop-types": "^15.5.10"
   },
   "devDependencies": {
-    "@data-ui/build-config": "^0.0.28",
+    "@data-ui/build-config": "^0.0.32",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "watch": "^1.0.2"

--- a/packages/xy-chart/src/utils/brush/Brush.jsx
+++ b/packages/xy-chart/src/utils/brush/Brush.jsx
@@ -396,7 +396,7 @@ export default class Brush extends React.Component {
           end &&
           Object.keys(handles)
             .filter(handleKey => resizeTriggerAreaSet.has(handleKey))
-            .map((handleKey, i) => {
+            .map(handleKey => {
               const handle = handles[handleKey];
 
               return (
@@ -417,7 +417,7 @@ export default class Brush extends React.Component {
           end &&
           Object.keys(corners)
             .filter(cornerKey => resizeTriggerAreaSet.has(cornerKey))
-            .map((cornerKey, i) => {
+            .map(cornerKey => {
               const corner = corners[cornerKey];
 
               return (

--- a/packages/xy-chart/test/axis/YAxis.test.js
+++ b/packages/xy-chart/test/axis/YAxis.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { AxisLeft, AxisRight } from '@vx/axis';
 import { scaleLinear } from '@vx/scale';
-import { Text } from '@vx/text';
 import { XYChart, YAxis, LineSeries } from '../../src';
 
 describe('<YAxis />', () => {


### PR DESCRIPTION
🏠 Internal

💥 [possibly breaking] Previously we've configured `@babel/preset-env` `useBuiltIns` to `"usage"` which has caused issues with `core-js` deps. Rather than adding a `core-js` dep we'll punt on polyfills to consumers 

Note: this doesn't apply to `event-flow` because it is bundled as a mini app essentially.