### PR TITLE
Use provided bin values for bin domains.

### DIFF
--- a/packages/histogram/src/utils/computeDomainsFromBins.js
+++ b/packages/histogram/src/utils/computeDomainsFromBins.js
@@ -4,7 +4,7 @@ import caseInsensitiveSort from './caseInsensitiveSort';
 /*
  * Computes the bin and value domains from numeric or categorical bins
  */
-export default function computeDomainsFromBins({ binsByIndex, binType, valueKey }) {
+export default function computeDomainsFromBins({ binsByIndex, binType, valueKey, binValues }) {
   let binDomain;
   let valueDomain;
 
@@ -31,8 +31,23 @@ export default function computeDomainsFromBins({ binsByIndex, binType, valueKey 
     }
   });
 
+  if (Array.isArray(binValues)) {
+    let providedBinsCoverDomain = true;
+    binValues.forEach(binValue => {
+      if (!(binValue in binDomain)) {
+        providedBinsCoverDomain = false
+      }
+    })
+
+    if (providedBinsCoverDomain) {
+      binDomain = binValues
+    }
+  }
+
   if (!Array.isArray(binDomain)) {
-    binDomain = Object.keys(binDomain).sort(caseInsensitiveSort);
+    if (binDomain === undefined) {
+      binDomain = Object.keys(binDomain).sort(caseInsensitiveSort);
+    }
   }
 
   return { binDomain, valueDomain };

--- a/packages/histogram/src/utils/computeDomainsFromBins.js
+++ b/packages/histogram/src/utils/computeDomainsFromBins.js
@@ -45,9 +45,7 @@ export default function computeDomainsFromBins({ binsByIndex, binType, valueKey,
   }
 
   if (!Array.isArray(binDomain)) {
-    if (binDomain === undefined) {
-      binDomain = Object.keys(binDomain).sort(caseInsensitiveSort);
-    }
+    binDomain = Object.keys(binDomain).sort(caseInsensitiveSort);
   }
 
   return { binDomain, valueDomain };

--- a/packages/histogram/test/utils/computeDomainsFromBins.test.js
+++ b/packages/histogram/test/utils/computeDomainsFromBins.test.js
@@ -64,4 +64,10 @@ describe('computeDomainsFromBins', () => {
     const categorical = computeDomainsFromBins({ ...categoricalProps, valueKey: 'cumulative' });
     expect(categorical.valueDomain).toEqual(expect.arrayContaining([0, 35]));
   });
+
+  it('should maintain bin values ordering', () => {
+    const binValues = ['b', 'a', 'c']
+    const categorical = computeDomainsFromBins({ ...categoricalProps, binValues: binValues })
+    expect(categorical.binDomain).toEqual(binValues)
+  });
 });


### PR DESCRIPTION
🏆 Enhancements
If the user provides a set of bin values, and these match the domain of
the data, use these under the assumption that the user has sorted the
bin values according to their preferred order.
