### PR TITLE
[shared]: fix issue #167

### DIFF
--- a/packages/shared/src/enhancer/WithTooltip.jsx
+++ b/packages/shared/src/enhancer/WithTooltip.jsx
@@ -62,6 +62,9 @@ class WithTooltip extends React.PureComponent {
   }
 
   handleMouseMove({ event, datum, coords, ...rest }) {
+    if (event.type === 'focus') {
+      return;
+    }
     const { showTooltip } = this.props;
     if (this.tooltipTimeout) {
       clearTimeout(this.tooltipTimeout);

--- a/packages/shared/src/enhancer/WithTooltip.jsx
+++ b/packages/shared/src/enhancer/WithTooltip.jsx
@@ -62,16 +62,13 @@ class WithTooltip extends React.PureComponent {
   }
 
   handleMouseMove({ event, datum, coords, ...rest }) {
-    if (event && event.type === 'focus') {
-      return;
-    }
     const { showTooltip } = this.props;
     if (this.tooltipTimeout) {
       clearTimeout(this.tooltipTimeout);
     }
 
     let tooltipCoords = { x: 0, y: 0 };
-    if (event && event.target && event.target.ownerSVGElement) {
+    if (event && event.target && event.type !== 'focus' && event.target.ownerSVGElement) {
       tooltipCoords = localPoint(event.target.ownerSVGElement, event);
     }
 

--- a/packages/shared/src/enhancer/WithTooltip.jsx
+++ b/packages/shared/src/enhancer/WithTooltip.jsx
@@ -62,7 +62,7 @@ class WithTooltip extends React.PureComponent {
   }
 
   handleMouseMove({ event, datum, coords, ...rest }) {
-    if (event.type === 'focus') {
+    if (event && event.type === 'focus') {
       return;
     }
     const { showTooltip } = this.props;


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix

Fix issue #167, after this fix, a focus event won't show the tooltip anymore.

An alternative fix I tried was to add `&& event.type !== 'focus'` to the condition here https://github.com/williaster/data-ui/blob/master/packages/shared/src/enhancer/WithTooltip.jsx#L71. In that case clicking on a bar for the first time (focusing it) would move the position of the bar. What do you think about this? @williaster 

🏠 Internal
