### PR TITLE
[histogram] squash end-inclusive histogram bins

### DIFF
--- a/packages/demo/examples/02-histogram/renderHistogramTooltip.jsx
+++ b/packages/demo/examples/02-histogram/renderHistogramTooltip.jsx
@@ -8,7 +8,7 @@ export default function RenderTooltip({ datum, color }) {
     <div>
       <div>
         <strong style={{ color }}>
-          {typeof bin === 'undefined' ? `${bin0.toFixed(1)} to ${bin1.toFixed(1)}` : bin}
+          {typeof bin === 'undefined' ? `${bin0.toFixed(2)} to ${bin1.toFixed(2)}` : bin}
         </strong>
       </div>
       <br />

--- a/packages/histogram/src/utils/binNumericData.js
+++ b/packages/histogram/src/utils/binNumericData.js
@@ -38,7 +38,7 @@ export default function binNumericData({
   }
   const scale = scaleLinear()
     .domain(extent)
-    .nice();
+    .nice(binCount);
 
   histogram.domain(limits || scale.domain()).thresholds(binValues || scale.ticks(binCount));
 
@@ -51,7 +51,8 @@ export default function binNumericData({
     const lastBinIndex = seriesBins.length - 1;
     const lastBin = seriesBins[lastBinIndex];
     const nextToLastBin = seriesBins[lastBinIndex - 1];
-    const shouldCombineEndBins = nextToLastBin.x1 === lastBin.x0 && lastBin.x1 === lastBin.x0;
+    const shouldCombineEndBins =
+      nextToLastBin && nextToLastBin.x1 === lastBin.x0 && lastBin.x1 === lastBin.x0;
     const filteredBins = shouldCombineEndBins ? seriesBins.slice(0, -1) : seriesBins;
 
     console.log({ seriesBins, shouldCombineEndBins });
@@ -71,11 +72,7 @@ export default function binNumericData({
         bin.length + (shouldCombineEndBins && i === lastBinIndex - 1 ? lastBin.length || 0 : 0),
       id: i.toString(),
     }));
-
-    debugger;
   });
-
-  console.log(binsByIndex);
 
   return binsByIndex;
 }

--- a/packages/histogram/src/utils/binNumericData.js
+++ b/packages/histogram/src/utils/binNumericData.js
@@ -55,8 +55,6 @@ export default function binNumericData({
       nextToLastBin && nextToLastBin.x1 === lastBin.x0 && lastBin.x1 === lastBin.x0;
     const filteredBins = shouldCombineEndBins ? seriesBins.slice(0, -1) : seriesBins;
 
-    console.log({ seriesBins, shouldCombineEndBins });
-
     binsByIndex[index] = filteredBins.map((bin, i) => ({
       bin0: bin.x0,
       // if the upper limit equals the lower one, use the delta between this bin and the last

--- a/packages/histogram/src/utils/binNumericData.js
+++ b/packages/histogram/src/utils/binNumericData.js
@@ -46,12 +46,11 @@ export default function binNumericData({
     const data = rawDataByIndex[index];
     const seriesBins = histogram.value(valueAccessor)(data);
 
-    // often the last bin is inclusive with the second to last bin, so we may combine them
-    // see https://github.com/d3/d3-array/issues/54#issuecomment-293629278
+    // if the last bin equals the upper bound of the second to last bin, combine them
+    // see https://github.com/d3/d3-array/issues/46#issuecomment-269873644
     const lastBinIndex = seriesBins.length - 1;
     const lastBin = seriesBins[lastBinIndex];
     const nextToLastBin = seriesBins[lastBinIndex - 1];
-    // last bin has same bounds, which equal the upper bound of the next to last bin
     const shouldCombineEndBins = nextToLastBin.x1 === lastBin.x0 && lastBin.x1 === lastBin.x0;
     const filteredBins = shouldCombineEndBins ? seriesBins.slice(0, -1) : seriesBins;
 

--- a/packages/histogram/src/utils/binNumericData.js
+++ b/packages/histogram/src/utils/binNumericData.js
@@ -54,6 +54,8 @@ export default function binNumericData({
     const shouldCombineEndBins = nextToLastBin.x1 === lastBin.x0 && lastBin.x1 === lastBin.x0;
     const filteredBins = shouldCombineEndBins ? seriesBins.slice(0, -1) : seriesBins;
 
+    console.log({ seriesBins, shouldCombineEndBins });
+
     binsByIndex[index] = filteredBins.map((bin, i) => ({
       bin0: bin.x0,
       // if the upper limit equals the lower one, use the delta between this bin and the last
@@ -61,12 +63,19 @@ export default function binNumericData({
         bin.x0 === bin.x1
           ? (i > 0 && bin.x0 + bin.x0 - seriesBins[i - 1].x0) || bin.x1 + 1
           : bin.x1,
-      data: bin,
+      data: [...bin].concat(
+        shouldCombineEndBins && (shouldCombineEndBins && i === lastBinIndex - 1 ? lastBin : []),
+      ),
       // if the last bin was inclusive / omitted, add its count to the last bin
-      count: bin.length + (shouldCombineEndBins && i === lastBin - 1 ? lastBin.length || 0 : 0),
+      count:
+        bin.length + (shouldCombineEndBins && i === lastBinIndex - 1 ? lastBin.length || 0 : 0),
       id: i.toString(),
     }));
+
+    debugger;
   });
+
+  console.log(binsByIndex);
 
   return binsByIndex;
 }


### PR DESCRIPTION
🏆 Enhancements

This PR updates the computation for numeric bins in `@data-ui/histogram` to squash the last two bins together when the thresholds of the **_last bin_** are equal to the upper threshold of the **_second to last_** bin. Without doing this the results can be quite confusing as pointed out by some `Superset` users.

example, given the following raw data `[0, 0, 1, 2, 3, 9, 9, 10, 10, 10]` (note **`10`** is the max value) and `binCount=10`

We get the following _`11 bins`_
<img src="https://user-images.githubusercontent.com/4496521/54258797-fbf63f00-4520-11e9-9308-3aaa9ab7d3e0.png" width="500" />

or with `binCount=20` (and _`21`_ resultant bins 🤔 )
<img src="https://user-images.githubusercontent.com/4496521/54259788-239ad680-4524-11e9-8233-dbb8d661c15a.png" width="500" />

[This issue](https://github.com/d3/d3-array/issues/46#issuecomment-269873644) explains this behavior

> given `n` bins, `n+1` bin thresholds are produced. 

> the last bin (bins[thresholds.length]) contains any value greater than or equal to the last threshold (thresholds[thresholds.length - 1]).

Specifically this clarifys that 
1) we were rendering `n+1` bins, not `n`
2) the the last bin in the histogram above has `x0 == x1 == 10`, equal to the upper bound of the second to last bin (`x0 = 9` and `x1 = 10`).

After updating with this squashing, we get more intuitive results
<img src="https://user-images.githubusercontent.com/4496521/54258738-c7828300-4520-11e9-8e16-54e07003807e.png" width="500" />

<img src="https://user-images.githubusercontent.com/4496521/54259757-0ebe4300-4524-11e9-859b-0caae477aeeb.png" width="500" />

cc @kristw @conglei 