### PR TITLE
Bump @vx/text version

### DIFF
--- a/packages/xy-chart/package.json
+++ b/packages/xy-chart/package.json
@@ -48,7 +48,7 @@
     "@vx/scale": "^0.0.165",
     "@vx/shape": "^0.0.165",
     "@vx/stats": "^0.0.165",
-    "@vx/text": "0.0.179",
+    "@vx/text": "0.0.183",
     "@vx/threshold": "0.0.170",
     "@vx/tooltip": "^0.0.165",
     "@vx/voronoi": "^0.0.165",


### PR DESCRIPTION
vx/text creates an invisible svg to measure text width, but in previous versions doesn't make the svg `absolute` positioned.

https://github.com/hshoff/vx/blame/013f2abd5fee794ea0c246e9d1de08559817af68/packages/vx-text/src/util/getStringWidth.js

💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix

🏠 Internal
