### PR TITLE
fix(xy-chart): allow rangePadding override

### DIFF
--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -367,7 +367,8 @@ class XYChart extends React.PureComponent {
                   labelOffset,
                   numTicks: name === 'XAxis' ? numXTicks : numYTicks,
                   scale: name === 'XAxis' ? xScale : yScale,
-                  rangePadding: name === 'XAxis' ? xScale.offset : null,
+                  rangePadding:
+                    Child.props.rangePadding || (name === 'XAxis' ? xScale.offset : undefined),
                   axisStyles: {
                     ...theme[`${styleKey}AxisStyles`],
                     ...Child.props.axisStyles,


### PR DESCRIPTION
🐛 Bug Fix

Fixes #189 by allowing `rangePadding` override on `Axis` components.