### PR TITLE
fix(xy-chart/BarSeries): fix negative value rendering, update stories

### DIFF
--- a/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
+++ b/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
@@ -1,14 +1,22 @@
 /* eslint react/prop-types: 0 */
 import React from 'react';
 import { timeParse, timeFormat } from 'd3-time-format';
-
-import { CrossHair, XAxis, YAxis, BarSeries, PatternLines, Brush, Text } from '@data-ui/xy-chart';
+import {
+  CrossHair,
+  XAxis,
+  YAxis,
+  BarSeries,
+  PatternLines,
+  Brush,
+  Text,
+  HorizontalReferenceLine,
+  VerticalReferenceLine,
+} from '@data-ui/xy-chart';
 import { allColors } from '@data-ui/theme/lib/color';
 import { xTickStyles, yTickStyles } from '@data-ui/theme/lib/chartTheme';
 import ResponsiveXYChart from './ResponsiveXYChart';
 
 import { timeSeriesData } from './data';
-import HorizontalReferenceLine from '@data-ui/xy-chart/lib/annotation/HorizontalReferenceLine';
 
 export const parseDate = timeParse('%Y%m%d');
 export const formatDate = timeFormat('%b %d');
@@ -46,7 +54,7 @@ class HorizontalBarChartExample extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      direction: 'vertical',
+      direction: 'horizontal',
       data: categoryHorizontalData,
     };
     this.Brush = React.createRef();
@@ -130,7 +138,7 @@ class HorizontalBarChartExample extends React.PureComponent {
         {this.renderControls()}
         <ResponsiveXYChart
           ariaLabel="Required label"
-          eventTrigger="container"
+          eventTrigger="series"
           xScale={horizontal ? valueScale : categoryScale}
           yScale={horizontal ? categoryScale : valueScale}
           margin={{ left: 100, top: 64, bottom: 64 }}
@@ -165,6 +173,7 @@ class HorizontalBarChartExample extends React.PureComponent {
             data={data.map((d, i) =>
               i % 4 === 0 ? { ...d, [horizontal ? 'x' : 'y']: -d[horizontal ? 'x' : 'y'] } : d,
             )}
+            disableMouseEvents={horizontal} // bug with these tooltips
             renderLabel={({ datum, labelProps, index: i }) =>
               datum.label ? (
                 <Text
@@ -177,7 +186,11 @@ class HorizontalBarChartExample extends React.PureComponent {
               ) : null
             }
           />
-          <HorizontalReferenceLine reference={0} />
+          {horizontal ? (
+            <VerticalReferenceLine reference={0} />
+          ) : (
+            <HorizontalReferenceLine reference={0} />
+          )}
           <CrossHair
             showVerticalLine
             showHorizontalLine={false}

--- a/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
+++ b/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
@@ -171,7 +171,7 @@ class HorizontalBarChartExample extends React.PureComponent {
             fill={bar => `url(#${bar.selected ? 'bar_pattern_1' : 'bar_pattern_2'})`}
             horizontal={horizontal}
             data={data.map((d, i) =>
-              i % 4 === 0 ? { ...d, [horizontal ? 'x' : 'y']: -d[horizontal ? 'x' : 'y'] } : d,
+              i % 3 === 0 ? { ...d, [horizontal ? 'x' : 'y']: -d[horizontal ? 'x' : 'y'] } : d,
             )}
             disableMouseEvents={horizontal} // bug with these tooltips
             renderLabel={({ datum, labelProps, index: i }) =>

--- a/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
+++ b/packages/demo/examples/01-xy-chart/HorizontalBarChart.jsx
@@ -8,6 +8,7 @@ import { xTickStyles, yTickStyles } from '@data-ui/theme/lib/chartTheme';
 import ResponsiveXYChart from './ResponsiveXYChart';
 
 import { timeSeriesData } from './data';
+import HorizontalReferenceLine from '@data-ui/xy-chart/lib/annotation/HorizontalReferenceLine';
 
 export const parseDate = timeParse('%Y%m%d');
 export const formatDate = timeFormat('%b %d');
@@ -45,7 +46,7 @@ class HorizontalBarChartExample extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      direction: 'horizontal',
+      direction: 'vertical',
       data: categoryHorizontalData,
     };
     this.Brush = React.createRef();
@@ -129,7 +130,7 @@ class HorizontalBarChartExample extends React.PureComponent {
         {this.renderControls()}
         <ResponsiveXYChart
           ariaLabel="Required label"
-          eventTrigger="series"
+          eventTrigger="container"
           xScale={horizontal ? valueScale : categoryScale}
           yScale={horizontal ? categoryScale : valueScale}
           margin={{ left: 100, top: 64, bottom: 64 }}
@@ -161,7 +162,9 @@ class HorizontalBarChartExample extends React.PureComponent {
           <BarSeries
             fill={bar => `url(#${bar.selected ? 'bar_pattern_1' : 'bar_pattern_2'})`}
             horizontal={horizontal}
-            data={data}
+            data={data.map((d, i) =>
+              i % 4 === 0 ? { ...d, [horizontal ? 'x' : 'y']: -d[horizontal ? 'x' : 'y'] } : d,
+            )}
             renderLabel={({ datum, labelProps, index: i }) =>
               datum.label ? (
                 <Text
@@ -174,6 +177,7 @@ class HorizontalBarChartExample extends React.PureComponent {
               ) : null
             }
           />
+          <HorizontalReferenceLine reference={0} />
           <CrossHair
             showVerticalLine
             showHorizontalLine={false}

--- a/packages/demo/examples/01-xy-chart/index.jsx
+++ b/packages/demo/examples/01-xy-chart/index.jsx
@@ -98,6 +98,7 @@ export default {
             <BarSeries
               data={timeSeriesData.map((d, i) => ({
                 ...d,
+                y: -d.y,
                 fill: `url(#${i === 2 ? 'lines' : 'gradient'})`,
               }))}
               fill="url(#aqua_lightaqua_gradient)"

--- a/packages/xy-chart/src/series/BarSeries.jsx
+++ b/packages/xy-chart/src/series/BarSeries.jsx
@@ -76,7 +76,8 @@ export default class BarSeries extends React.PureComponent {
     const valueField = horizontal ? x : y;
     const categoryField = horizontal ? y : x;
 
-    const zeroPosition = valueScale(0);
+    const minValue = Math.min(...valueScale.domain());
+    const minPosition = valueScale(minValue < 0 ? 0 : minValue);
     const categoryOffset = categoryScale.offset || 0;
     const Labels = []; // Labels on top
 
@@ -85,8 +86,8 @@ export default class BarSeries extends React.PureComponent {
         {data.map((d, i) => {
           const barPosition = categoryScale(categoryField(d)) - categoryOffset;
           const barLength = horizontal
-            ? valueScale(valueField(d)) - zeroPosition
-            : valueScale(valueField(d)) - zeroPosition;
+            ? valueScale(valueField(d)) - minPosition
+            : valueScale(valueField(d)) - minPosition;
 
           const color = d.fill || callOrValue(fill, d, i);
           const key = `bar-${barPosition}`;
@@ -98,8 +99,8 @@ export default class BarSeries extends React.PureComponent {
               labelProps: {
                 key,
                 ...labelProps,
-                x: horizontal ? zeroPosition + Math.abs(barLength) : barPosition + barWidth / 2,
-                y: horizontal ? barPosition + barWidth / 2 : zeroPosition + Math.min(0, barLength),
+                x: horizontal ? minPosition + Math.abs(barLength) : barPosition + barWidth / 2,
+                y: horizontal ? barPosition + barWidth / 2 : minPosition + Math.min(0, barLength),
                 dx: horizontal ? '0.5em' : 0,
                 dy: horizontal ? 0 : '-0.74em',
                 textAnchor: horizontal ? 'start' : 'middle',
@@ -125,8 +126,8 @@ export default class BarSeries extends React.PureComponent {
                 }
               >
                 <Bar
-                  x={horizontal ? zeroPosition + Math.min(0, barLength) : barPosition}
-                  y={horizontal ? barPosition : zeroPosition + Math.min(0, barLength)}
+                  x={horizontal ? minPosition + Math.min(0, barLength) : barPosition}
+                  y={horizontal ? barPosition : minPosition + Math.min(0, barLength)}
                   width={horizontal ? Math.abs(barLength) : barWidth}
                   height={horizontal ? barWidth : Math.abs(barLength)}
                   fill={color}

--- a/packages/xy-chart/src/series/BarSeries.jsx
+++ b/packages/xy-chart/src/series/BarSeries.jsx
@@ -76,17 +76,17 @@ export default class BarSeries extends React.PureComponent {
     const valueField = horizontal ? x : y;
     const categoryField = horizontal ? y : x;
 
-    const maxBarLength = Math.max(...valueScale.range());
-    const offset = categoryScale.offset || 0;
+    const zeroPosition = valueScale(0);
+    const categoryOffset = categoryScale.offset || 0;
     const Labels = []; // Labels on top
 
     return (
       <Group style={disableMouseEvents ? noEventsStyles : null}>
         {data.map((d, i) => {
-          const barPosition = categoryScale(categoryField(d)) - offset;
+          const barPosition = categoryScale(categoryField(d)) - categoryOffset;
           const barLength = horizontal
-            ? valueScale(valueField(d))
-            : maxBarLength - valueScale(valueField(d));
+            ? valueScale(valueField(d)) - zeroPosition
+            : valueScale(valueField(d)) - zeroPosition;
 
           const color = d.fill || callOrValue(fill, d, i);
           const key = `bar-${barPosition}`;
@@ -98,8 +98,8 @@ export default class BarSeries extends React.PureComponent {
               labelProps: {
                 key,
                 ...labelProps,
-                x: horizontal ? barLength : barPosition + barWidth / 2,
-                y: horizontal ? barPosition + barWidth / 2 : maxBarLength - barLength,
+                x: horizontal ? zeroPosition + Math.abs(barLength) : barPosition + barWidth / 2,
+                y: horizontal ? barPosition + barWidth / 2 : zeroPosition + Math.min(0, barLength),
                 dx: horizontal ? '0.5em' : 0,
                 dy: horizontal ? 0 : '-0.74em',
                 textAnchor: horizontal ? 'start' : 'middle',
@@ -125,10 +125,10 @@ export default class BarSeries extends React.PureComponent {
                 }
               >
                 <Bar
-                  x={horizontal ? 0 : barPosition}
-                  y={horizontal ? barPosition : maxBarLength - barLength}
-                  width={horizontal ? barLength : barWidth}
-                  height={horizontal ? barWidth : barLength}
+                  x={horizontal ? zeroPosition + Math.min(0, barLength) : barPosition}
+                  y={horizontal ? barPosition : zeroPosition + Math.min(0, barLength)}
+                  width={horizontal ? Math.abs(barLength) : barWidth}
+                  height={horizontal ? barWidth : Math.abs(barLength)}
                   fill={color}
                   fillOpacity={d.fillOpacity || callOrValue(fillOpacity, d, i)}
                   stroke={d.stroke || callOrValue(stroke, d, i)}

--- a/packages/xy-chart/test/series/BarSeries.test.js
+++ b/packages/xy-chart/test/series/BarSeries.test.js
@@ -76,7 +76,7 @@ describe('<BarSeries />', () => {
           right: 0,
         }}
         yScale={{ type: 'time' }}
-        xScale={{ type: 'linear', includeZero: false }}
+        xScale={{ type: 'linear' }}
       >
         <BarSeries
           data={mockData.map((d, i) => ({


### PR DESCRIPTION
🐛 Bug Fix

This fixes an issue in `@data-ui/xy-chart` where negative `y` values render incorrectly for `BarSeries`. Updates the demo to include such `y` values.

**Before** (look at tooltips)
<img src="https://user-images.githubusercontent.com/4496521/68156987-9ddbf900-ff01-11e9-89db-ed9d2db0bf71.png" width="400" />
<img src="https://user-images.githubusercontent.com/4496521/68156999-a7fdf780-ff01-11e9-9816-fc326df6f0bc.png" width="400" />
<img src="https://user-images.githubusercontent.com/4496521/68156960-93b9fa80-ff01-11e9-838a-da639dd3b868.png" width="400" />

**After** 
<img src="https://user-images.githubusercontent.com/4496521/68156516-da5b2500-ff00-11e9-85fa-ddd69a6b5e5d.png" width="400" />
<img src="https://user-images.githubusercontent.com/4496521/68156781-4ccc0500-ff01-11e9-9b69-57232210b8d4.png" width="400" />
<img src="https://user-images.githubusercontent.com/4496521/68156799-55244000-ff01-11e9-99f2-c6947e40bdc5.png" width="400" />


@conglei @kristw 