### PR TITLE
fix(XYChart, Network): Preserve passed onMouseLeave and onMouseMove

### DIFF
--- a/packages/network/src/chart/Network.jsx
+++ b/packages/network/src/chart/Network.jsx
@@ -324,6 +324,8 @@ class Network extends React.PureComponent {
       children,
       className,
       height,
+      onMouseLeave,
+      onMouseMove,
       renderLink,
       renderNode,
       renderTooltip,
@@ -335,7 +337,11 @@ class Network extends React.PureComponent {
 
     if (renderTooltip) {
       return (
-        <WithTooltip renderTooltip={renderTooltip}>
+        <WithTooltip
+          renderTooltip={renderTooltip}
+          onMouseLeave={onMouseLeave} // preserve these as WithTooltip will override them
+          onMouseMove={onMouseMove}
+        >
           <Network {...this.props} renderTooltip={null} />
         </WithTooltip>
       );

--- a/packages/shared/src/enhancer/WithTooltip.jsx
+++ b/packages/shared/src/enhancer/WithTooltip.jsx
@@ -20,6 +20,8 @@ export const propTypes = {
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.func]).isRequired,
   className: PropTypes.string,
   HoverStyles: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  onMouseMove: PropTypes.func,
+  onMouseLeave: PropTypes.func,
   renderTooltip: PropTypes.func,
   styles: PropTypes.objectOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
   TooltipComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
@@ -40,6 +42,8 @@ const defaultProps = {
     `}
     </style>
   ),
+  onMouseMove: null,
+  onMouseLeave: null,
   renderTooltip: null,
   styles: { display: 'inline-block', position: 'relative' },
   TooltipComponent: TooltipWithBounds,
@@ -62,7 +66,7 @@ class WithTooltip extends React.PureComponent {
   }
 
   handleMouseMove({ event, datum, coords, ...rest }) {
-    const { showTooltip } = this.props;
+    const { showTooltip, onMouseMove } = this.props;
     if (this.tooltipTimeout) {
       clearTimeout(this.tooltipTimeout);
     }
@@ -83,13 +87,16 @@ class WithTooltip extends React.PureComponent {
         ...rest,
       },
     });
+
+    if (onMouseMove) onMouseMove({ event, datum, coords, ...rest });
   }
 
   handleMouseLeave() {
-    const { tooltipTimeout, hideTooltip } = this.props;
+    const { tooltipTimeout, hideTooltip, onMouseLeave } = this.props;
     this.tooltipTimeout = setTimeout(() => {
       hideTooltip();
     }, tooltipTimeout);
+    if (onMouseLeave) onMouseLeave();
   }
 
   render() {

--- a/packages/shared/test/enhancer/WithTooltip.test.js
+++ b/packages/shared/test/enhancer/WithTooltip.test.js
@@ -73,6 +73,44 @@ describe('<WithTooltip />', () => {
     expect(wrapper.find('#test')).toHaveLength(1);
   });
 
+  it('it should invoke the passed onMouseMove when the provided onMouseMove is invoked', () => {
+    const passedOnMouseMove = jest.fn();
+
+    let providedMouseMove;
+    const wrapper = mount(
+      <WithTooltip renderTooltip={() => null} onMouseMove={passedOnMouseMove}>
+        {({ onMouseMove }) => {
+          providedMouseMove = onMouseMove;
+
+          return <svg />;
+        }}
+      </WithTooltip>,
+    );
+
+    providedMouseMove({});
+    wrapper.update();
+    expect(passedOnMouseMove).toHaveBeenCalledTimes(1);
+  });
+
+  it('it should invoke the passed onMouseLeave when the provided onMouseLeave is invoked', () => {
+    const passedOnMouseLeave = jest.fn();
+
+    let providedMouseLeave;
+    const wrapper = mount(
+      <WithTooltip renderTooltip={() => null} onMouseLeave={passedOnMouseLeave}>
+        {({ onMouseLeave }) => {
+          providedMouseLeave = onMouseLeave;
+
+          return <svg />;
+        }}
+      </WithTooltip>,
+    );
+
+    providedMouseLeave({});
+    wrapper.update();
+    expect(passedOnMouseLeave).toHaveBeenCalledTimes(1);
+  });
+
   it('it should use the provided `coords` if passed to onMouseMove', () => {
     let mouseMove;
     const wrapper = mount(

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -263,10 +263,14 @@ class XYChart extends React.PureComponent {
   }
 
   render() {
-    const { renderTooltip } = this.props;
+    const { renderTooltip, onMouseLeave, onMouseMove } = this.props;
     if (renderTooltip) {
       return (
-        <WithTooltip renderTooltip={renderTooltip}>
+        <WithTooltip
+          renderTooltip={renderTooltip}
+          onMouseLeave={onMouseLeave} // preserve these as WithTooltip will override them
+          onMouseMove={onMouseMove}
+        >
           <XYChart {...this.props} renderTooltip={null} />
         </WithTooltip>
       );


### PR DESCRIPTION
🏆 Enhancements

Currently if a user of `XYChart` or `Network` passes their own `onMouseLeave` or `onMouseMove` props **in addition to** a `renderTooltip` prop, the mouse handlers are overwritten by the `WithTooltip` provided mouse handlers and never invoked. 

This PR fixes this by
- updating `@data-ui/shared`s `WithTooltip` to accept `onMouseLeave` and `onMouseMove` functions, which are invoked when the provided equivalents are called.
- updates `XYChart` and `Network` to pass along the user-provided  `onMouseLeave` and `onMouseMove` to `WithTooltip`

### Test plan
- [x] CI – New unit tests in `WithTooltip`