### PR TITLE
rename deprecated lifecycle methods with UNSAFE_ prefix

### DIFF
--- a/packages/data-table/src/enhancers/withFiltering.jsx
+++ b/packages/data-table/src/enhancers/withFiltering.jsx
@@ -39,13 +39,13 @@ function withFiltering(WrappedComponent, pureComponent = true) {
       };
     }
 
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
       if (this.state.filterText) {
         this.handleChangeFilterText(this.state.filterText, this.props);
       }
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       if (nextProps.dataList !== this.props.dataList) {
         this.handleChangeFilterText(this.state.filterText, nextProps);
       }

--- a/packages/data-table/src/enhancers/withSorting.jsx
+++ b/packages/data-table/src/enhancers/withSorting.jsx
@@ -72,7 +72,7 @@ function withSorting(WrappedComponent, pureComponent = true) {
       };
     }
 
-    componentWillReceiveProps(nextProps) {
+    UNSAFE_componentWillReceiveProps(nextProps) {
       if (nextProps.dataList !== this.props.dataList) {
         this.onSort(this.state, nextProps);
       }

--- a/packages/event-flow/src/components/AggregatePanel.jsx
+++ b/packages/event-flow/src/components/AggregatePanel.jsx
@@ -75,7 +75,7 @@ class AggregatePanel extends React.PureComponent {
     this.resetZoom();
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (Object.keys(nextProps).some(prop => nextProps[prop] !== this.props[prop])) {
       this.resetZoom(nextProps);
       this.setState({ ...AggregatePanel.clearedState() });

--- a/packages/event-flow/src/components/App.jsx
+++ b/packages/event-flow/src/components/App.jsx
@@ -82,7 +82,7 @@ class App extends React.PureComponent {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const nextState = {};
     if (this.props.data !== nextProps.data) {
       const { alignByIndex, alignByEventType } = this.state;

--- a/packages/event-flow/src/components/SingleSequencesPanel.jsx
+++ b/packages/event-flow/src/components/SingleSequencesPanel.jsx
@@ -75,7 +75,7 @@ class SingleSequencePanel extends React.PureComponent {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       nextProps.sequences &&
       (this.props.sequences !== nextProps.sequences || this.width !== nextProps.width)

--- a/packages/event-flow/src/components/Visualization.jsx
+++ b/packages/event-flow/src/components/Visualization.jsx
@@ -53,7 +53,7 @@ class Visualization extends React.PureComponent {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const updateProps = ['graph'];
     if (updateProps.some(key => nextProps[key] !== this.props[key])) {
       this.setState({

--- a/packages/forms/src/StepIncrementer.jsx
+++ b/packages/forms/src/StepIncrementer.jsx
@@ -69,7 +69,7 @@ class StepIncrementer extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const { value } = this.state;
     const { value: nextValue } = nextProps;
     if (nextValue !== value) {

--- a/packages/histogram/src/chart/Histogram.jsx
+++ b/packages/histogram/src/chart/Histogram.jsx
@@ -63,7 +63,7 @@ class Histogram extends React.PureComponent {
     this.state = this.getStateFromProps(props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     let shouldComputeBinsAndScales = false;
     // eslint-disable-next-line react/destructuring-assignment
     if (['width', 'height', 'children'].some(prop => this.props[prop] !== nextProps[prop])) {

--- a/packages/network/src/chart/Network.jsx
+++ b/packages/network/src/chart/Network.jsx
@@ -138,7 +138,7 @@ class Network extends React.PureComponent {
     });
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const {
       graph,
       animated,

--- a/packages/sparkline/src/chart/Sparkline.jsx
+++ b/packages/sparkline/src/chart/Sparkline.jsx
@@ -69,7 +69,7 @@ class Sparkline extends React.PureComponent {
     this.state = this.getStateFromProps(props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       [
         // recompute scales if any of the following change

--- a/packages/xy-chart/src/chart/Voronoi.jsx
+++ b/packages/xy-chart/src/chart/Voronoi.jsx
@@ -38,7 +38,7 @@ class Voronoi extends React.PureComponent {
     this.state = { voronoi: Voronoi.getVoronoi(props) };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       ['data', 'x', 'y', 'width', 'height'].some(
         prop => this.props[prop] !== nextProps[prop], // eslint-disable-line react/destructuring-assignment

--- a/packages/xy-chart/src/chart/XYChart.jsx
+++ b/packages/xy-chart/src/chart/XYChart.jsx
@@ -129,7 +129,7 @@ class XYChart extends React.PureComponent {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     let shouldComputeScales = false;
     if (
       ['width', 'height', 'children'].some(

--- a/packages/xy-chart/src/series/CirclePackSeries.jsx
+++ b/packages/xy-chart/src/series/CirclePackSeries.jsx
@@ -39,7 +39,7 @@ class CirclePackSeries extends React.PureComponent {
     this.state = { data: this.computeCirclePack(props) };
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     // eslint-disable-next-line react/destructuring-assignment
     if (['data', 'xScale', 'size'].some(prop => this.props[prop] !== nextProps[prop])) {
       this.setState({ data: this.computeCirclePack(nextProps) });

--- a/packages/xy-chart/src/utils/brush/Brush.jsx
+++ b/packages/xy-chart/src/utils/brush/Brush.jsx
@@ -96,7 +96,7 @@ export default class Brush extends React.Component {
     this.mouseDownTime = 0;
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (
       ['width', 'height'].some(
         prop => this.props[prop] !== nextProps[prop], // eslint-disable-line react/destructuring-assignment


### PR DESCRIPTION
💔 Breaking Changes
Introduces 16.3 as the oldest compatible React version (where they introduced the UNSAFE_ aliases)

🐛 Bug Fix
Removes warnings about unsafe lifecycle methods